### PR TITLE
chore: harden desktop updater release readiness

### DIFF
--- a/.github/scripts/validate-desktop-release.mjs
+++ b/.github/scripts/validate-desktop-release.mjs
@@ -35,6 +35,32 @@ function requireFile(relativePath, minBytes = 1) {
   }
 }
 
+function collectStrings(value, out = []) {
+  if (typeof value === 'string') {
+    out.push(value)
+    return out
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, out)
+    return out
+  }
+  if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectStrings(item, out)
+  }
+  return out
+}
+
+function includesLocalBackendTarget(value) {
+  return /(^|[^a-z0-9.-])(localhost|127\.0\.0\.1)(?::|\/|\*|$)/i.test(value)
+}
+
+function requireNoLocalTargets(label, value) {
+  const offenders = collectStrings(value).filter(includesLocalBackendTarget)
+  for (const offender of offenders) {
+    fail(`${label} must not include local backend target in release config: ${offender}`)
+  }
+}
+
 const tauri = loadJson('apps/desktop/src-tauri/tauri.conf.json')
 const cargoToml = existsSync(resolve(repoRoot, 'apps/desktop/src-tauri/Cargo.toml'))
   ? readFileSync(resolve(repoRoot, 'apps/desktop/src-tauri/Cargo.toml'), 'utf8')
@@ -81,6 +107,17 @@ if (tauri) {
     fail('Updater artifacts are enabled but updater pubkey is missing or placeholder')
   }
 
+  const updaterEndpoints = tauri.plugins?.updater?.endpoints
+  const expectedUpdaterEndpoint =
+    'https://github.com/emircanagac/voxpery/releases/latest/download/latest.json'
+  if (!Array.isArray(updaterEndpoints) || updaterEndpoints.length !== 1) {
+    fail('tauri.conf.json plugins.updater.endpoints must contain exactly one release metadata endpoint')
+  } else if (updaterEndpoints[0] !== expectedUpdaterEndpoint) {
+    fail(`Unexpected desktop updater endpoint: ${String(updaterEndpoints[0])}`)
+  }
+
+  requireNoLocalTargets('tauri.conf.json app.security.csp', tauri.app?.security?.csp)
+
   const installerIcon = tauri.bundle?.windows?.nsis?.installerIcon
   if (installerIcon !== 'icons/icon.ico') {
     fail(
@@ -100,12 +137,28 @@ requireFile('apps/desktop/src-tauri/icons/icon.png', 8_000)
 
 const capability = loadJson('apps/desktop/src-tauri/capabilities/default.json')
 if (capability) {
-  const permissions = Array.isArray(capability.permissions) ? capability.permissions : []
+  const capabilityEntries = Array.isArray(capability.capabilities)
+    ? capability.capabilities
+    : [capability]
+  const releaseCapability = capabilityEntries.find((entry) => entry?.identifier === 'default')
+  const permissions = Array.isArray(releaseCapability?.permissions)
+    ? releaseCapability.permissions
+    : []
   const httpPermission = permissions.find(
     (entry) => typeof entry === 'object' && entry?.identifier === 'http:default'
   )
   if (!httpPermission) {
-    fail('Desktop capability must include http:default permission block')
+    fail('Release desktop capability must include http:default permission block')
+  } else {
+    const allowedUrls = Array.isArray(httpPermission.allow)
+      ? httpPermission.allow.map((entry) => entry?.url).filter(Boolean)
+      : []
+    if (allowedUrls.length !== 1 || allowedUrls[0] !== 'https://api.voxpery.com/**') {
+      fail(
+        `Release desktop capability http scope must be limited to https://api.voxpery.com/** (found: ${allowedUrls.join(', ')})`
+      )
+    }
+    requireNoLocalTargets('release desktop capability http scope', allowedUrls)
   }
 }
 

--- a/apps/web/src/updater.test.ts
+++ b/apps/web/src/updater.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DESKTOP_UPDATE_STATUS_EVENT,
+  checkForUpdatesWithRuntime,
+  downloadAndInstallUpdateWithRuntime,
+  type UpdateResult,
+} from './updater'
+
+function createRuntime(options?: {
+  isDesktop?: boolean
+  update?: {
+    version?: string
+    body?: string | null
+    date?: string | null
+    downloadAndInstall?: () => Promise<void>
+  } | null
+  checkRejects?: boolean
+}) {
+  const downloadAndInstall = vi.fn(options?.update?.downloadAndInstall ?? (() => Promise.resolve()))
+  const update =
+    options?.update === undefined
+      ? null
+      : options.update && {
+          version: options.update.version ?? '0.2.0',
+          body: options.update.body,
+          date: options.update.date,
+          downloadAndInstall,
+        }
+  const check = options?.checkRejects
+    ? vi.fn<() => Promise<typeof update>>(() => Promise.reject(new Error('updater failed')))
+    : vi.fn<() => Promise<typeof update>>(() => Promise.resolve(update))
+  return {
+    runtime: {
+      isDesktop: () => options?.isDesktop ?? true,
+      check,
+      prepareForInstall: vi.fn(() => Promise.resolve()),
+      relaunch: vi.fn(() => Promise.resolve()),
+    },
+    check,
+    downloadAndInstall,
+  }
+}
+
+function listenForUpdateStatus() {
+  const events: UpdateResult[] = []
+  const listener = (event: Event) => {
+    events.push((event as CustomEvent<{ result: UpdateResult }>).detail.result)
+  }
+  window.addEventListener(DESKTOP_UPDATE_STATUS_EVENT, listener)
+  return {
+    events,
+    stop: () => window.removeEventListener(DESKTOP_UPDATE_STATUS_EVENT, listener),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('desktop updater', () => {
+  it('does not check for updates outside desktop runtime', async () => {
+    const { runtime, check } = createRuntime({ isDesktop: false })
+
+    await expect(checkForUpdatesWithRuntime(runtime)).resolves.toEqual({ available: false })
+    expect(check).not.toHaveBeenCalled()
+  })
+
+  it('emits unavailable status when no update exists', async () => {
+    const { runtime } = createRuntime({ update: null })
+    const status = listenForUpdateStatus()
+
+    await expect(checkForUpdatesWithRuntime(runtime)).resolves.toEqual({ available: false })
+
+    expect(status.events).toEqual([{ available: false }])
+    status.stop()
+  })
+
+  it('emits update metadata when an update is available', async () => {
+    const { runtime } = createRuntime({
+      update: { version: '0.2.0', body: 'Release notes', date: '2026-04-26' },
+    })
+    const status = listenForUpdateStatus()
+
+    await expect(checkForUpdatesWithRuntime(runtime)).resolves.toEqual({
+      available: true,
+      version: '0.2.0',
+      body: 'Release notes',
+      date: '2026-04-26',
+    })
+
+    expect(status.events).toEqual([
+      {
+        available: true,
+        version: '0.2.0',
+        body: 'Release notes',
+        date: '2026-04-26',
+      },
+    ])
+    status.stop()
+  })
+
+  it('prepares the desktop runtime before installing and relaunching', async () => {
+    const calls: string[] = []
+    const { runtime, downloadAndInstall } = createRuntime({
+      update: {
+        downloadAndInstall: async () => {
+          calls.push('downloadAndInstall')
+        },
+      },
+    })
+    runtime.prepareForInstall = vi.fn(async () => {
+      calls.push('prepare')
+    })
+    runtime.relaunch = vi.fn(async () => {
+      calls.push('relaunch')
+    })
+
+    await expect(downloadAndInstallUpdateWithRuntime(runtime)).resolves.toBe(true)
+
+    expect(downloadAndInstall).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(['prepare', 'downloadAndInstall', 'relaunch'])
+  })
+
+  it('returns false without install side effects when no update exists', async () => {
+    const { runtime, downloadAndInstall } = createRuntime({ update: null })
+
+    await expect(downloadAndInstallUpdateWithRuntime(runtime)).resolves.toBe(false)
+
+    expect(runtime.prepareForInstall).not.toHaveBeenCalled()
+    expect(downloadAndInstall).not.toHaveBeenCalled()
+    expect(runtime.relaunch).not.toHaveBeenCalled()
+  })
+
+  it('handles updater errors without throwing', async () => {
+    const { runtime } = createRuntime({ checkRejects: true })
+
+    await expect(checkForUpdatesWithRuntime(runtime)).resolves.toEqual({ available: false, error: true })
+    await expect(downloadAndInstallUpdateWithRuntime(runtime)).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/updater.ts
+++ b/apps/web/src/updater.ts
@@ -15,6 +15,20 @@ export type DesktopUpdateStatusDetail = {
   result: UpdateResult
 }
 
+type DesktopUpdate = {
+  version: string
+  body?: string | null
+  date?: string | null
+  downloadAndInstall: () => Promise<void>
+}
+
+type DesktopUpdaterRuntime = {
+  isDesktop: () => boolean
+  check: () => Promise<DesktopUpdate | null>
+  prepareForInstall: () => Promise<void>
+  relaunch: () => Promise<void>
+}
+
 function logUpdaterError(scope: string, error: unknown) {
   if (!import.meta.env.DEV) return
   console.error(`[desktop-updater] ${scope}`, error)
@@ -28,13 +42,23 @@ function emitDesktopUpdateStatus(result: UpdateResult) {
   )
 }
 
-export async function checkForUpdates(): Promise<UpdateResult> {
-  if (!isTauri()) {
+async function defaultRuntime(): Promise<DesktopUpdaterRuntime> {
+  const { check } = await import('@tauri-apps/plugin-updater')
+  const { relaunch } = await import('@tauri-apps/plugin-process')
+  return {
+    isDesktop: isTauri,
+    check,
+    prepareForInstall: prepareDesktopForUpdateInstall,
+    relaunch,
+  }
+}
+
+export async function checkForUpdatesWithRuntime(runtime: DesktopUpdaterRuntime): Promise<UpdateResult> {
+  if (!runtime.isDesktop()) {
     return { available: false }
   }
   try {
-    const { check } = await import('@tauri-apps/plugin-updater')
-    const update = await check()
+    const update = await runtime.check()
     if (!update) {
       const result: UpdateResult = { available: false }
       emitDesktopUpdateStatus(result)
@@ -56,23 +80,35 @@ export async function checkForUpdates(): Promise<UpdateResult> {
   }
 }
 
-export async function downloadAndInstallUpdate(): Promise<boolean> {
-  if (!isTauri()) {
+export async function downloadAndInstallUpdateWithRuntime(runtime: DesktopUpdaterRuntime): Promise<boolean> {
+  if (!runtime.isDesktop()) {
     return false
   }
   try {
-    const { check } = await import('@tauri-apps/plugin-updater')
-    const { relaunch } = await import('@tauri-apps/plugin-process')
-    const update = await check()
+    const update = await runtime.check()
     if (!update) return false
-    await prepareDesktopForUpdateInstall()
+    await runtime.prepareForInstall()
     await update.downloadAndInstall()
-    await relaunch()
+    await runtime.relaunch()
     return true
   } catch (error) {
     logUpdaterError('install failed', error)
     return false
   }
+}
+
+export async function checkForUpdates(): Promise<UpdateResult> {
+  if (!isTauri()) {
+    return { available: false }
+  }
+  return checkForUpdatesWithRuntime(await defaultRuntime())
+}
+
+export async function downloadAndInstallUpdate(): Promise<boolean> {
+  if (!isTauri()) {
+    return false
+  }
+  return downloadAndInstallUpdateWithRuntime(await defaultRuntime())
 }
 
 export async function getDesktopAppVersion(): Promise<string | null> {

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -35,8 +35,8 @@ This document defines Voxpery desktop release hardening policy for metadata, dee
 
 Current strategy:
 
-- Regular installer releases are allowed without updater artifacts.
-- If updater artifacts are enabled (`bundle.createUpdaterArtifacts=true`), signing becomes mandatory.
+- Desktop updater artifacts are enabled (`bundle.createUpdaterArtifacts=true`).
+- Updater signing is mandatory for every desktop release build.
 
 Mandatory conditions when updater artifacts are enabled:
 
@@ -44,6 +44,7 @@ Mandatory conditions when updater artifacts are enabled:
 - CI must inject the real updater public key before validation/build.
 - Repository secret `TAURI_SIGNING_PRIVATE_KEY` must be configured.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is required if the key is password-protected.
+- `plugins.updater.endpoints` must point to the official GitHub `latest.json` release metadata URL.
 
 This policy is enforced in release preflight validation.
 
@@ -54,8 +55,22 @@ Before publishing a desktop release:
 1. Complete `docs/RELEASE_SMOKE_TEST_CHECKLIST.md`.
 2. Confirm OAuth deep-link roundtrip works from browser back to desktop app.
 3. Confirm installer uses Voxpery icon/name (not default NSIS icon).
+4. Confirm update check UX:
+   - no-update state is understandable
+   - available-update state shows version metadata
+   - failed update check/install does not crash or leave the settings panel stuck
+5. Confirm installer/update preparation closes tray/minimize state cleanly before install.
 
-## 5) Recommended Repository Secrets
+## 5) Rollback Expectations
+
+Voxpery desktop rollback is manual and release-artifact based:
+
+- Keep the previous stable installer artifacts available in GitHub Releases.
+- If a desktop release is bad, mark the bad release as draft or remove the updater metadata asset so clients stop discovering it.
+- Publish or re-promote the previous stable release metadata if updater clients must move back to a known-good version.
+- Document the rollback decision and affected version in release notes or the incident record.
+
+## 6) Recommended Repository Secrets
 
 - `VITE_API_URL` (required for desktop release build)
 - `TAURI_UPDATER_PUBLIC_KEY` (required when updater artifacts enabled)

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -32,9 +32,14 @@ Use this checklist for every production release candidate before tag/publish.
 
 - [ ] Installer opens with Voxpery app name and icon (not default NSIS icon).
 - [ ] App opens and reaches login screen.
+- [ ] Production desktop build connects only to the official API and does not allow localhost API scopes.
 - [ ] Google OAuth opens browser and returns to desktop app via `voxpery://` deep link.
 - [ ] Session is restored after OAuth callback (user ends in authenticated app state).
 - [ ] If updater artifacts are enabled, signing keys and updater pubkey are configured (see `docs/DESKTOP_RELEASE_HARDENING.md`).
+- [ ] Updater check shows a clear no-update state when no newer version is available.
+- [ ] Updater check shows the available version when a newer signed release is available.
+- [ ] Updater install path prepares the desktop runtime before install/relaunch.
+- [ ] Failed updater check/install shows recoverable UI and does not leave settings stuck.
 - [ ] Linux desktop test host has `xdg-desktop-portal` + (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` running.
 - [ ] First voice join shows OS/browser microphone permission prompt when needed.
 - [ ] Voice join succeeds after permission grant.
@@ -45,6 +50,7 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Changelog updated (`docs/CHANGELOG.md`).
 - [ ] Deployment notes updated if needed (`docs/DEPLOYMENT.md`).
 - [ ] Release notes draft prepared.
+- [ ] Previous stable desktop installer artifacts remain available for manual rollback.
 - [ ] Approved to tag and publish.
 
 ## Sign-off


### PR DESCRIPTION
## Summary
- Add desktop updater regression tests for no-update, available-update, install ordering, and error handling.
- Harden desktop release validation so production builds keep updater metadata and HTTP scopes locked to official endpoints.
- Update desktop release hardening and smoke-test docs with updater QA and rollback expectations.

## Validation
- `npm run test:run -- src/updater.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes
- No runtime desktop updater behavior was changed; the updater flow was split behind a testable runtime seam.
- Local release validation still fails without real signing secrets, as expected. CI should inject the updater public key before validation.
