### PR TITLE
feat: enhance message search functionality with filters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ REDIS_URL=redis://redis:6379
 VITE_API_URL=http://localhost:3001
 PUBLIC_API_URL=http://localhost:3001
 ATTACHMENTS_PUBLIC_BASE_URL=http://localhost:3001
+ATTACHMENTS_MAX_FILE_BYTES=10485760
+ATTACHMENTS_ALLOWED_MIME_PREFIXES=image/,video/,audio/,application/pdf,text/plain,application/zip,application/x-zip-compressed,application/octet-stream
 
 LIVEKIT_WS_URL=ws://localhost:7880
 LIVEKIT_API_KEY=devkey

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -233,7 +233,7 @@ impl Config {
                 .trim_matches('/')
                 .to_string(),
             attachments_max_file_bytes: std::env::var("ATTACHMENTS_MAX_FILE_BYTES")
-                .unwrap_or_else(|_| "5242880".into())
+                .unwrap_or_else(|_| "10485760".into())
                 .parse()
                 .expect("ATTACHMENTS_MAX_FILE_BYTES must be a number"),
             attachments_max_files_per_request: std::env::var("ATTACHMENTS_MAX_FILES_PER_REQUEST")
@@ -244,7 +244,7 @@ impl Config {
                 "ATTACHMENTS_ALLOWED_MIME_PREFIXES",
             )
             .unwrap_or_else(|_| {
-                "image/,video/,audio/,application/pdf,text/plain,application/zip,application/octet-stream".into()
+                "image/,video/,audio/,application/pdf,text/plain,application/zip,application/x-zip-compressed,application/octet-stream".into()
             })
             .split(',')
             .map(|x| x.trim().to_string())

--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
             attachments_public_base_url: None,
             attachments_local_dir: "./storage/attachments".into(),
             attachments_key_prefix: "attachments".into(),
-            attachments_max_file_bytes: 5_242_880,
+            attachments_max_file_bytes: 10_485_760,
             attachments_max_files_per_request: 4,
             attachments_allowed_mime_prefixes: vec!["image/".into()],
             attachments_url_ttl_secs: 900,

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -42,8 +42,10 @@ pub struct DmReadState {
 
 #[derive(Debug, serde::Deserialize)]
 pub struct DmSearchQuery {
-    pub q: String,
+    pub q: Option<String>,
     pub limit: Option<i64>,
+    pub from: Option<String>,
+    pub has_attachment: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -615,13 +617,23 @@ async fn search_dm_messages(
 ) -> Result<Json<Vec<MessageWithAuthor>>, AppError> {
     check_dm_access(&state, channel_id, claims.sub).await?;
 
-    let term = query.q.trim();
-    if term.is_empty() {
+    let term = query.q.as_deref().unwrap_or("").trim();
+    let author = query.from.as_deref().unwrap_or("").trim().trim_start_matches('@');
+    let has_attachment = query.has_attachment.unwrap_or(false);
+    if term.is_empty() && author.is_empty() && !has_attachment {
         return Ok(Json(vec![]));
     }
     let limit = query.limit.unwrap_or(100).min(200);
-    let escaped_term = escape_ilike_pattern(term);
-    let pattern = format!("%{}%", escaped_term);
+    let pattern = if term.is_empty() {
+        String::new()
+    } else {
+        format!("%{}%", escape_ilike_pattern(term))
+    };
+    let author_pattern = if author.is_empty() {
+        None
+    } else {
+        Some(format!("%{}%", escape_ilike_pattern(author)))
+    };
 
     let rows = sqlx::query_as::<_, DmMessageRow>(
         r#"SELECT m.id, m.channel_id, m.content, m.attachments, m.edited_at, m.created_at,
@@ -629,12 +641,22 @@ async fn search_dm_messages(
            FROM dm_messages m
            INNER JOIN users u ON m.user_id = u.id
            WHERE m.channel_id = $1
-                         AND m.content ILIKE $2 ESCAPE '\'
+             AND ($2 = '' OR m.content ILIKE $2 ESCAPE '\')
+             AND ($3::TEXT IS NULL OR u.username ILIKE $3 ESCAPE '\')
+             AND (
+                 NOT $4
+                 OR (
+                     jsonb_typeof(m.attachments) = 'array'
+                     AND jsonb_array_length(m.attachments) > 0
+                 )
+             )
            ORDER BY m.created_at DESC
-           LIMIT $3"#,
+           LIMIT $5"#,
     )
     .bind(channel_id)
-    .bind(pattern)
+    .bind(&pattern)
+    .bind(&author_pattern)
+    .bind(has_attachment)
     .bind(limit)
     .fetch_all(&state.db)
     .await?;

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -156,6 +156,8 @@ fn audit_content_preview(content: &str) -> (String, bool) {
 struct MessageSearchQuery {
     q: Option<String>,
     limit: Option<i64>,
+    from: Option<String>,
+    has_attachment: Option<bool>,
 }
 
 /// Intermediate row type for JOIN query result
@@ -364,12 +366,22 @@ async fn search_messages(
     .await?;
 
     let term = query.q.as_deref().unwrap_or("").trim();
-    if term.is_empty() {
+    let author = query.from.as_deref().unwrap_or("").trim().trim_start_matches('@');
+    let has_attachment = query.has_attachment.unwrap_or(false);
+    if term.is_empty() && author.is_empty() && !has_attachment {
         return Ok(Json(vec![]));
     }
     let limit = query.limit.unwrap_or(100).min(200);
-    let escaped_term = escape_ilike_pattern(term);
-    let pattern = format!("%{}%", escaped_term);
+    let pattern = if term.is_empty() {
+        String::new()
+    } else {
+        format!("%{}%", escape_ilike_pattern(term))
+    };
+    let author_pattern = if author.is_empty() {
+        None
+    } else {
+        Some(format!("%{}%", escape_ilike_pattern(author)))
+    };
 
     let rows = sqlx::query_as::<_, MessageRow>(
         r#"SELECT m.id, m.channel_id, m.content, m.attachments, m.edited_at, m.created_at,
@@ -388,12 +400,22 @@ async fn search_messages(
            FROM messages m
            INNER JOIN users u ON m.user_id = u.id
            WHERE m.channel_id = $1
-             AND m.content ILIKE $2 ESCAPE '\'
+             AND ($2 = '' OR m.content ILIKE $2 ESCAPE '\')
+             AND ($3::TEXT IS NULL OR u.username ILIKE $3 ESCAPE '\')
+             AND (
+                 NOT $4
+                 OR (
+                     jsonb_typeof(m.attachments) = 'array'
+                     AND jsonb_array_length(m.attachments) > 0
+                 )
+             )
            ORDER BY m.created_at DESC
-           LIMIT $3"#,
+           LIMIT $5"#,
     )
     .bind(channel_id)
     .bind(&pattern)
+    .bind(&author_pattern)
+    .bind(has_attachment)
     .bind(limit)
     .fetch_all(&state.db)
     .await?;

--- a/apps/server/src/services/attachments.rs
+++ b/apps/server/src/services/attachments.rs
@@ -146,6 +146,7 @@ impl AttachmentService {
                 "application/pdf".to_string(),
                 "text/plain".to_string(),
                 "application/zip".to_string(),
+                "application/x-zip-compressed".to_string(),
                 "application/octet-stream".to_string(),
             ],
             ClamAvConfig {
@@ -960,6 +961,23 @@ mod tests {
     fn sanitizes_filename() {
         assert_eq!(sanitize_file_name("my image?.png"), "my_image_.png");
         assert_eq!(sanitize_file_name(""), "file.bin");
+    }
+
+    #[tokio::test]
+    async fn upload_meta_allows_windows_zip_mime_but_rejects_executables() {
+        let test_root = std::env::temp_dir().join(format!("voxpery-att-test-{}", Uuid::new_v4()));
+        let service = AttachmentService::new_local_for_tests(test_root.clone())
+            .await
+            .expect("service");
+
+        assert!(service
+            .validate_upload_file_meta("application/x-zip-compressed", 1024)
+            .is_ok());
+        assert!(service
+            .validate_upload_file_meta("application/x-msdownload", 1024)
+            .is_err());
+
+        fs::remove_dir_all(test_root).await.expect("cleanup");
     }
 
     #[tokio::test]

--- a/apps/web/src/api/dm.ts
+++ b/apps/web/src/api/dm.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from './client'
 import type { AuthToken, DmChannel, DmReadState, MessageWithAuthor } from './contracts'
+import { buildMessageSearchQuery } from '../searchFilters'
 
 export const dmApi = {
     listChannels: (token: AuthToken) =>
@@ -19,7 +20,7 @@ export const dmApi = {
 
     searchMessages: (channelId: string, q: string, token: AuthToken, limit = 100) =>
         apiFetch<MessageWithAuthor[]>(
-            `/api/dm/messages/${channelId}/search?q=${encodeURIComponent(q)}&limit=${limit}`,
+            `/api/dm/messages/${channelId}/search?${buildMessageSearchQuery(q, limit)}`,
             { token },
         ),
 

--- a/apps/web/src/api/messages.ts
+++ b/apps/web/src/api/messages.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from './client'
 import type { AuthToken, MessageWithAuthor } from './contracts'
+import { buildMessageSearchQuery } from '../searchFilters'
 
 export const messageApi = {
     list: (channelId: string, token: AuthToken, before?: string, limit = 50) =>
@@ -10,7 +11,7 @@ export const messageApi = {
 
     search: (channelId: string, q: string, token: AuthToken, limit = 100) =>
         apiFetch<MessageWithAuthor[]>(
-            `/api/messages/${channelId}/search?q=${encodeURIComponent(q)}&limit=${limit}`,
+            `/api/messages/${channelId}/search?${buildMessageSearchQuery(q, limit)}`,
             { token },
         ),
 

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -262,6 +262,23 @@ export default function ChatArea({
     const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
     const searchInputRef = useRef<HTMLInputElement | null>(null)
     const searchDropdownRef = useRef<HTMLDivElement | null>(null)
+    const searchHelpRef = useRef<HTMLDetailsElement | null>(null)
+    const applySearchFilter = useCallback((token: 'from:' | 'has:attachment') => {
+        const parts = searchQuery.trim().split(/\s+/).filter(Boolean)
+        const nextParts = parts.filter((part) => {
+            const normalized = part.toLowerCase()
+            if (token === 'from:') return !normalized.startsWith('from:')
+            return normalized !== 'has:attachment' && normalized !== 'has:attachments'
+        })
+        nextParts.push(token)
+        const nextQuery = nextParts.join(' ')
+        onSearchChange?.(nextQuery)
+        if (searchHelpRef.current) searchHelpRef.current.open = false
+        requestAnimationFrame(() => {
+            searchInputRef.current?.focus()
+            searchInputRef.current?.setSelectionRange(nextQuery.length, nextQuery.length)
+        })
+    }, [onSearchChange, searchQuery])
     const [mentionOpen, setMentionOpen] = useState(false)
     const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(null)
     const [mentionQuery, setMentionQuery] = useState('')
@@ -710,6 +727,7 @@ export default function ChatArea({
             if (!isFindShortcut) return
             if (target && searchDropdownRef.current?.contains(target)) return
             e.preventDefault()
+            setPinnedOpen(false)
             setSearchOpen(true)
             requestAnimationFrame(() => searchInputRef.current?.focus())
         }
@@ -1077,6 +1095,7 @@ export default function ChatArea({
                                     className="chat-header-search-trigger"
                                     onClick={(e) => {
                                         e.stopPropagation()
+                                        setPinnedOpen(false)
                                         setSearchOpen(true)
                                         setTimeout(() => searchInputRef.current?.focus(), 0)
                                     }}
@@ -1090,13 +1109,33 @@ export default function ChatArea({
                                     <Search size={16} className="chat-header-search-icon" aria-hidden />
                                     <input
                                         ref={searchInputRef}
-                                        type="search"
+                                        type="text"
                                         className="chat-header-search-input"
-                                        placeholder="Search in conversation"
+                                        placeholder="Search messages"
                                         value={searchQuery}
                                         onChange={(e) => onSearchChange(e.target.value)}
+                                        title="Search text. Filters: from:username, has:attachment"
                                         aria-label="Search messages"
                                     />
+                                    <details ref={searchHelpRef} className="chat-header-search-help">
+                                        <summary>Filters</summary>
+                                        <div className="chat-header-search-help-panel" role="note">
+                                            <button
+                                                type="button"
+                                                onClick={() => applySearchFilter('from:')}
+                                                title="Add author filter"
+                                            >
+                                                from:
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => applySearchFilter('has:attachment')}
+                                                title="Only show messages with attachments"
+                                            >
+                                                has:attachment
+                                            </button>
+                                        </div>
+                                    </details>
                                     <button
                                         type="button"
                                         className="chat-header-search-close"
@@ -1119,7 +1158,13 @@ export default function ChatArea({
                         <button
                             type="button"
                             className="chat-header-pinned-btn"
-                            onClick={() => setPinnedOpen((o) => !o)}
+                            onClick={() => {
+                                if (!pinnedOpen) {
+                                    onSearchChange?.('')
+                                    setSearchOpen(false)
+                                }
+                                setPinnedOpen((o) => !o)
+                            }}
                             title="Pinned messages"
                             aria-label="Pinned messages"
                             aria-expanded={pinnedOpen}
@@ -1128,9 +1173,17 @@ export default function ChatArea({
                         </button>
                         {pinnedOpen && (
                             <div className="chat-header-pinned-dropdown">
-                                <div className="chat-header-pinned-title">Pinned messages</div>
+                                <div className="chat-header-pinned-title">
+                                    <span className="chat-header-pinned-title-main">
+                                        <Pin size={14} aria-hidden />
+                                        Pinned messages
+                                    </span>
+                                    <span className="chat-header-pinned-title-count">
+                                        {pinnedMessages.length}
+                                    </span>
+                                </div>
                                 {pinnedMessages.length === 0 ? (
-                                    <div className="chat-header-pinned-empty">No pinned messages</div>
+                                    <div className="chat-header-pinned-empty">No pinned messages yet</div>
                                 ) : (
                                     <ul className="chat-header-pinned-list">
                                         {pinnedMessages.map((m) => (
@@ -1269,7 +1322,7 @@ export default function ChatArea({
                                     key={msg.id}
                                     data-index={virtualRow.index}
                                     ref={rowVirtualizer.measureElement}
-                                    className="virtual-list-item"
+                                    className={`virtual-list-item ${virtualRow.index === 0 ? 'virtual-list-item-first' : ''}`}
                                     style={{ transform: `translateY(${virtualRow.start}px)` }}
                                 >
                                     {showDayDivider && (
@@ -1478,11 +1531,17 @@ export default function ChatArea({
                 {draftAttachments.length > 0 && (
                     <div className="dm-draft-attachments">
                         {draftAttachments.map((att, i) => (
-                            <div key={`${att.name}-${i}`} className="dm-draft-attachment">
+                            <div
+                                key={`${att.name}-${i}`}
+                                className={`dm-draft-attachment is-${att.uploadStatus}`}
+                            >
                                 <div className="dm-draft-attachment-meta">
-                                    <span>{att.name}</span>
+                                    <span title={att.name}>{att.name}</span>
                                     {att.uploadStatus === 'uploading' && (
                                         <span className="dm-draft-attachment-state">Uploading...</span>
+                                    )}
+                                    {att.uploadStatus === 'uploaded' && (
+                                        <span className="dm-draft-attachment-state is-uploaded">Ready to send</span>
                                     )}
                                     {att.uploadStatus === 'failed' && (
                                         <span className="dm-draft-attachment-state is-failed">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3862,6 +3862,7 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
+  position: relative;
 }
 
 .chat-header-search-expanded {
@@ -3913,6 +3914,90 @@ body {
   border-color: var(--accent);
 }
 
+.chat-header-search-help {
+  flex-shrink: 0;
+  position: relative;
+}
+
+.chat-header-search-help summary {
+  display: flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid rgba(79, 127, 216, 0.5);
+  border-radius: 7px;
+  background: rgba(79, 127, 216, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  list-style: none;
+  user-select: none;
+}
+
+.chat-header-search-help summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-header-search-help[open] summary,
+.chat-header-search-help summary:hover {
+  border-color: var(--accent-primary-hover);
+  background: rgba(79, 127, 216, 0.2);
+  color: var(--text);
+}
+
+.chat-header-search-help-panel {
+  position: absolute;
+  top: calc(100% + 14px);
+  right: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(280px, calc(100vw - 48px));
+  padding: 8px;
+  border: var(--border-subtle);
+  border-radius: 10px;
+  background: rgba(18, 29, 55, 0.98);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.34);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.chat-header-search-help-panel::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  right: 18px;
+  width: 9px;
+  height: 9px;
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(18, 29, 55, 0.98);
+  transform: rotate(45deg);
+}
+
+.chat-header-search-help-panel button {
+  position: relative;
+  z-index: 1;
+  padding: 4px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: rgba(13, 27, 42, 0.9);
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.chat-header-search-help-panel button:hover {
+  border-color: var(--accent-primary);
+  background: rgba(79, 127, 216, 0.16);
+}
+
 .chat-header-search-close {
   display: flex;
   align-items: center;
@@ -3958,6 +4043,12 @@ body {
   color: var(--text);
 }
 
+.chat-header-pinned-btn[aria-expanded='true'] {
+  border: 1px solid rgba(79, 127, 216, 0.5);
+  background: rgba(79, 127, 216, 0.12);
+  color: var(--text);
+}
+
 .chat-header-member-btn {
   display: flex;
   align-items: center;
@@ -3987,67 +4078,101 @@ body {
 .chat-header-pinned-dropdown {
   position: absolute;
   top: 100%;
-  right: -8px;
-  margin-top: 14px;
-  min-width: 300px;
-  max-width: 420px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-  box-shadow: var(--shadow-md);
+  right: 0;
+  margin-top: 10px;
+  width: min(340px, calc(100vw - 32px));
+  background: rgba(18, 29, 55, 0.98);
+  border: var(--border-subtle);
+  border-radius: 14px;
+  box-shadow: 0 22px 44px rgba(0, 0, 0, 0.36);
   z-index: 100;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
+.chat-header-pinned-dropdown::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  right: 13px;
+  width: 9px;
+  height: 9px;
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(18, 29, 55, 0.98);
+  transform: rotate(45deg);
+}
+
 .chat-header-pinned-title {
-  padding: 12px 14px;
-  font-size: 11px;
-  font-weight: 600;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  font-size: 12px;
+  font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text);
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.chat-header-pinned-title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-header-pinned-title-main svg {
+  color: var(--accent-primary-hover);
+}
+
+.chat-header-pinned-title-count {
+  min-width: 22px;
+  padding: 2px 7px;
+  border: 1px solid rgba(79, 127, 216, 0.35);
+  border-radius: 999px;
+  background: rgba(79, 127, 216, 0.12);
+  color: var(--text);
+  font-size: 11px;
+  text-align: center;
+}
+
 .chat-header-pinned-empty {
-  padding: 20px 14px;
-  font-size: 14px;
+  padding: 22px 16px;
+  font-size: 13px;
   color: var(--text-muted);
+  text-align: center;
 }
 
 .chat-header-pinned-list {
   list-style: none;
   margin: 0;
-  padding: 6px 0;
-  max-height: 280px;
+  padding: 10px;
+  max-height: 238px;
   overflow-y: auto;
   flex-shrink: 0;
+  display: grid;
+  gap: 8px;
 }
 
 .chat-header-pinned-item {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: transparent;
-  border-radius: 6px;
-  margin: 0 6px;
-  transition: background 0.15s ease;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(13, 27, 42, 0.52);
+  border-radius: 10px;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
 }
 
 .chat-header-pinned-item:hover {
-  background: var(--bg-surface-hover);
-}
-
-.chat-header-pinned-item:active {
-  background: var(--bg-surface-hover);
-}
-
-.chat-header-pinned-item:last-child {
-  border-bottom: none;
+  border-color: rgba(79, 127, 216, 0.38);
+  background: rgba(79, 127, 216, 0.1);
+  transform: translateY(-1px);
 }
 
 .chat-header-pinned-item-meta {
@@ -4096,9 +4221,11 @@ body {
 }
 
 .chat-header-pinned-item-content-wrap {
-  border-left: 3px solid rgba(255, 255, 255, 0.12);
-  padding-left: 10px;
-  margin-left: 2px;
+  padding: 9px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-left: 3px solid rgba(79, 127, 216, 0.5);
+  border-radius: 8px;
+  background: rgba(3, 9, 20, 0.22);
 }
 
 .chat-header-pinned-item-content-label {
@@ -4114,26 +4241,28 @@ body {
 .chat-header-pinned-item-actions {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 4px;
   flex-shrink: 0;
 }
 
-.chat-header-pinned-goto {
+.chat-header-pinned-goto,
+.chat-header-pinned-unpin {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 32px;
   height: 32px;
   padding: 0;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
   color: var(--text-muted);
   cursor: pointer;
 }
 
 .chat-header-pinned-goto:hover {
-  background: var(--bg-surface-hover);
+  border-color: rgba(79, 127, 216, 0.45);
+  background: rgba(79, 127, 216, 0.14);
   color: var(--text);
 }
 
@@ -4151,29 +4280,16 @@ body {
   overflow: hidden;
 }
 
-.chat-header-pinned-unpin {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-}
-
 .chat-header-pinned-unpin:hover {
-  background: var(--bg-hover);
+  border-color: rgba(255, 125, 125, 0.4);
+  background: rgba(255, 125, 125, 0.12);
   color: var(--text);
 }
 
 .chat-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 0 4px;
+  padding: 10px 0 4px;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -4205,6 +4321,11 @@ body {
   min-width: 0;
   padding-bottom: 1px;
   box-sizing: border-box;
+}
+
+.virtual-list-item-first .message-day-divider {
+  margin-top: 0;
+  margin-bottom: 10px;
 }
 
 .message-day-divider {
@@ -7994,27 +8115,44 @@ a.community-open-btn:hover {
 }
 
 .dm-draft-attachments {
-  margin-bottom: 8px;
+  margin: 0 8px 8px;
   display: flex;
   flex-wrap: nowrap;
-  gap: 6px;
+  gap: 8px;
   overflow-x: auto;
   overflow-y: hidden;
-  padding-bottom: 2px;
+  padding: 0 0 2px;
 }
 
 .dm-draft-attachment {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  border: var(--border-subtle);
-  border-radius: var(--border-radius-sm);
-  padding: 4px 6px;
+  gap: 8px;
+  min-height: 38px;
+  border: 1px solid rgba(124, 171, 255, 0.18);
+  border-radius: 8px;
+  padding: 7px 8px 7px 10px;
   font-size: 12px;
   color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(15, 29, 52, 0.84);
   flex: 0 0 auto;
-  max-width: min(280px, 72vw);
+  max-width: min(340px, 78vw);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
+}
+
+.dm-draft-attachment.is-uploaded {
+  border-color: rgba(82, 196, 142, 0.34);
+  background: rgba(11, 45, 35, 0.72);
+}
+
+.dm-draft-attachment.is-uploading {
+  border-color: rgba(124, 171, 255, 0.3);
+}
+
+.dm-draft-attachment.is-failed {
+  border-color: rgba(255, 111, 111, 0.48);
+  background: rgba(58, 18, 31, 0.78);
+  color: #ffd8df;
 }
 
 .dm-draft-attachment-meta {
@@ -8031,27 +8169,53 @@ a.community-open-btn:hover {
 }
 
 .dm-draft-attachment-state {
+  width: fit-content;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
   font-size: 11px;
   color: var(--text-muted);
 }
 
+.dm-draft-attachment-state.is-uploaded {
+  background: rgba(82, 196, 142, 0.14);
+  color: #9be7bd;
+}
+
 .dm-draft-attachment-state.is-failed {
-  color: var(--danger);
+  background: rgba(255, 111, 111, 0.16);
+  color: #ffb8c2;
 }
 
 .dm-draft-attachment-retry {
   appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--accent-primary);
+  border: 1px solid rgba(255, 184, 194, 0.28);
+  border-radius: 999px;
+  background: rgba(255, 111, 111, 0.12);
+  color: #ffd8df;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  padding: 0;
+  padding: 4px 8px;
 }
 
 .dm-draft-attachment-retry:hover {
-  color: var(--accent-primary-hover);
+  border-color: rgba(255, 184, 194, 0.5);
+  background: rgba(255, 111, 111, 0.2);
+}
+
+.dm-draft-attachment .dm-msg-btn {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.dm-draft-attachment.is-failed .dm-msg-btn {
+  border-color: rgba(255, 184, 194, 0.22);
+  color: #ffd8df;
 }
 
 /* Left-bottom panel: User bar only (callbar moved to chat overlay) */

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -1493,7 +1493,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             setDraftAttachments((prev) => applyUploadedDraftAttachments(prev, pendingIds, uploaded))
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : 'Could not upload attachment(s).'
-            setDraftAttachments((prev) => markDraftAttachmentsFailed(prev, pendingIds, errorMessage))
+            setDraftAttachments((prev) => markDraftAttachmentsFailed(prev, pendingIds, 'Upload failed'))
             pushToast({
                 level: 'error',
                 title: 'Upload failed',
@@ -2028,14 +2028,14 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             setDraftAttachments((prev) => applyUploadedDraftAttachments(prev, [localId], [uploaded]))
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : 'Could not upload attachment(s).'
-            setDraftAttachments((prev) => markDraftAttachmentsFailed(prev, [localId], errorMessage))
+            setDraftAttachments((prev) => markDraftAttachmentsFailed(prev, [localId], 'Upload failed'))
             pushToast({
                 level: 'error',
                 title: 'Upload failed',
                 message: errorMessage,
             })
         }
-    }, [draftAttachments, pushToast, token])
+    }, [draftAttachments, token, pushToast])
 
     const handleServerSettingsProfileRender = useCallback(
         (

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -784,7 +784,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setDmDraftAttachments((prev) => applyUploadedDraftAttachments(prev, pendingIds, uploaded))
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Could not upload attachment(s).'
-      setDmDraftAttachments((prev) => markDraftAttachmentsFailed(prev, pendingIds, errorMessage))
+      setDmDraftAttachments((prev) => markDraftAttachmentsFailed(prev, pendingIds, 'Upload failed'))
       pushToast({
         level: 'error',
         title: 'Upload failed',
@@ -803,14 +803,14 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setDmDraftAttachments((prev) => applyUploadedDraftAttachments(prev, [localId], [uploaded]))
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Could not upload attachment(s).'
-      setDmDraftAttachments((prev) => markDraftAttachmentsFailed(prev, [localId], errorMessage))
+      setDmDraftAttachments((prev) => markDraftAttachmentsFailed(prev, [localId], 'Upload failed'))
       pushToast({
         level: 'error',
         title: 'Upload failed',
         message: errorMessage,
       })
     }
-  }, [dmDraftAttachments, pushToast, token])
+  }, [dmDraftAttachments, token, pushToast])
 
   const handleSendDm = async (_e?: FormEvent, forceContent?: string) => {
     if (!user || !activeDmChannelId) return

--- a/apps/web/src/searchFilters.test.ts
+++ b/apps/web/src/searchFilters.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { buildMessageSearchQuery, parseMessageSearchInput } from './searchFilters'
+
+describe('message search filters', () => {
+    it('keeps plain text searches unchanged', () => {
+        expect(parseMessageSearchInput('hello world')).toEqual({
+            text: 'hello world',
+            from: undefined,
+            hasAttachment: false,
+        })
+    })
+
+    it('extracts author and attachment filters', () => {
+        expect(parseMessageSearchInput('from:@alice has:attachment release notes')).toEqual({
+            text: 'release notes',
+            from: 'alice',
+            hasAttachment: true,
+        })
+    })
+
+    it('ignores incomplete author filter tokens while typing', () => {
+        expect(parseMessageSearchInput('from:')).toEqual({
+            text: '',
+            from: undefined,
+            hasAttachment: false,
+        })
+    })
+
+    it('builds URL query parameters for filters', () => {
+        expect(buildMessageSearchQuery('from:bob has:attachments', 25)).toBe(
+            'q=&limit=25&from=bob&has_attachment=true',
+        )
+    })
+})

--- a/apps/web/src/searchFilters.ts
+++ b/apps/web/src/searchFilters.ts
@@ -1,0 +1,44 @@
+export interface MessageSearchFilters {
+    text: string
+    from?: string
+    hasAttachment: boolean
+}
+
+export function parseMessageSearchInput(input: string): MessageSearchFilters {
+    const tokens = input.trim().split(/\s+/).filter(Boolean)
+    const textParts: string[] = []
+    let from: string | undefined
+    let hasAttachment = false
+
+    for (const token of tokens) {
+        const lower = token.toLowerCase()
+        if (lower === 'has:attachment' || lower === 'has:attachments') {
+            hasAttachment = true
+            continue
+        }
+        if (lower === 'from:') {
+            continue
+        }
+        if (lower.startsWith('from:') && token.length > 'from:'.length) {
+            from = token.slice('from:'.length).replace(/^@/, '').trim()
+            continue
+        }
+        textParts.push(token)
+    }
+
+    return {
+        text: textParts.join(' '),
+        from: from || undefined,
+        hasAttachment,
+    }
+}
+
+export function buildMessageSearchQuery(input: string, limit = 100): string {
+    const filters = parseMessageSearchInput(input)
+    const params = new URLSearchParams()
+    params.set('q', filters.text)
+    params.set('limit', String(limit))
+    if (filters.from) params.set('from', filters.from)
+    if (filters.hasAttachment) params.set('has_attachment', 'true')
+    return params.toString()
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -136,6 +136,8 @@ Notes:
 
 - `POST /api/attachments/upload` (auth required)
   - `multipart/form-data` with one or more `files` fields.
+  - Default per-file limit is 10 MB (`ATTACHMENTS_MAX_FILE_BYTES=10485760`).
+  - Default MIME allowlist includes ZIP uploads from common browsers/Windows (`application/zip`, `application/x-zip-compressed`) but not executable installers.
   - Returns uploaded attachment objects with `id`, signed `url`, `type`, `name`, `size`, `sha256`.
   - Upload pipeline: MIME/size validation -> optional ClamAV scan -> local storage -> metadata insert -> short-lived signed URL.
 - `GET /api/attachments/content/:attachment_id?exp=...&sig=...`
@@ -145,7 +147,9 @@ Notes:
 ## Message Endpoints (Server Channels)
 
 - `GET /api/messages/:channel_id?before=<uuid>&limit=<n>`
-- `GET /api/messages/:channel_id/search?q=<term>&limit=<n>`
+- `GET /api/messages/:channel_id/search?q=<term>&from=<username>&has_attachment=<bool>&limit=<n>`
+  - `from` filters by message author username.
+  - `has_attachment=true` returns only messages with one or more attachments.
 - `POST /api/messages/:channel_id` (requires `SEND_MESSAGES`)
 - `PATCH /api/messages/item/:message_id` (author only)
 - `DELETE /api/messages/item/:message_id` (author or `MANAGE_MESSAGES`)
@@ -176,7 +180,9 @@ Notes:
 - `GET /api/dm/channels`
 - `POST /api/dm/channels/:peer_id`
 - `GET /api/dm/messages/:channel_id?before=<uuid>&limit=<n>`
-- `GET /api/dm/messages/:channel_id/search?q=<term>&limit=<n>`
+- `GET /api/dm/messages/:channel_id/search?q=<term>&from=<username>&has_attachment=<bool>&limit=<n>`
+  - `from` filters by message author username.
+  - `has_attachment=true` returns only messages with one or more attachments.
 - `POST /api/dm/messages/:channel_id`
 - `PATCH /api/dm/messages/item/:message_id`
 - `DELETE /api/dm/messages/item/:message_id`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -195,9 +195,9 @@ let query = format!("SELECT * FROM users WHERE username = '{}'", username); // S
 
 - **Upload endpoint**: `POST /api/attachments/upload` (`multipart/form-data`, auth required)
 - **Validation**:
-  - per-file size limit (`ATTACHMENTS_MAX_FILE_BYTES`)
+  - per-file size limit (`ATTACHMENTS_MAX_FILE_BYTES`, default 10 MB)
   - per-request file count limit (`ATTACHMENTS_MAX_FILES_PER_REQUEST`)
-  - MIME allowlist (`ATTACHMENTS_ALLOWED_MIME_PREFIXES`)
+  - MIME allowlist (`ATTACHMENTS_ALLOWED_MIME_PREFIXES`; ZIP includes `application/zip` and `application/x-zip-compressed`)
 - **Malware scan**:
   - Optional ClamAV (`ATTACHMENTS_CLAMAV_ENABLED=1`)
   - `ATTACHMENTS_CLAMAV_FAIL_CLOSED=1` blocks uploads if scanner is unavailable


### PR DESCRIPTION
## Summary

- **Message search filters** — Added `from:username` and `has:attachment` filter support to the chat search bar. A "Filters" dropdown lets users apply filters with a single click.
- **Pinned messages UI polish** — Added pin count badge, improved empty state, and resolved search/pinned dropdown overlap conflicts.
- **Attachment draft chip states** — Visual feedback for uploading, uploaded ("Ready to send"), and failed ("Upload failed") states with retry/remove actions.
- **Upload error handling** — Failed uploads now show both a persistent failed chip at the bottom-left (for retry) and a toast at the top-right with the specific error message.

## New files

- `apps/web/src/searchFilters.ts` — search input parser and URL query builder
- `apps/web/src/searchFilters.test.ts` — unit tests for the parser

## Validation

- `npm run lint` — passed
- `npm run test:run` — 60 tests passed
- `npm run build` — passed

## Checklist

- [x] No secrets or private environment values in tracked files
- [x] English source, comments, and documentation
- [x] Frontend validation (`lint`, `test:run`, `build`) completed