### PR TITLE
fix: use Tauri HTTP plugin for production desktop API

### DIFF
--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, it, expect, afterEach } from 'vitest'
-import { createWebSocket, getAuthErrorMessage, isAuthError } from './api'
+import {
+  createWebSocket,
+  getAuthErrorMessage,
+  isAuthError,
+  shouldUseTauriHttpPluginForApiBase,
+} from './api'
 
 class MockWebSocket {
   url: string
@@ -81,6 +86,21 @@ describe('API Error Handling', () => {
       expect(ws.url).toMatch(/\/ws$/)
       expect(ws.url).not.toContain('token=')
       expect(ws.protocols).toBeUndefined()
+    })
+  })
+
+  describe('shouldUseTauriHttpPluginForApiBase', () => {
+    it('uses the Tauri HTTP plugin for production desktop API calls', () => {
+      expect(shouldUseTauriHttpPluginForApiBase(true, 'https://api.voxpery.com')).toBe(true)
+    })
+
+    it('keeps local desktop development on browser fetch for loopback APIs', () => {
+      expect(shouldUseTauriHttpPluginForApiBase(true, 'http://localhost:3001')).toBe(false)
+      expect(shouldUseTauriHttpPluginForApiBase(true, 'http://127.0.0.1:3001')).toBe(false)
+    })
+
+    it('does not use the Tauri HTTP plugin outside desktop', () => {
+      expect(shouldUseTauriHttpPluginForApiBase(false, 'https://api.voxpery.com')).toBe(false)
     })
   })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -27,25 +27,21 @@ function isLoopbackHostname(hostname: string): boolean {
     return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
 }
 
-function isLoopbackApiBase(): boolean {
+function isLoopbackApiBase(apiBase: string = effectiveApiBase()): boolean {
     try {
-        const apiUrl = new URL(effectiveApiBase())
+        const apiUrl = new URL(apiBase)
         return isLoopbackHostname(apiUrl.hostname)
     } catch {
         return false
     }
 }
 
-function isTauriHttpDevSession(): boolean {
-    if (!isTauri() || typeof window === 'undefined') return false
-    if (isLoopbackApiBase()) return true
-    const isBrowserProtocol = window.location.protocol === 'http:' || window.location.protocol === 'https:'
-    const isLoopbackHost = isLoopbackHostname(window.location.hostname) || window.location.hostname === 'tauri.localhost'
-    return isBrowserProtocol && isLoopbackHost
+export function shouldUseTauriHttpPluginForApiBase(isDesktop: boolean, apiBase: string): boolean {
+    return isDesktop && !isLoopbackApiBase(apiBase)
 }
 
 function shouldUseTauriHttpPlugin(): boolean {
-    return isTauri() && !isTauriHttpDevSession()
+    return shouldUseTauriHttpPluginForApiBase(isTauri(), effectiveApiBase())
 }
 
 /** In browser, if page is on localhost but API_BASE uses 127.0.0.1, return API base with localhost so the auth cookie is sent. */


### PR DESCRIPTION
## Summary
- Fix production desktop API calls by using the Tauri HTTP plugin for non-loopback API bases.
- Keep browser fetch only for local desktop development against `localhost` / `127.0.0.1`.
- Add regression coverage for production desktop vs local desktop API routing.

## Validation
- `npm run test:run -- src/api.test.ts`
- `npm run lint`
- `npm run build`

## Notes
- This fixes the v0.1.7 desktop login error: `Cannot connect to the server. (API: https://api.voxpery.com) Failed to fetch`.
- This branch also contains the desktop `0.1.7` metadata/version sync fixes from the previous branch, so it can be used as the hotfix PR.
