### PR TITLE
test: add security regression coverage

### DIFF
--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -214,6 +214,7 @@ async fn optional_auth_integrations_return_feature_disabled_when_unconfigured() 
         return;
     };
     let (mut app, _) = setup_app().await;
+    let disabled_reset_password = format!("disabled-reset-{}", Uuid::new_v4());
 
     let disabled_requests = [
         Request::builder()
@@ -253,7 +254,7 @@ async fn optional_auth_integrations_return_feature_disabled_when_unconfigured() 
             .body(Body::from(
                 serde_json::to_vec(&json!({
                     "token": "disabled-token",
-                    "new_password": "password123"
+                    "new_password": disabled_reset_password
                 }))
                 .unwrap(),
             ))
@@ -284,7 +285,8 @@ async fn email_verification_request_returns_feature_disabled_when_email_delivery
     let uid = Uuid::new_v4();
     let email = format!("verify-disabled-{uid}@example.com");
     let username = format!("verify_disabled_{}", uid.as_u128() % 1_000_000);
-    let (token, _) = register_user(&mut app, &email, &username, "password123").await;
+    let password = format!("verify-disabled-{}", uid.as_simple());
+    let (token, _) = register_user(&mut app, &email, &username, &password).await;
 
     let req = Request::builder()
         .method("POST")

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -191,6 +191,113 @@ async fn health_returns_200_when_db_connected() {
     assert!(json.get("checks").is_none());
 }
 
+fn assert_feature_disabled(status: StatusCode, body: &[u8]) {
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "expected FEATURE_DISABLED response, got {}: {}",
+        status,
+        String::from_utf8_lossy(body)
+    );
+    let json: serde_json::Value = serde_json::from_slice(body).unwrap();
+    assert_eq!(json["code"], "FEATURE_DISABLED");
+    assert!(
+        json["error"].as_str().is_some_and(|message| !message.is_empty()),
+        "FEATURE_DISABLED response should include a safe user-facing error message"
+    );
+}
+
+#[tokio::test]
+async fn optional_auth_integrations_return_feature_disabled_when_unconfigured() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app().await;
+
+    let disabled_requests = [
+        Request::builder()
+            .method("GET")
+            .uri("/api/auth/google")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("GET")
+            .uri("/api/auth/google/callback?code=test-code")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/google/desktop-exchange")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "code": "00000000000000000000000000000000",
+                    "code_verifier": "test-verifier"
+                }))
+                .unwrap(),
+            ))
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/forgot-password")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "email": "disabled@example.com" })).unwrap(),
+            ))
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/reset-password")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "token": "disabled-token",
+                    "new_password": "password123"
+                }))
+                .unwrap(),
+            ))
+            .unwrap(),
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/email/confirm")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "token": "disabled-token" })).unwrap(),
+            ))
+            .unwrap(),
+    ];
+
+    for req in disabled_requests {
+        let (status, body) = oneshot(&mut app, req).await;
+        assert_feature_disabled(status, &body);
+    }
+}
+
+#[tokio::test]
+async fn email_verification_request_returns_feature_disabled_when_email_delivery_is_disabled() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app().await;
+    let uid = Uuid::new_v4();
+    let email = format!("verify-disabled-{uid}@example.com");
+    let username = format!("verify_disabled_{}", uid.as_u128() % 1_000_000);
+    let (token, _) = register_user(&mut app, &email, &username, "password123").await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/email/request-verification")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&json!({})).unwrap()))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+
+    assert_feature_disabled(status, &body);
+}
+
 #[tokio::test]
 async fn register_login_me_flow() {
     let Some(_) = test_db_url() else {

--- a/apps/web/src/pages/AuthFeatureGating.test.tsx
+++ b/apps/web/src/pages/AuthFeatureGating.test.tsx
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import LoginPage from './LoginPage'
+import RegisterPage from './RegisterPage'
+import ForgotPasswordPage from './ForgotPasswordPage'
+import ResetPasswordPage from './ResetPasswordPage'
+import { useFeatureStore } from '../stores/features'
+import type { SystemFeatures } from '../api'
+
+const disabledFeatures: SystemFeatures = {
+  google_oauth_enabled: false,
+  email_delivery_enabled: false,
+  email_verification_enabled: false,
+  email_verification_required: false,
+  password_reset_enabled: false,
+}
+
+function renderWithFeatures(ui: ReactElement, features: SystemFeatures = disabledFeatures) {
+  useFeatureStore.setState({ features, loading: false, error: null })
+  return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+afterEach(() => {
+  useFeatureStore.setState({ features: null, loading: false, error: null })
+})
+
+describe('auth feature gating', () => {
+  it('hides Google and password reset actions on login when integrations are disabled', () => {
+    renderWithFeatures(<LoginPage />)
+
+    expect(screen.queryByText('Continue with Google')).not.toBeInTheDocument()
+    expect(screen.queryByText('Forgot password?')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument()
+  })
+
+  it('hides Google sign-up on register when Google OAuth is disabled', () => {
+    renderWithFeatures(<RegisterPage />)
+
+    expect(screen.queryByText('Continue with Google')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sign Up' })).toBeInTheDocument()
+  })
+
+  it('shows a disabled password reset message instead of the request form', () => {
+    renderWithFeatures(<ForgotPasswordPage />)
+
+    expect(
+      screen.getByText('Password reset is not available because this server has not configured email delivery.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Send Reset Link' })).not.toBeInTheDocument()
+  })
+
+  it('shows a disabled password reset message instead of the reset form', () => {
+    renderWithFeatures(<ResetPasswordPage />)
+
+    expect(
+      screen.getByText('Password reset is not available because this server has not configured email delivery.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reset Password' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Added backend regression coverage for disabled optional auth integrations.
- Added frontend regression coverage for auth UI feature gating.
- Added a public health regression assertion to ensure detailed dependency checks are not exposed.

## Security Notes

- Verifies disabled Google OAuth, password reset, and email verification endpoints return `FEATURE_DISABLED`.
- Verifies disabled auth UI paths are hidden or replaced with safe unavailable messages.
- Confirms `/health` stays minimal and does not expose diagnostic `checks`.

## Validation

- `cargo test --locked feature_disabled --test integration`
- `cargo test --locked health_returns_200_when_db_connected --test integration`
- `cargo check --locked`
- `npm run test:run -- src/pages/AuthFeatureGating.test.tsx`
- `npm run lint`
- `npm run build`
- `git diff --check`
