### PR TITLE
chore: bump desktop version to 0.1.7

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5231,7 +5231,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",


### PR DESCRIPTION
## Summary
- Bump desktop app metadata from `0.1.6` to `0.1.7`.
- Keep `Cargo.toml`, `Cargo.lock`, and `tauri.conf.json` aligned for the desktop release.

## Validation
- `cargo metadata --locked --no-deps --format-version 1`

## Notes
- Runtime behavior is unchanged.
- This fixes the missed desktop version metadata for the already published `v0.1.7` release.
