### PR TITLE
fix: enhance voice noise suppression and adjust sensitivity thresholds

### DIFF
--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -358,11 +358,11 @@ export function useAudioEngine() {
         rnnoise.node.connect(lowPassFilter)
         lowPassFilter.connect(deClickFilter)
         deClickFilter.connect(refinementAnalyser)
-        deClickFilter.connect(vadDestination)   // branch for VAD analyser
         deClickFilter.connect(speechPresenceFilter)
         speechPresenceFilter.connect(speechIsolationGainNode)
         speechIsolationGainNode.connect(transientCompressor)
         transientCompressor.connect(noiseFloorGainNode)
+        noiseFloorGainNode.connect(vadDestination) // branch for VAD after final floor suppression
         noiseFloorGainNode.connect(volumeGainNode)
         volumeGainNode.connect(destination)
 
@@ -427,7 +427,7 @@ export function useAudioEngine() {
                 // ignore
             }
             try {
-                deClickFilter.disconnect(vadDestination)
+                noiseFloorGainNode.disconnect(vadDestination)
             } catch {
                 // ignore
             }

--- a/apps/web/src/webrtc/sensitivityThreshold.ts
+++ b/apps/web/src/webrtc/sensitivityThreshold.ts
@@ -1,5 +1,5 @@
 /**
- * Single source of truth for Sensitivity threshold (0–100 slider).
+ * Single source of truth for Sensitivity threshold (0-100 slider).
  * Used by: speaking indicator (VAD), noise gate (send chain), and settings UI.
  * Lower slider = more sensitive (quieter sounds pass / are sent).
  */
@@ -13,10 +13,10 @@ export const DEFAULT_SPEAKING_PRESET: Exclude<SpeakingPreset, 'custom'> = 'norma
 /** Default slider value when not set (matches "Balanced" preset). */
 export const DEFAULT_SENSITIVITY_SLIDER = 42
 
-/** Sensitivity threshold (0–100) per preset. Lower = more sensitive (quieter sounds pass / sent). */
+/** Sensitivity threshold (0-100) per preset. Lower = more sensitive (quieter sounds pass / sent). */
 export function thresholdByPreset(preset: Exclude<SpeakingPreset, 'custom'>): number {
-  if (preset === 'noisy') return 54   // −46dB
-  return 42                           // −58dB (balanced default)
+  if (preset === 'noisy') return 60   // -40dB
+  return 42                           // -58dB (balanced default)
 }
 
 export function getStoredSpeakingPreset(): SpeakingPreset {
@@ -26,7 +26,7 @@ export function getStoredSpeakingPreset(): SpeakingPreset {
   return DEFAULT_SPEAKING_PRESET
 }
 
-/** Slider 0 → ~0.00001 (-100dB), slider 100 → 1.0 (0dB). */
+/** Slider 0 -> ~0.00001 (-100dB), slider 100 -> 1.0 (0dB). */
 export function onThresholdFromSlider(slider: number): number {
   const s = Math.min(100, Math.max(0, Number(slider)))
   // Linear in dB so each slider step maps to a stable 1dB step (-100..0).
@@ -39,7 +39,7 @@ export function offThresholdFromOn(onThr: number): number {
   return Math.max(0.000001, onThr * 0.14)
 }
 
-/** Read slider from storage (0–100), default DEFAULT_SENSITIVITY_SLIDER. */
+/** Read slider from storage (0-100), default DEFAULT_SENSITIVITY_SLIDER. */
 export function getSliderFromStorage(): number {
   const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(SENSITIVITY_THRESHOLD_KEY) : null
   if (raw != null && raw.trim().length > 0) {

--- a/apps/web/src/webrtc/voiceGate.test.ts
+++ b/apps/web/src/webrtc/voiceGate.test.ts
@@ -28,10 +28,11 @@ function buildFrequencyFrame({
 }
 
 describe('evaluateVoiceGateFrame', () => {
-  it('opens immediately for non-aggressive isolation when speech is above threshold', () => {
-    const result = evaluateVoiceGateFrame({
+  it('opens after two speech frames for non-aggressive suppression', () => {
+    const frame = buildFrequencyFrame({ speechDb: -28, highNoiseDb: -70, lowNoiseDb: -84 })
+    const first = evaluateVoiceGateFrame({
       rms: 0.024,
-      frequencyData: buildFrequencyFrame({ speechDb: -28, highNoiseDb: -70, lowNoiseDb: -84 }),
+      frequencyData: frame,
       sampleRate: SAMPLE_RATE,
       fftSize: FFT_SIZE,
       onThr: 0.01,
@@ -44,11 +45,29 @@ describe('evaluateVoiceGateFrame', () => {
       smoothedRms: 0,
     })
 
-    expect(result.openFramesRequired).toBe(1)
-    expect(result.speaking).toBe(true)
+    expect(first.openFramesRequired).toBe(2)
+    expect(first.speaking).toBe(false)
+    expect(first.openFrames).toBe(1)
+
+    const second = evaluateVoiceGateFrame({
+      rms: 0.024,
+      frequencyData: frame,
+      sampleRate: SAMPLE_RATE,
+      fftSize: FFT_SIZE,
+      onThr: 0.01,
+      offThr: 0.0014,
+      noiseSuppressionEnabled: true,
+      aggressiveIsolation: false,
+      speaking: first.speaking,
+      openFrames: first.openFrames,
+      belowFrames: first.belowFrames,
+      smoothedRms: first.smoothedRms,
+    })
+
+    expect(second.speaking).toBe(true)
   })
 
-  it('requires two consecutive frames for aggressive isolation before opening', () => {
+  it('requires three consecutive frames for aggressive isolation before opening', () => {
     const frame = buildFrequencyFrame({ speechDb: -30, highNoiseDb: -68, lowNoiseDb: -82 })
     const first = evaluateVoiceGateFrame({
       rms: 0.021,
@@ -64,7 +83,7 @@ describe('evaluateVoiceGateFrame', () => {
       belowFrames: 0,
       smoothedRms: 0,
     })
-    expect(first.openFramesRequired).toBe(2)
+    expect(first.openFramesRequired).toBe(3)
     expect(first.speaking).toBe(false)
     expect(first.openFrames).toBe(1)
 
@@ -82,7 +101,24 @@ describe('evaluateVoiceGateFrame', () => {
       belowFrames: first.belowFrames,
       smoothedRms: first.smoothedRms,
     })
-    expect(second.speaking).toBe(true)
+    expect(second.speaking).toBe(false)
+    expect(second.openFrames).toBe(2)
+
+    const third = evaluateVoiceGateFrame({
+      rms: 0.021,
+      frequencyData: frame,
+      sampleRate: SAMPLE_RATE,
+      fftSize: FFT_SIZE,
+      onThr: 0.01,
+      offThr: 0.0014,
+      noiseSuppressionEnabled: true,
+      aggressiveIsolation: true,
+      speaking: second.speaking,
+      openFrames: second.openFrames,
+      belowFrames: second.belowFrames,
+      smoothedRms: second.smoothedRms,
+    })
+    expect(third.speaking).toBe(true)
   })
 
   it('closes after hold frames are exhausted when signal remains below off threshold', () => {
@@ -97,11 +133,11 @@ describe('evaluateVoiceGateFrame', () => {
       aggressiveIsolation: false,
       speaking: true,
       openFrames: 0,
-      belowFrames: 8,
+      belowFrames: 6,
       smoothedRms: 0.000001,
     })
 
-    expect(result.holdFrames).toBe(9)
+    expect(result.holdFrames).toBe(7)
     expect(result.speaking).toBe(false)
   })
 
@@ -122,5 +158,26 @@ describe('evaluateVoiceGateFrame', () => {
     })
 
     expect(result.speaking).toBe(false)
+  })
+
+  it('keeps aggressive gate closed on broadband breath or room noise above threshold', () => {
+    const result = evaluateVoiceGateFrame({
+      rms: 0.014,
+      frequencyData: buildFrequencyFrame({ speechDb: -42, highNoiseDb: -37, lowNoiseDb: -76 }),
+      sampleRate: SAMPLE_RATE,
+      fftSize: FFT_SIZE,
+      onThr: 0.01,
+      offThr: 0.0014,
+      noiseSuppressionEnabled: true,
+      aggressiveIsolation: true,
+      speaking: false,
+      openFrames: 0,
+      belowFrames: 0,
+      smoothedRms: 0,
+    })
+
+    expect(result.speechFrame.noiseDominant).toBe(true)
+    expect(result.speaking).toBe(false)
+    expect(result.openFrames).toBe(0)
   })
 })

--- a/apps/web/src/webrtc/voiceGate.ts
+++ b/apps/web/src/webrtc/voiceGate.ts
@@ -1,6 +1,7 @@
 export interface SpeechFrameScore {
   score: number
   clicky: boolean
+  noiseDominant: boolean
 }
 
 export interface VoiceGateFrameInput {
@@ -74,7 +75,11 @@ export function getSpeechFrameScore(
     highNoiseDb > presenceDb + 3.2
     && highNoiseDb > speechBodyDb + 4.2
     && lowNoiseDb < speechBodyDb - 6
-  return { score, clicky }
+  const noiseDominant =
+    highNoiseDb > presenceDb + 2.2
+    && highNoiseDb > speechBodyDb + 2.8
+    && upperSpeechDb < highNoiseDb + 1.2
+  return { score, clicky, noiseDominant }
 }
 
 export function evaluateVoiceGateFrame(input: VoiceGateFrameInput): VoiceGateFrameResult {
@@ -95,18 +100,19 @@ export function evaluateVoiceGateFrame(input: VoiceGateFrameInput): VoiceGateFra
 
   const speechFrame = getSpeechFrameScore(frequencyData, sampleRate, fftSize)
   const speechLike = aggressiveIsolation
-    ? speechFrame.score >= -1.4 && !speechFrame.clicky
-    : speechFrame.score >= -2.6
-  const openFramesRequired = aggressiveIsolation ? 2 : 1
-  const holdFrames = aggressiveIsolation ? 8 : noiseSuppressionEnabled ? 9 : 7
-  const smoothAlpha = aggressiveIsolation ? 0.945 : 0.955
+    ? speechFrame.score >= -0.8 && !speechFrame.clicky && !speechFrame.noiseDominant
+    : speechFrame.score >= -2.4 && !speechFrame.noiseDominant
+  const openFramesRequired = aggressiveIsolation ? 3 : noiseSuppressionEnabled ? 2 : 1
+  const holdFrames = aggressiveIsolation ? 6 : noiseSuppressionEnabled ? 7 : 7
+  const smoothAlpha = aggressiveIsolation ? 0.94 : 0.955
   const effectiveOffThr = Math.max(
     offThr,
     onThr * (aggressiveIsolation ? 0.36 : noiseSuppressionEnabled ? 0.3 : 0.24),
   )
   const nextSmoothedRms = smoothAlpha * smoothedRms + (1 - smoothAlpha) * rms
-  const strongOnset = rms >= onThr * (aggressiveIsolation ? 1.35 : 1.12)
-  const shouldOpen = (rms >= onThr && speechLike) || (strongOnset && !speechFrame.clicky)
+  const strongOnset = rms >= onThr * (aggressiveIsolation ? 1.65 : 1.16)
+  const shouldOpen = (rms >= onThr && speechLike)
+    || (strongOnset && !speechFrame.clicky && !speechFrame.noiseDominant && (!aggressiveIsolation || speechFrame.score >= -0.4))
 
   if (shouldOpen) {
     const nextOpenFrames = openFrames + 1

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -43,6 +43,7 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Linux desktop test host has `xdg-desktop-portal` + (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` running.
 - [ ] First voice join shows OS/browser microphone permission prompt when needed.
 - [ ] Voice join succeeds after permission grant.
+- [ ] Voice settings mic test with noise suppression on and `Noisy room` selected does not pass normal keyboard, mouse, fan, or breath noise as speech.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 
 ## 4) Final Sign-off

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -9,7 +9,9 @@ Microphone -> getUserMedia -> AudioContext pipeline -> LiveKit Room -> SFU -> Re
                                     |
                            High-pass cleanup
                            RNNoise denoiser
+                           Speech / transient cleanup
                            Low-level noise taming
+                           VAD analyser tap
                            Input gain
                            VAD gate (optional)
                            Sensitivity threshold
@@ -65,9 +67,9 @@ Speech / transient cleanup stage
     |
 Low-level noise tamer (post-RNNoise floor shaping)
     |
-GainNode (input volume)
+VAD analyser tap (post-denoise + post-floor suppression, pre-volume)
     |
-VAD analyser tap (post-RNNoise, pre-volume)
+GainNode (input volume)
     |
 VAD gate (optional, voice_activity mode)
     |
@@ -99,6 +101,9 @@ Room.localParticipant.publishTrack
 - **Low-level noise tamer**
   - A gentle post-RNNoise gain stage reduces very quiet residual noise between phrases without hard-gating speech
   - Helps with dip hiss, room hum, and lingering background texture while keeping speech natural
+- **Post-suppression VAD tap**
+  - The mic test monitor and local speaking indicator now read from the signal after residual floor attenuation
+  - This keeps the glow and mic test closer to the audio Voxpery would actually send, so keyboard, mouse, and breath noise are less likely to appear as speech
 - **Preset-aware DSP behavior**
   - With suppression enabled, Voxpery adjusts multiple stages together:
     - low-pass filtering for high-frequency keyboard/transient cleanup
@@ -118,9 +123,10 @@ Room.localParticipant.publishTrack
 Two modes:
 
 1. **Voice Activity**: Mic auto-mutes when RMS below threshold (Discord-like)
-   - Analyser reads RMS from the denoised signal (`post-RNNoise`, `pre-volume`)
+   - Analyser reads RMS from the post-suppression signal (`post-denoise`, `post-floor-suppression`, `pre-volume`)
    - If above `onThreshold`, enable track; below `offThreshold` for enough held frames, disable
    - Fast attack + slower release + hysteresis keep speaking feedback responsive without flicker during short pauses
+   - Suppression-enabled mode requires consecutive speech-like frames before opening the gate, and aggressive isolation rejects noise-dominant frames such as keyboard clicks, mouse clicks, and breath-heavy broadband noise
 2. **Push-to-Talk**: Manual control via keyboard (default: `V` key)
 
 ### Sensitivity Threshold
@@ -128,7 +134,7 @@ Two modes:
 - **Range**: `-100 dB .. 0 dB` in the UI (`0..100` internal slider scale)
 - **Presets**:
   - `Balanced` (`-58 dB`) - recommended default for everyday use
-  - `Noisy room` (`-46 dB`) - stricter for louder environments
+  - `Noisy room` (`-40 dB`) - stricter for louder environments with keyboard, mouse, fan, or breath noise
   - `Custom` - manual threshold control across the full `-100 .. 0 dB` range
 - **Default preset**: `Balanced`
 - **Mapping**:


### PR DESCRIPTION
## Summary

Improves voice noise suppression and mic-test behavior for keyboard, mouse, fan, and breath noise.

This PR moves the local VAD/mic-test tap after final floor suppression so the speaking glow and mic monitor follow audio closer to what Voxpery actually sends. It also makes voice activity gating more selective for suppression-enabled modes and tightens the `Noisy room` preset to `-40 dB`.

## Docs

- Updated `docs/VOICE_SYSTEM.md` for the new post-suppression VAD tap and stricter gate behavior.
- Added a release smoke check for noisy-room mic testing.

## Validation

- `npm.cmd run lint`
- `npm.cmd run test:run`
- `npm.cmd run build`
