### PR TITLE
chore(desktop): bump release version to 0.1.8

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5307,7 +5307,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",


### PR DESCRIPTION
## Summary
- Bumps the Voxpery desktop/Tauri release version from `0.1.7` to `0.1.8`.
- Keeps `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock` release metadata in sync.

## Test Plan
- `cargo metadata --locked --no-deps`
