### PR TITLE
chore: add realtime load smoke test and update documentation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "smoke:e2e": "node scripts/smoke-e2e.mjs",
     "chaos:reconnect": "node scripts/chaos-reconnect.mjs",
     "regression:multi-user": "node scripts/regression-multi-user.mjs",
+    "load:realtime": "node scripts/realtime-load-smoke.mjs",
     "rate-limit:check": "node scripts/rate-limit-check.mjs"
   },
   "dependencies": {

--- a/apps/web/scripts/realtime-load-smoke.mjs
+++ b/apps/web/scripts/realtime-load-smoke.mjs
@@ -1,0 +1,275 @@
+/**
+ * Lightweight realtime load smoke test.
+ *
+ * This is not a full benchmark. It creates a small synthetic room, measures
+ * WebSocket message delivery latency, exercises a reconnect burst, and checks
+ * voice-state fan-out without touching the LiveKit media plane.
+ *
+ * Run with backend up:
+ *   npm run load:realtime
+ *
+ * Optional env:
+ *   SMOKE_API_URL=http://127.0.0.1:3001
+ *   REALTIME_LOAD_USERS=5
+ *   REALTIME_LOAD_MESSAGES=12
+ *   REALTIME_LOAD_RECONNECT_USERS=3
+ */
+import { WebSocket } from 'ws'
+import { randomUUID } from 'node:crypto'
+
+const API_BASE = process.env.SMOKE_API_URL || 'http://127.0.0.1:3001'
+const WS_BASE = API_BASE.replace(/^http/, 'ws')
+
+const USERS = intEnv('REALTIME_LOAD_USERS', 5, 2, 50)
+const MESSAGES = intEnv('REALTIME_LOAD_MESSAGES', 12, 1, 200)
+const RECONNECT_USERS = intEnv(
+  'REALTIME_LOAD_RECONNECT_USERS',
+  Math.min(3, USERS),
+  1,
+  USERS
+)
+const WAIT_TIMEOUT_MS = intEnv('REALTIME_LOAD_TIMEOUT_MS', 15000, 1000, 120000)
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function intEnv(name, fallback, min, max) {
+  const parsed = Number.parseInt(process.env[name] || '', 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function randomIdentity(prefix) {
+  const suffix = `${Date.now()}_${randomUUID().slice(0, 8)}`
+  return {
+    username: `${prefix}_${suffix}`,
+    email: `${prefix}_${suffix}@voxpery.dev`,
+    password: 'load-test-password-123',
+  }
+}
+
+async function api(path, { method = 'GET', body, token } = {}) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`${method} ${path} failed (${res.status}): ${text}`)
+  }
+  return res.json()
+}
+
+async function registerUser(prefix) {
+  const res = await api('/api/auth/register', {
+    method: 'POST',
+    body: randomIdentity(prefix),
+  })
+  assert(res?.token && res?.user?.id, 'register response missing token/user')
+  return { token: res.token, userId: res.user.id, username: res.user.username }
+}
+
+async function openWs(user) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`${WS_BASE}/ws`, ['voxpery.auth', user.token])
+    const client = {
+      ...user,
+      ws,
+      events: [],
+      messageTimes: new Map(),
+      pongTimes: new Map(),
+      voiceStateTimes: new Map(),
+    }
+
+    const onError = (err) => reject(err)
+    ws.on('error', onError)
+    ws.on('open', () => {
+      ws.off('error', onError)
+      ws.on('message', (raw) => {
+        const receivedAt = Date.now()
+        try {
+          const event = JSON.parse(String(raw))
+          client.events.push({ event, receivedAt })
+          if (event?.type === 'NewMessage' && event?.data?.message?.id) {
+            client.messageTimes.set(event.data.message.id, receivedAt)
+          }
+          if (event?.type === 'Pong' && event?.data?.sent_at_ms) {
+            client.pongTimes.set(event.data.sent_at_ms, receivedAt)
+          }
+          if (event?.type === 'VoiceStateUpdate' && event?.data?.user_id) {
+            client.voiceStateTimes.set(event.data.user_id, receivedAt)
+          }
+        } catch {
+          // Ignore non-json frames.
+        }
+      })
+      resolve(client)
+    })
+  })
+}
+
+function wsSend(ws, type, data) {
+  ws.send(JSON.stringify({ type, data }))
+}
+
+async function waitFor(predicate, label, timeoutMs = WAIT_TIMEOUT_MS) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await sleep(50)
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)
+  return sorted[idx]
+}
+
+function summarize(label, values) {
+  const rounded = values.map((v) => Math.round(v))
+  console.log(
+    `[load:realtime] ${label}: count=${rounded.length} p50=${percentile(rounded, 50)}ms p95=${percentile(rounded, 95)}ms max=${Math.max(...rounded)}ms`
+  )
+}
+
+async function createRoom(owner, members) {
+  const server = await api('/api/servers', {
+    method: 'POST',
+    token: owner.token,
+    body: { name: `Realtime Load ${Date.now()}`, icon_url: null },
+  })
+  assert(server?.id && server?.invite_code, 'server create failed')
+
+  for (const member of members) {
+    await api('/api/servers/join', {
+      method: 'POST',
+      token: member.token,
+      body: { invite_code: server.invite_code },
+    })
+  }
+
+  const channels = await api(`/api/servers/${server.id}/channels`, { token: owner.token })
+  const textChannel = channels.find((c) => c.channel_type === 'text')
+  const voiceChannel = channels.find((c) => c.channel_type === 'voice')
+  assert(textChannel?.id, 'text channel missing')
+  assert(voiceChannel?.id, 'voice channel missing')
+  return { server, textChannel, voiceChannel }
+}
+
+async function measureMessageDelivery(clients, textChannel) {
+  const latencies = []
+  for (let i = 0; i < MESSAGES; i += 1) {
+    const sender = clients[i % clients.length]
+    const startedAt = Date.now()
+    const sent = await api(`/api/messages/${textChannel.id}`, {
+      method: 'POST',
+      token: sender.token,
+      body: { content: `load message ${i} ${startedAt}`, attachments: [] },
+    })
+    assert(sent?.id, 'message send response missing id')
+
+    await waitFor(
+      () => clients.every((client) => client.messageTimes.has(sent.id)),
+      `NewMessage ${sent.id} delivery to ${clients.length} clients`
+    )
+
+    for (const client of clients) {
+      latencies.push(client.messageTimes.get(sent.id) - startedAt)
+    }
+  }
+  summarize('message delivery latency', latencies)
+}
+
+async function measureReconnectBurst(clients, textChannel, voiceChannel) {
+  const subset = clients.slice(0, RECONNECT_USERS)
+  const reconnectStartedAt = Date.now()
+  for (const client of subset) {
+    client.ws.terminate()
+  }
+  await sleep(300)
+
+  const reconnected = await Promise.all(subset.map((client) => openWs(client)))
+  for (const client of reconnected) {
+    wsSend(client.ws, 'Subscribe', { channel_ids: [textChannel.id, voiceChannel.id] })
+  }
+
+  const pingLatencies = []
+  for (const client of reconnected) {
+    const sentAt = Date.now()
+    wsSend(client.ws, 'Ping', { sent_at_ms: sentAt })
+    await waitFor(() => client.pongTimes.has(sentAt), `Pong for ${client.username}`)
+    pingLatencies.push(client.pongTimes.get(sentAt) - sentAt)
+  }
+
+  summarize('post-reconnect ping latency', pingLatencies)
+  console.log(
+    `[load:realtime] reconnect burst: users=${RECONNECT_USERS} elapsed=${Date.now() - reconnectStartedAt}ms`
+  )
+
+  return clients.map((client) => reconnected.find((next) => next.userId === client.userId) || client)
+}
+
+async function measureVoiceStateFanout(clients, voiceChannel) {
+  const latencies = []
+  for (const joiningClient of clients) {
+    const startedAt = Date.now()
+    wsSend(joiningClient.ws, 'JoinVoice', { channel_id: voiceChannel.id })
+    await waitFor(
+      () => clients.every((client) => client.voiceStateTimes.has(joiningClient.userId)),
+      `VoiceStateUpdate for ${joiningClient.username}`
+    )
+    for (const client of clients) {
+      latencies.push(client.voiceStateTimes.get(joiningClient.userId) - startedAt)
+    }
+  }
+  summarize('voice state fan-out latency', latencies)
+}
+
+async function main() {
+  console.log(`[load:realtime] API: ${API_BASE}`)
+  console.log(
+    `[load:realtime] users=${USERS} messages=${MESSAGES} reconnect_users=${RECONNECT_USERS}`
+  )
+
+  const users = []
+  for (let i = 0; i < USERS; i += 1) {
+    users.push(await registerUser(`rt_load_${i}`))
+  }
+
+  const owner = users[0]
+  const members = users.slice(1)
+  const { textChannel, voiceChannel } = await createRoom(owner, members)
+
+  let clients = await Promise.all(users.map((user) => openWs(user)))
+  for (const client of clients) {
+    wsSend(client.ws, 'Subscribe', { channel_ids: [textChannel.id, voiceChannel.id] })
+  }
+  await sleep(300)
+
+  await measureMessageDelivery(clients, textChannel)
+  clients = await measureReconnectBurst(clients, textChannel, voiceChannel)
+  await sleep(300)
+  await measureVoiceStateFanout(clients, voiceChannel)
+
+  for (const client of clients) {
+    wsSend(client.ws, 'LeaveVoice', null)
+    client.ws.close()
+  }
+
+  console.log('[load:realtime] OK')
+}
+
+main().catch((err) => {
+  console.error('[load:realtime] FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,6 +80,7 @@ npm run test:e2e
 npm run smoke:e2e
 npm run chaos:reconnect
 npm run regression:multi-user
+npm run load:realtime
 npm run rate-limit:check
 ```
 

--- a/docs/PERFORMANCE_REVIEW.md
+++ b/docs/PERFORMANCE_REVIEW.md
@@ -1,0 +1,164 @@
+# Performance Review
+
+This document tracks performance risks for larger real-time Voxpery workloads. It is intentionally measurement-first: avoid speculative rewrites, capture likely bottlenecks, then turn confirmed issues into scoped follow-up work.
+
+## Current Scope
+
+Reviewed areas:
+
+- WebSocket fan-out and Redis Pub/Sub bridge.
+- Client reconnect behavior.
+- Voice state/control signaling.
+- Message list/search queries.
+- Attachment upload, hydration, and signed content serving.
+- Existing smoke, chaos, and multi-user regression scripts.
+
+Not reviewed yet:
+
+- Browser rendering performance with very large channel histories.
+- Multi-backend-pod load under a real reverse proxy.
+- LiveKit media-plane capacity; this review focuses on Voxpery signaling and app APIs.
+
+## Initial Findings
+
+### WebSocket Fan-Out
+
+Current behavior:
+
+- Each backend instance uses `tokio::broadcast` for process-local fan-out.
+- Redis Pub/Sub mirrors broadcast and targeted user events across instances.
+- Delivery is authorization-aware: server re-checks channel visibility, friendship/shared-server visibility, or server membership before sending events to a socket.
+
+Likely scaling risks:
+
+- Delivery-time permission checks can become expensive during high-volume channels because each connected socket may perform database checks for broadcast events.
+- Presence and profile updates call shared-server/friendship checks per recipient, which can become noisy in large servers or reconnect bursts.
+- Broadcast lag is logged, but there is no thresholded metric or load test that quantifies when lag starts.
+
+Recommended next step:
+
+- Add a lightweight WebSocket load script that creates many authenticated sockets, subscribes them to channels, sends message bursts, and records delivery latency plus broadcast lag warnings.
+
+### Reconnect Storms
+
+Current behavior:
+
+- The web client uses exponential backoff with jitter.
+- The backend rate-limits WebSocket connection attempts per user.
+- `chaos:reconnect` verifies a two-user reconnect and voice state recovery path.
+
+Likely scaling risks:
+
+- Existing reconnect coverage is correctness-oriented, not load-oriented.
+- There is no script that simulates many users reconnecting after a deploy, proxy restart, or network flap.
+
+Recommended next step:
+
+- Extend reconnect testing with a configurable socket count and reconnect burst profile before changing backoff behavior.
+
+### Voice State And Signaling
+
+Current behavior:
+
+- LiveKit handles the media plane.
+- Voxpery tracks voice session/control state in memory for signaling/UI state.
+- Sticky WebSocket routing is still recommended for multi-instance voice until this state is externalized.
+- Joining voice iterates current `voice_sessions` to send existing occupants to the joining user.
+
+Likely scaling risks:
+
+- Voice state iteration is fine for small/medium rooms, but should be measured for larger rooms.
+- Multi-instance voice state remains a known constraint because `voice_sessions` and `voice_controls` are process-local.
+
+Recommended next step:
+
+- Measure join latency for larger voice rooms before externalizing voice state. Keep LiveKit capacity analysis as a separate operations task.
+
+### Messages And Search
+
+Current behavior:
+
+- Message pagination uses `(channel_id, created_at DESC)` indexes.
+- Message fetching avoids N+1 author lookups with joins.
+- Reactions are hydrated in batches.
+- Search uses `ILIKE '%term%'`, rate-limited per user/channel.
+
+Likely scaling risks:
+
+- Search will not scale well for large channels without full-text indexing.
+- Attachment hydration currently resolves attachment records per message attachment payload, which is acceptable for small pages but should be measured for attachment-heavy rooms.
+
+Recommended next step:
+
+- Add query-plan checks for high-row channels before introducing full-text search or attachment hydration batching.
+
+### Attachments
+
+Current behavior:
+
+- Uploads are rate-limited.
+- Image metadata stripping is moved to `spawn_blocking`.
+- Local content serving reads the full attachment into memory before responding.
+- Signed attachment ACL checks include JSONB containment lookups against message attachment arrays.
+
+Likely scaling risks:
+
+- Large concurrent downloads can increase memory pressure because files are read into memory.
+- JSONB containment checks may need indexing or a normalized attachment-message join table if attachment-heavy rooms become common.
+
+Recommended next step:
+
+- Measure concurrent signed content downloads and attachment-heavy message reads before changing storage layout.
+
+## Existing Coverage
+
+Available scripts:
+
+- `npm run smoke:e2e`
+- `npm run chaos:reconnect`
+- `npm run regression:multi-user`
+- `npm run load:realtime`
+- `npm run rate-limit:check`
+
+`load:realtime` is the first lightweight measurement script. It records message delivery latency, post-reconnect ping latency, and voice-state fan-out latency against a running backend.
+
+Remaining coverage gap:
+
+- Existing scripts still do not record throughput over long soak windows, server-side memory pressure, Redis Pub/Sub lag, or database query plans under seeded large channels.
+
+## Local Baseline
+
+Baseline run:
+
+- Date: 2026-05-09
+- Command: `npm run load:realtime`
+- Target API: `http://127.0.0.1:3001`
+- Users: 5
+- Messages: 12
+- Reconnect users: 3
+
+Results:
+
+- Message delivery latency: count `60`, p50 `17ms`, p95 `27ms`, max `28ms`
+- Post-reconnect ping latency: count `3`, p50 `3ms`, p95 `11ms`, max `11ms`
+- Reconnect burst: `3` users, elapsed `511ms`
+- Voice state fan-out latency: count `25`, p50 `6ms`, p95 `8ms`, max `9ms`
+
+Outcome:
+
+- No immediate realtime performance blocker was found in this local baseline.
+- Keep the default synthetic user count at `5` because the backend intentionally allows a maximum of five registrations per IP per hour.
+
+## Recommended Follow-Up Order
+
+1. Capture baseline p50/p95 event delivery latency and server broadcast lag warnings on a local dev stack with `npm run load:realtime`.
+2. Run `EXPLAIN ANALYZE` for message list, message search, and attachment ACL queries against seeded larger channels.
+3. Decide whether delivery-time permission checks need short-lived caching after measurements.
+4. Decide whether attachment serving should stream files instead of reading full files into memory after download concurrency measurements.
+5. Add longer soak/load coverage only after the lightweight script exposes useful baseline numbers.
+
+## Current Recommendation
+
+No immediate production blocker was found in the static review. The code already has useful safety rails: WebSocket rate limits, reconnect jitter, indexed message pagination, Redis Pub/Sub fan-out, and release smoke/regression scripts.
+
+The highest-value next implementation after this baseline is query-plan and attachment download measurement, not optimization. Promote confirmed bottlenecks into focused P1/P2 tasks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This folder is the source of truth for architecture, development, deployment, an
 - **[API.md](API.md)** - REST API endpoints and auth behavior
 - **[WEBSOCKET_EVENTS.md](WEBSOCKET_EVENTS.md)** - Realtime protocol and event contracts
 - **[VOICE_SYSTEM.md](VOICE_SYSTEM.md)** - LiveKit integration and voice pipeline
+- **[PERFORMANCE_REVIEW.md](PERFORMANCE_REVIEW.md)** - Realtime workload risks and measurement plan
 - **[DATABASE.md](DATABASE.md)** - Schema, migrations, and key queries
 - **[SECURITY.md](SECURITY.md)** - Security model and hardening checklist
 - **[../SECURITY.md](../SECURITY.md)** - Private vulnerability reporting policy


### PR DESCRIPTION
## Summary
- Added a realtime performance review document covering WebSocket fan-out, reconnect storms, voice state signaling, message/search queries, and attachment-heavy workloads.
- Added a lightweight `npm run load:realtime` smoke script for measuring WebSocket delivery latency, reconnect burst behavior, and voice-state fan-out.
- Documented the local baseline results and follow-up areas for query-plan and attachment download measurement.
- Updated development docs and docs index with the new performance review workflow.

## Testing
- `npm run load:realtime`
- `node --check scripts/realtime-load-smoke.mjs`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
