### PR TITLE
docs: clarify self-host smoke flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@
 #
 # Optional integrations near the bottom are disabled while commented out.
 # Disabled integrations are hidden by the web and desktop UI.
+# Do not uncomment optional variables with empty values. Leave them commented out
+# until you are ready to provide real values.
 
 # ==============================================================================
 # 1. REQUIRED SETUP
@@ -64,6 +66,8 @@ ADMIN_USERNAME=admin
 # 4. OPTIONAL INTEGRATIONS
 # ==============================================================================
 # Leave these commented out for the simplest self-hosted setup.
+# To disable an integration, keep its variables commented out instead of setting
+# them to empty values.
 # The server reports disabled integrations through `/api/system/features`, and
 # web/desktop clients hide the related UI.
 
@@ -87,5 +91,6 @@ ADMIN_USERNAME=admin
 # ATTACHMENTS_CLAMAV_FAIL_CLOSED=1
 
 ## External TURN server. Usually not needed for local/dev.
-# TURN_URLS=
+# TURN_URLS=turn:turn.example.com:3478?transport=udp
 # TURN_SHARED_SECRET=CHANGE_ME_TO_A_STRONG_TURN_SECRET
+# TURN_CREDENTIAL_TTL_SECS=3600

--- a/README.md
+++ b/README.md
@@ -90,8 +90,14 @@ Use Voxpery instantly on **voxpery.com** as a hosted Discord alternative, or sel
 git clone https://github.com/emircanagac/voxpery.git
 cd voxpery
 
-# Copy and edit environment
+# Copy the environment template.
 cp .env.example .env
+
+# Edit `.env` and replace every CHANGE_ME value before starting.
+# Optional integrations can stay commented out.
+
+# Validate the Compose configuration generated from `.env`.
+docker compose config >/dev/null
 
 # Start full stack (postgres + redis + livekit + backend + web)
 docker compose up -d --build
@@ -101,12 +107,23 @@ docker compose up -d --build
 
 Note: ClamAV is disabled by default. To enable malware scanning, set `ATTACHMENTS_CLAMAV_ENABLED=1` and start Compose with `--profile security`.
 
+Self-host smoke check:
+
+```bash
+docker compose ps
+curl -f http://localhost:3001/health
+curl -I http://localhost:5173
+curl -s http://localhost:3001/api/system/features
+```
+
+With the default `.env.example` flow, Google OAuth, SMTP email delivery, password reset, and email verification are disabled and hidden until configured.
+
 **Need production setup?** → See [**Deployment Guide**](docs/DEPLOYMENT.md)
 - Full Docker Compose deployment
 - Reverse proxy/TLS options
 - Backup and operations checklist
 
-Optional integrations are disabled unless fully configured. If Google OAuth or SMTP email delivery is not configured, Voxpery hides the related sign-in, password reset, and email verification flows and the API returns `FEATURE_DISABLED` for direct calls.
+Optional integrations are disabled unless fully configured. If Google OAuth or SMTP email delivery is not configured, Voxpery hides the related sign-in, password reset, and email verification flows and the API returns `FEATURE_DISABLED` for direct calls. Keep optional environment variables commented out when disabled; do not uncomment them with empty values.
 
 **For developers:** See [Contributing Guide](docs/CONTRIBUTING.md)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,8 +55,44 @@ Optional integrations note:
 - The backend publishes integration availability at `/api/system/features`; web and desktop clients hide unavailable flows.
 - Direct calls to disabled integration endpoints return `FEATURE_DISABLED`.
 - `EMAIL_VERIFICATION_REQUIRED=true` requires SMTP email delivery and fails startup if email delivery is not configured.
+- Keep disabled optional integrations commented out in `.env`; do not set optional variables to empty values.
 
-## 2) Start Full Stack
+## 2) Self-Host Smoke Test
+
+Before production changes, validate the default self-host flow from a clean environment file:
+
+```bash
+cp .env.example .env
+# Edit `.env` and replace every CHANGE_ME value.
+docker compose config >/dev/null
+docker compose up -d --build
+docker compose ps
+```
+
+Basic service checks:
+
+```bash
+curl -f http://localhost:3001/health
+curl -I http://localhost:${WEB_PORT:-5173}
+curl -s http://localhost:3001/api/system/features
+```
+
+Expected default integration state:
+
+- `google_oauth_enabled` is `false`.
+- `email_delivery_enabled` is `false`.
+- `email_verification_enabled` is `false`.
+- `password_reset_enabled` is `false`.
+- The web and desktop UI should hide Google sign-in, password reset, and email verification prompts until those integrations are configured.
+
+Manual product checks:
+
+- Register/login works with the seeded admin account or a new local account.
+- Server, channel, and category navigation work.
+- Voice join reaches LiveKit.
+- Attachment upload and signed attachment viewing work.
+
+## 3) Start Full Stack
 
 ```bash
 docker compose up -d --build
@@ -102,7 +138,7 @@ Important:
 - These limits reduce single-host blast radius (LiveKit cannot consume all CPU/RAM/PIDs).
 - They do **not** protect against upstream bandwidth saturation from large volumetric UDP floods.
 
-## 3) Validation Checklist
+## 4) Validation Checklist
 
 ```bash
 curl -f http://localhost:3001/health
@@ -116,14 +152,14 @@ Manual checks:
 - Voice join works
 - Moderation actions (kick/ban) work
 
-## 4) Updating
+## 5) Updating
 
 ```bash
 git pull
 docker compose up -d --build
 ```
 
-## 5) Prebuilt Images (Optional, Recommended for Production)
+## 6) Prebuilt Images (Optional, Recommended for Production)
 
 You can prebuild and push images, then let Compose pull them during deploy instead of rebuilding on the server.
 
@@ -155,7 +191,7 @@ docker compose pull server web
 docker compose up -d --no-build --remove-orphans
 ```
 
-## 6) Backups
+## 7) Backups
 
 ```bash
 ./scripts/ops/db_backup.sh


### PR DESCRIPTION
## Summary

Clarifies the self-host setup and smoke-test flow for Voxpery.

## Changes

- Documented that optional integrations should stay commented out when disabled, instead of being uncommented with empty values.
- Added safer TURN examples to `.env.example`.
- Added `docker compose config` validation to the README quick start.
- Added self-host smoke-check commands for health, web, and `/api/system/features`.
- Expanded `docs/DEPLOYMENT.md` with expected default optional integration states and manual validation steps.

## Validation

- `docker compose --env-file .env.example config --quiet`
- `git diff --check`
