### PR TITLE
fix: harden websocket reconnect handling

### DIFF
--- a/apps/web/src/stores/socket.test.ts
+++ b/apps/web/src/stores/socket.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { useSocketStore } from './socket'
+import { useSocketStore, websocketReconnectDelayMs } from './socket'
 import { act } from '@testing-library/react'
 
 // WebSocket ready state constants
@@ -9,6 +9,8 @@ const WS_CLOSED = 3
 
 // Mock WebSocket
 class MockWebSocket {
+  static instances: MockWebSocket[] = []
+
   url: string
   readyState = WS_CONNECTING
   onopen: ((event: Event) => void) | null = null
@@ -18,6 +20,7 @@ class MockWebSocket {
 
   constructor(url: string) {
     this.url = url
+    MockWebSocket.instances.push(this)
     // Simulate async connection
     setTimeout(() => {
       this.readyState = WS_OPEN
@@ -32,9 +35,9 @@ class MockWebSocket {
     }
   }
 
-  close() {
+  close(code = 1000) {
     this.readyState = WS_CLOSED
-    this.onclose?.(new CloseEvent('close'))
+    this.onclose?.(new CloseEvent('close', { code }))
   }
 }
 
@@ -62,7 +65,12 @@ describe('WebSocket Store', () => {
       shouldReconnect: false,
       listeners: new Set(),
       reconnectListeners: new Set(),
+      reconnectAttempt: 0,
+      reconnectTimer: null,
+      connectionId: 0,
+      wasConnectedBefore: false,
     })
+    MockWebSocket.instances = []
     vi.clearAllTimers()
     vi.useFakeTimers()
   })
@@ -183,9 +191,19 @@ describe('WebSocket Store', () => {
     expect(listener).not.toHaveBeenCalled()
   })
 
+  it('calculates exponential reconnect delays with jitter', () => {
+    expect(websocketReconnectDelayMs(1, () => 0.5)).toBe(1000)
+    expect(websocketReconnectDelayMs(2, () => 0.5)).toBe(2000)
+    expect(websocketReconnectDelayMs(3, () => 0.5)).toBe(4000)
+    expect(websocketReconnectDelayMs(20, () => 0.5)).toBe(30000)
+    expect(websocketReconnectDelayMs(1, () => 0)).toBe(750)
+    expect(websocketReconnectDelayMs(1, () => 1)).toBe(1250)
+  })
+
   it('should handle reconnection', async () => {
     const { connect } = useSocketStore.getState()
     const reconnectListener = vi.fn()
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
     act(() => {
       connect('test-token')
@@ -201,8 +219,8 @@ describe('WebSocket Store', () => {
       state.socket?.close()
     })
 
-    // Wait for auto-reconnect (3s delay)
-    await vi.advanceTimersByTimeAsync(3100)
+    // Wait for auto-reconnect (1s base delay)
+    await vi.advanceTimersByTimeAsync(1100)
 
     expect(reconnectListener).toHaveBeenCalled()
     unsubscribe()
@@ -211,6 +229,7 @@ describe('WebSocket Store', () => {
   it('should reconnect web cookie-auth sessions even when token is null', async () => {
     const { connect } = useSocketStore.getState()
     const reconnectListener = vi.fn()
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
     act(() => {
       connect(null)
@@ -224,13 +243,115 @@ describe('WebSocket Store', () => {
       state.socket?.close()
     })
 
-    await vi.advanceTimersByTimeAsync(3100)
+    await vi.advanceTimersByTimeAsync(1100)
 
     const next = useSocketStore.getState()
     expect(next.socket).toBeTruthy()
     expect(next.isConnected).toBe(true)
     expect(reconnectListener).toHaveBeenCalled()
     unsubscribe()
+  })
+
+  it('should not call removed reconnect listeners', async () => {
+    const { connect } = useSocketStore.getState()
+    const reconnectListener = vi.fn()
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    act(() => {
+      connect('test-token')
+    })
+    await vi.runAllTimersAsync()
+
+    const unsubscribe = useSocketStore.getState().onReconnect(reconnectListener)
+    unsubscribe()
+
+    act(() => {
+      useSocketStore.getState().socket?.close()
+    })
+
+    await vi.advanceTimersByTimeAsync(1100)
+
+    expect(reconnectListener).not.toHaveBeenCalled()
+  })
+
+  it('should not reconnect after auth-expired close code', async () => {
+    const { connect } = useSocketStore.getState()
+    const reconnectListener = vi.fn()
+
+    act(() => {
+      connect('test-token')
+    })
+    await vi.runAllTimersAsync()
+
+    const unsubscribe = useSocketStore.getState().onReconnect(reconnectListener)
+
+    act(() => {
+      useSocketStore.getState().socket?.close(4001)
+    })
+
+    await vi.advanceTimersByTimeAsync(30000)
+
+    const state = useSocketStore.getState()
+    expect(state.socket).toBe(null)
+    expect(state.isConnected).toBe(false)
+    expect(state.shouldReconnect).toBe(false)
+    expect(reconnectListener).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('should stop reconnecting after the reconnect cap', async () => {
+    const { connect } = useSocketStore.getState()
+
+    act(() => {
+      connect('test-token')
+    })
+    await vi.runAllTimersAsync()
+
+    act(() => {
+      useSocketStore.setState({ reconnectAttempt: 8 })
+      useSocketStore.getState().socket?.close()
+    })
+
+    await vi.advanceTimersByTimeAsync(30000)
+
+    const state = useSocketStore.getState()
+    expect(state.socket).toBe(null)
+    expect(state.shouldReconnect).toBe(false)
+    expect(state.reconnectAttempt).toBe(0)
+  })
+
+  it('should not create duplicate sockets while connecting', () => {
+    const { connect } = useSocketStore.getState()
+
+    act(() => {
+      connect('test-token')
+      connect('test-token')
+    })
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('should clear pending reconnect timers on disconnect', async () => {
+    const { connect, disconnect } = useSocketStore.getState()
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    act(() => {
+      connect('test-token')
+    })
+    await vi.runAllTimersAsync()
+
+    act(() => {
+      useSocketStore.getState().socket?.close()
+      disconnect()
+    })
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    const state = useSocketStore.getState()
+    expect(state.socket).toBe(null)
+    expect(state.isConnected).toBe(false)
+    expect(state.shouldReconnect).toBe(false)
+    expect(MockWebSocket.instances).toHaveLength(1)
   })
 
   it('should handle multiple subscribers', async () => {

--- a/apps/web/src/stores/socket.ts
+++ b/apps/web/src/stores/socket.ts
@@ -4,6 +4,19 @@ import { createWebSocket } from '../api'
 type WsListener = (data: unknown) => void
 type ReconnectListener = () => void
 
+const AUTH_EXPIRED_CLOSE_CODE = 4001
+const RECONNECT_BASE_DELAY_MS = 1000
+const RECONNECT_MAX_DELAY_MS = 30000
+const RECONNECT_MAX_ATTEMPTS = 8
+const RECONNECT_JITTER_RATIO = 0.25
+
+export function websocketReconnectDelayMs(attempt: number, random: () => number = Math.random): number {
+    const exponent = Math.max(0, attempt - 1)
+    const rawDelay = Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** exponent)
+    const jitter = 1 + (random() * 2 - 1) * RECONNECT_JITTER_RATIO
+    return Math.round(rawDelay * jitter)
+}
+
 interface SocketState {
     socket: WebSocket | null
     isConnected: boolean
@@ -11,6 +24,10 @@ interface SocketState {
     shouldReconnect: boolean
     listeners: Set<WsListener>
     reconnectListeners: Set<ReconnectListener>
+    reconnectAttempt: number
+    reconnectTimer: ReturnType<typeof setTimeout> | null
+    connectionId: number
+    wasConnectedBefore: boolean
 
     // Actions
     connect: (token: string | null) => void
@@ -28,22 +45,40 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     shouldReconnect: false,
     listeners: new Set(),
     reconnectListeners: new Set(),
-    _wasConnectedBefore: false,
+    reconnectAttempt: 0,
+    reconnectTimer: null,
+    connectionId: 0,
+    wasConnectedBefore: false,
 
     connect: (token) => {
         const state = get()
-        // If we already have a valid socket, just update token if needed
+        if (state.reconnectTimer) {
+            clearTimeout(state.reconnectTimer)
+            set({ reconnectTimer: null })
+        }
+
+        // If we already have a valid socket, just update token if needed.
         if (state.socket && (state.socket.readyState === WebSocket.OPEN || state.socket.readyState === WebSocket.CONNECTING)) {
             if (state.token !== token || !state.shouldReconnect) set({ token, shouldReconnect: true })
             return
         }
 
-        set({ token, shouldReconnect: true })
+        const connectionId = state.connectionId + 1
+        set({ token, shouldReconnect: true, connectionId })
         const ws = createWebSocket(token)
 
         ws.onopen = () => {
-            const wasConnected = (get() as SocketState & { _wasConnectedBefore?: boolean })._wasConnectedBefore
-            set({ isConnected: true, socket: ws, _wasConnectedBefore: true } as Partial<SocketState>)
+            if (get().connectionId !== connectionId) return
+
+            const wasConnected = get().wasConnectedBefore
+            set({
+                isConnected: true,
+                socket: ws,
+                reconnectAttempt: 0,
+                reconnectTimer: null,
+                wasConnectedBefore: true,
+            })
+
             // Fire reconnect listeners if this was a re-establishment (not first connect)
             if (wasConnected) {
                 get().reconnectListeners.forEach((cb) => {
@@ -52,27 +87,51 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             }
         }
 
-        ws.onclose = () => {
+        ws.onclose = (event) => {
+            if (get().connectionId !== connectionId) return
+
+            if (event.code === AUTH_EXPIRED_CLOSE_CODE) {
+                set({
+                    isConnected: false,
+                    socket: null,
+                    shouldReconnect: false,
+                    reconnectAttempt: 0,
+                    reconnectTimer: null,
+                })
+                return
+            }
+
             set({ isConnected: false, socket: null })
 
             // Auto-reconnect for active sessions.
             // Web cookie-auth sessions use token=null, so reconnect intent must
             // be tracked separately from the bearer token itself.
-            const { shouldReconnect } = get()
-            if (shouldReconnect) {
-                setTimeout(() => {
-                    const { token: latestToken, shouldReconnect: latestShouldReconnect } = get()
+            const { shouldReconnect, reconnectAttempt } = get()
+            if (shouldReconnect && reconnectAttempt < RECONNECT_MAX_ATTEMPTS) {
+                const nextAttempt = reconnectAttempt + 1
+                const delayMs = websocketReconnectDelayMs(nextAttempt)
+                const reconnectTimer = setTimeout(() => {
+                    const { token: latestToken, shouldReconnect: latestShouldReconnect, connectionId: latestConnectionId } = get()
                     const currentSocket = get().socket
-                    // Only try to reconnect if the session still wants a socket
-                    // and we aren't already connected/connecting.
-                    if (latestShouldReconnect && (!currentSocket || currentSocket.readyState === WebSocket.CLOSED)) {
+                    const hasActiveSocket = currentSocket && (
+                        currentSocket.readyState === WebSocket.OPEN ||
+                        currentSocket.readyState === WebSocket.CONNECTING
+                    )
+
+                    if (latestShouldReconnect && latestConnectionId === connectionId && !hasActiveSocket) {
                         get().connect(latestToken)
                     }
-                }, 3000)
+                }, delayMs)
+
+                set({ reconnectAttempt: nextAttempt, reconnectTimer })
+            } else if (shouldReconnect) {
+                set({ shouldReconnect: false, reconnectAttempt: 0, reconnectTimer: null })
             }
         }
 
         ws.onmessage = (event) => {
+            if (get().connectionId !== connectionId) return
+
             try {
                 const data = JSON.parse(event.data)
                 get().listeners.forEach((listener) => listener(data))
@@ -85,8 +144,17 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     },
 
     disconnect: () => {
-        // Clear token first to prevent auto-reconnect
-        set({ token: null, shouldReconnect: false })
+        const { reconnectTimer } = get()
+        if (reconnectTimer) clearTimeout(reconnectTimer)
+
+        // Clear token first to prevent auto-reconnect.
+        set({
+            token: null,
+            shouldReconnect: false,
+            reconnectAttempt: 0,
+            reconnectTimer: null,
+            connectionId: get().connectionId + 1,
+        })
         get().socket?.close()
         set({ socket: null, isConnected: false })
     },

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resyncVoiceStateAfterReconnect } from './useLiveKitVoice'
+
+describe('resyncVoiceStateAfterReconnect', () => {
+  it('re-sends voice join and control state after WebSocket reconnect', () => {
+    const send = vi.fn()
+
+    resyncVoiceStateAfterReconnect({
+      channelId: 'voice-channel-1',
+      roomState: 'connected',
+      control: {
+        muted: true,
+        deafened: false,
+        screenSharing: true,
+        cameraOn: true,
+      },
+      send,
+    })
+
+    expect(send).toHaveBeenNthCalledWith(1, 'JoinVoice', {
+      channel_id: 'voice-channel-1',
+    })
+    expect(send).toHaveBeenNthCalledWith(2, 'SetVoiceControl', {
+      muted: true,
+      deafened: false,
+      screen_sharing: true,
+      camera_on: true,
+    })
+  })
+
+  it('defaults missing voice controls to false', () => {
+    const send = vi.fn()
+
+    resyncVoiceStateAfterReconnect({
+      channelId: 'voice-channel-1',
+      roomState: 'connected',
+      control: null,
+      send,
+    })
+
+    expect(send).toHaveBeenNthCalledWith(2, 'SetVoiceControl', {
+      muted: false,
+      deafened: false,
+      screen_sharing: false,
+      camera_on: false,
+    })
+  })
+
+  it('does not resync when no voice channel is joined', () => {
+    const send = vi.fn()
+
+    resyncVoiceStateAfterReconnect({
+      channelId: null,
+      roomState: 'connected',
+      control: null,
+      send,
+    })
+
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does not resync when the media room is gone', () => {
+    const send = vi.fn()
+
+    resyncVoiceStateAfterReconnect({
+      channelId: 'voice-channel-1',
+      roomState: null,
+      control: null,
+      send,
+    })
+
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does not resync when the media room is disconnected', () => {
+    const send = vi.fn()
+
+    resyncVoiceStateAfterReconnect({
+      channelId: 'voice-channel-1',
+      roomState: 'disconnected',
+      control: null,
+      send,
+    })
+
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -24,6 +24,37 @@ import {
 
 type PeerId = string
 
+type VoiceControlState = {
+  muted?: boolean
+  deafened?: boolean
+  screenSharing?: boolean
+  cameraOn?: boolean
+} | null | undefined
+
+interface VoiceReconnectResyncOptions {
+  channelId: string | null
+  roomState: string | null
+  control: VoiceControlState
+  send: (type: string, data: unknown) => void
+}
+
+export function resyncVoiceStateAfterReconnect({
+  channelId,
+  roomState,
+  control,
+  send,
+}: VoiceReconnectResyncOptions): void {
+  if (!channelId || !roomState || roomState === 'disconnected') return
+
+  send('JoinVoice', { channel_id: channelId })
+  send('SetVoiceControl', {
+    muted: !!control?.muted,
+    deafened: !!control?.deafened,
+    screen_sharing: !!control?.screenSharing,
+    camera_on: !!control?.cameraOn,
+  })
+}
+
 export interface UseLiveKitVoiceState {
   joinedChannelId: string | null
   isJoining: boolean
@@ -831,17 +862,13 @@ export function useLiveKitVoice() {
     const unsub = onReconnect(() => {
       const channelId = joinedChannelIdRef.current
       const room = roomRef.current
-      if (!channelId || !room || room.state === 'disconnected') return
 
-      send('JoinVoice', { channel_id: channelId })
-
-      // Re-send current control state
       const control = userId ? useAppStore.getState().voiceControls[userId] : null
-      send('SetVoiceControl', {
-        muted: !!control?.muted,
-        deafened: !!control?.deafened,
-        screen_sharing: !!control?.screenSharing,
-        camera_on: !!control?.cameraOn,
+      resyncVoiceStateAfterReconnect({
+        channelId,
+        roomState: room ? String(room.state) : null,
+        control,
+        send,
       })
     })
     return unsub


### PR DESCRIPTION
## Summary

Hardens the WebSocket reconnect flow for web and desktop sessions.

## Changes

- Replaced fixed reconnect delay with exponential backoff, jitter, and a reconnect cap.
- Preserved reconnect intent for both web cookie sessions and desktop bearer-token sessions.
- Added guards against duplicate sockets while an existing socket is open or connecting.
- Added stale socket event protection using a connection id.
- Stops reconnect attempts when the server closes the socket with auth-expired code `4001`.
- Clears pending reconnect timers on manual disconnect.
- Expanded focused WebSocket store tests for reconnect behavior, listener cleanup, auth-expired behavior, reconnect cap, and duplicate socket prevention.

## Validation

- `npm run test:run -- src/stores/socket.test.ts`
- `npm run build`
- `npm run lint`
- `git diff --check`

## Manual Smoke Test

Recommended before merge:

1. Log in and open a server/channel.
2. Stop the backend with `docker compose stop server`.
3. Start it again with `docker compose start server`.
4. Confirm the UI reconnects without logout, messages work again, and there is no rapid reconnect spam.
