### PR TITLE
feat: implement desktop media permission handling and recovery guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ dist/
 
 # IDE / Editor
 .rules/
+.codex/
+AGENTS.md
+graphify-out/
 .vscode/
 .idea/
 *.swp

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ use image::{
     imageops::{crop_imm, overlay, resize, FilterType},
     ImageReader, RgbaImage,
 };
+use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
 
@@ -239,6 +240,54 @@ fn desktop_update_unread_feedback(
     }
 }
 
+#[tauri::command]
+fn desktop_open_media_permission_settings(kind: String) -> Result<(), String> {
+    let target = match kind.as_str() {
+        "camera" => "camera",
+        _ => "microphone",
+    };
+
+    #[cfg(target_os = "windows")]
+    {
+        let uri = if target == "camera" {
+            "ms-settings:privacy-webcam"
+        } else {
+            "ms-settings:privacy-microphone"
+        };
+        Command::new("cmd")
+            .args(["/C", "start", "", uri])
+            .spawn()
+            .map_err(|err| format!("Failed to open Windows privacy settings: {err}"))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let uri = if target == "camera" {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        } else {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        };
+        Command::new("open")
+            .arg(uri)
+            .spawn()
+            .map_err(|err| format!("Failed to open macOS privacy settings: {err}"))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Err(format!(
+            "Open your desktop privacy settings manually and verify portal/PipeWire services are running for {target} access."
+        ))
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        Err("Opening media permission settings is not supported on this platform.".into())
+    }
+}
+
 fn main() {
     // Dev-only convenience: auto-allow media permissions on Windows WebView2.
     // Never enable in production builds.
@@ -253,7 +302,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             desktop_set_minimize_to_tray_on_close,
             desktop_prepare_for_update_install,
-            desktop_update_unread_feedback
+            desktop_update_unread_feedback,
+            desktop_open_media_permission_settings
         ]);
 
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -7,8 +7,12 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores/app'
 import { useAuthStore } from '../stores/auth'
 import { useToastStore } from '../stores/toast'
-import { isTauri } from '../secureStorage'
 import { applyPreferredAudioOutputDevice, buildPreferredMicrophoneConstraints, VOICE_SETTINGS_CHANGED_EVENT } from '../voiceDevices'
+import {
+  desktopMediaPermissionRecoveryMessage,
+  isMediaPermissionDeniedError,
+  openDesktopMediaPermissionSettings,
+} from '../desktopMediaPermissions'
 import { ROUTES } from '../routes'
 
 interface VoxperyTrack extends MediaStreamTrack {
@@ -95,26 +99,14 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     navigate(ROUTES.servers)
   }
   const pushToast = useToastStore((s) => s.pushToast)
-  const isLinuxDesktop = useMemo(
-    () => isTauri() && typeof navigator !== 'undefined' && /linux/i.test(navigator.userAgent),
-    []
-  )
   const mapMicPreflightError = useCallback((err: unknown): string | null => {
     const errName = err && typeof err === 'object' && 'name' in err ? String((err as { name?: unknown }).name) : ''
     const errMessage = err && typeof err === 'object' && 'message' in err
       ? String((err as { message?: unknown }).message).toLowerCase()
       : ''
 
-    const isPermissionError =
-      errName === 'NotAllowedError' ||
-      errMessage.includes('permission denied') ||
-      errMessage.includes('notallowederror') ||
-      errMessage.includes('microphone permission denied')
-
-    if (isPermissionError) {
-      return isLinuxDesktop
-        ? 'Permission was blocked. On Linux desktop, ensure xdg-desktop-portal (+ xdg-desktop-portal-gtk or xdg-desktop-portal-kde) and PipeWire are installed/running, then restart Voxpery.'
-        : 'Permission was blocked. Allow microphone/screen access in system or browser settings and try again.'
+    if (isMediaPermissionDeniedError(err, 'microphone')) {
+      return desktopMediaPermissionRecoveryMessage('microphone')
     }
     if (errName === 'NotFoundError' || errMessage.includes('device not found') || errMessage.includes('no microphone')) {
       return 'No microphone device detected. Connect a microphone and retry.'
@@ -126,23 +118,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       return 'Microphone capture is not available in this runtime. Update your desktop runtime or use the latest Voxpery desktop build.'
     }
     return null
-  }, [isLinuxDesktop])
+  }, [])
   const mapCameraError = useCallback((err: unknown): string | null => {
     const errName = err && typeof err === 'object' && 'name' in err ? String((err as { name?: unknown }).name) : ''
     const errMessage = err && typeof err === 'object' && 'message' in err
       ? String((err as { message?: unknown }).message).toLowerCase()
       : ''
 
-    const isPermissionError =
-      errName === 'NotAllowedError' ||
-      errMessage.includes('permission denied') ||
-      errMessage.includes('camera permission denied') ||
-      errMessage.includes('securityerror')
-
-    if (isPermissionError) {
-      return isLinuxDesktop
-        ? 'Permission was blocked. On Linux desktop, ensure xdg-desktop-portal (+ xdg-desktop-portal-gtk or xdg-desktop-portal-kde) and PipeWire are installed/running, then restart Voxpery.'
-        : 'Permission was blocked. Allow camera access in system or browser settings and try again.'
+    if (isMediaPermissionDeniedError(err, 'camera')) {
+      return desktopMediaPermissionRecoveryMessage('camera')
     }
     if (errName === 'NotFoundError' || errMessage.includes('no camera') || errMessage.includes('no camera device detected')) {
       return 'No camera device detected. Connect a camera and retry.'
@@ -154,7 +138,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       return 'Camera capture is not available in this runtime. Update your desktop runtime or use the latest Voxpery desktop build.'
     }
     return null
-  }, [isLinuxDesktop])
+  }, [])
   const [muted, setMuted] = useState(false)
   const [deafened, setDeafened] = useState(false)
   const localControl = user?.id ? voiceControls[user.id] : null
@@ -567,6 +551,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         micStream?.getTracks().forEach((t) => t.stop())
         const message = mapMicPreflightError(err)
         if (message) {
+          if (isMediaPermissionDeniedError(err, 'microphone')) {
+            void openDesktopMediaPermissionSettings('microphone')
+          }
           pushToast({ level: 'error', title: 'Microphone access required', message })
           return
         }
@@ -611,9 +598,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       message = "You don't have permission to connect to this voice channel."
     } else
     if (lower.includes('notallowederror') || lower.includes('permission denied') || lower.includes('permission')) {
-      message = isLinuxDesktop
-        ? 'Permission was blocked. On Linux desktop, ensure xdg-desktop-portal (+ xdg-desktop-portal-gtk or xdg-desktop-portal-kde) and PipeWire are installed/running, then restart Voxpery.'
-        : 'Permission was blocked. Allow microphone/screen access in system or browser settings and try again.'
+      message = desktopMediaPermissionRecoveryMessage('microphone')
     } else if (lower.includes('notfounderror') || lower.includes('device not found')) {
       message = 'No microphone device detected. Connect a microphone and retry.'
     } else if (lower.includes('websocket is not connected')) {
@@ -625,7 +610,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       title,
       message,
     })
-  }, [isLinuxDesktop, pushToast, state.lastError])
+  }, [pushToast, state.lastError])
 
   const toggleMute = () => {
     const stream = localStreamRef.current ?? state.localStream
@@ -656,6 +641,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       stream?.getTracks().forEach((t) => t.stop())
       const message = mapMicPreflightError(err)
       if (message) {
+        if (isMediaPermissionDeniedError(err, 'microphone')) {
+          void openDesktopMediaPermissionSettings('microphone')
+        }
         pushToast({ level: 'error', title: 'Microphone access required', message })
         return
       }
@@ -821,6 +809,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     try {
       await startCamera()
     } catch (e) {
+      if (isMediaPermissionDeniedError(e, 'camera')) {
+        void openDesktopMediaPermissionSettings('camera')
+      }
       const message = mapCameraError(e) ?? (e instanceof Error ? e.message : 'Could not access camera. Check permission.')
       pushToast({ level: 'error', title: 'Camera failed', message })
     }

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -43,6 +43,10 @@ import {
   setDesktopMinimizeToTrayOnClose,
 } from '../desktopSettings'
 import {
+  desktopMediaPermissionRecoveryMessage,
+  openDesktopMediaPermissionSettings,
+} from '../desktopMediaPermissions'
+import {
   getPushNotificationPermission,
   getPushNotificationsEnabled,
   requestPushNotificationPermission,
@@ -1145,6 +1149,10 @@ export default function UserBar() {
   const currentOutputDevice = outputDevices.find((device) => device.id === selectedOutputDeviceId) ?? DEFAULT_OUTPUT_DEVICE_OPTION
   const microphoneAccessAllowed = microphonePermissionState === 'granted'
   const microphoneAccessButtonLabel = microphonePermissionState === 'denied' ? 'Retry mic access' : 'Allow mic access'
+  const microphoneRecoveryMessage = microphonePermissionState === 'denied'
+    ? desktopMediaPermissionRecoveryMessage('microphone')
+    : 'Allow microphone access to unlock full voice controls.'
+  const showDesktopMicrophoneRecovery = isTauri() && microphonePermissionState === 'denied'
 
   const voiceDeviceMenu = openDeviceMenu && deviceMenuAnchor && typeof document !== 'undefined'
     ? createPortal(
@@ -1476,11 +1484,25 @@ export default function UserBar() {
                   <div className="voice-settings-block__title">Audio devices</div>
                   {!microphoneAccessAllowed && (
                     <div className="voice-settings-banner">
-                      <span>
-                        {microphonePermissionState === 'denied'
-                          ? 'Microphone access is blocked. Allow it to choose devices and run mic test.'
-                          : 'Allow microphone access to unlock full voice controls.'}
-                      </span>
+                      <span>{microphoneRecoveryMessage}</span>
+                      {showDesktopMicrophoneRecovery && (
+                        <button
+                          type="button"
+                          className="user-toggle account-action-btn"
+                          onClick={async () => {
+                            const opened = await openDesktopMediaPermissionSettings('microphone')
+                            if (!opened) {
+                              pushToast({
+                                level: 'info',
+                                title: 'Open privacy settings',
+                                message: microphoneRecoveryMessage,
+                              })
+                            }
+                          }}
+                        >
+                          Open settings
+                        </button>
+                      )}
                       <button
                         type="button"
                         className="user-toggle account-action-btn"

--- a/apps/web/src/desktopMediaPermissions.ts
+++ b/apps/web/src/desktopMediaPermissions.ts
@@ -1,0 +1,64 @@
+import { isTauri } from './secureStorage'
+
+export type MediaPermissionKind = 'microphone' | 'camera'
+
+function currentDesktopPlatform(): 'windows' | 'macos' | 'linux' | 'unknown' {
+  if (typeof navigator === 'undefined') return 'unknown'
+  const value = `${navigator.userAgent} ${navigator.platform}`.toLowerCase()
+  if (value.includes('windows') || value.includes('win32') || value.includes('win64')) return 'windows'
+  if (value.includes('macintosh') || value.includes('mac os') || value.includes('darwin')) return 'macos'
+  if (value.includes('linux')) return 'linux'
+  return 'unknown'
+}
+
+function mediaLabel(kind: MediaPermissionKind): string {
+  return kind === 'camera' ? 'camera' : 'microphone'
+}
+
+export function isMediaPermissionDeniedError(err: unknown, kind: MediaPermissionKind): boolean {
+  const errName = err && typeof err === 'object' && 'name' in err ? String((err as { name?: unknown }).name) : ''
+  const errMessage = err && typeof err === 'object' && 'message' in err
+    ? String((err as { message?: unknown }).message).toLowerCase()
+    : ''
+  const label = mediaLabel(kind)
+
+  return (
+    errName === 'NotAllowedError'
+    || errName === 'SecurityError'
+    || errMessage.includes('permission denied')
+    || errMessage.includes('notallowederror')
+    || errMessage.includes(`${label} permission denied`)
+    || (kind === 'camera' && errMessage.includes('securityerror'))
+  )
+}
+
+export function desktopMediaPermissionRecoveryMessage(kind: MediaPermissionKind): string {
+  const label = mediaLabel(kind)
+  if (!isTauri()) {
+    return `Permission was blocked. Allow ${label} access in your browser or system settings and try again.`
+  }
+
+  const platform = currentDesktopPlatform()
+  if (platform === 'windows') {
+    return `Permission was blocked. Open Windows Privacy & security settings, allow ${label} access for desktop apps, then return to Voxpery and retry.`
+  }
+  if (platform === 'macos') {
+    return `Permission was blocked. Open macOS Privacy & Security settings, allow Voxpery to use the ${label}, then restart Voxpery and retry.`
+  }
+  if (platform === 'linux') {
+    return `Permission was blocked. Ensure xdg-desktop-portal, a portal backend, and PipeWire are installed/running, then restart Voxpery and retry ${label} access.`
+  }
+
+  return `Permission was blocked. Allow ${label} access in system settings, restart Voxpery if needed, and try again.`
+}
+
+export async function openDesktopMediaPermissionSettings(kind: MediaPermissionKind): Promise<boolean> {
+  if (!isTauri()) return false
+  try {
+    const { invoke } = await import('@tauri-apps/api/core')
+    await invoke('desktop_open_media_permission_settings', { kind })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -51,6 +51,8 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Linux desktop test host has `xdg-desktop-portal` + (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` running.
 - [ ] First voice join shows OS/browser microphone permission prompt when needed.
 - [ ] Voice join succeeds after permission grant.
+- [ ] Denying desktop microphone permission shows recovery guidance, opens OS privacy settings from Voice & Audio, and succeeds after permission is restored and retried.
+- [ ] Denying desktop camera permission shows OS-specific recovery guidance, opens OS privacy settings when supported, and succeeds after permission is restored and retried.
 - [ ] Voice settings mic test with noise suppression on and `Noisy room` selected does not pass normal keyboard, mouse, fan, or breath noise as speech.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -225,6 +225,14 @@ await room.localParticipant.publishTrack(videoTrack, {
 3. Try another browser (Firefox, Chrome, Edge)
 4. Linux desktop: ensure `xdg-desktop-portal` + one backend (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` are installed/running, then restart Voxpery.
 
+### Mic or camera permission denied on desktop
+
+1. Open User Settings -> Voice & Audio.
+2. Click `Open settings` when microphone access is blocked, then allow Voxpery or desktop apps to use the microphone in OS privacy settings.
+3. For camera denial, open the OS camera privacy settings, allow Voxpery or desktop apps to use the camera, then retry the camera toggle.
+4. Restart Voxpery if the OS requires a restart before WebView permissions refresh.
+5. Return to Voxpery and click `Retry mic access` or retry the camera action.
+
 ### Echo or feedback
 
 - **Browser echo cancellation**: Enabled by default (`echoCancellation: true`)


### PR DESCRIPTION
## Summary

- Add desktop media permission recovery for denied microphone/camera access
- Open OS privacy settings from the desktop app for microphone/camera recovery
- Show clearer OS-specific recovery guidance in voice join, mic settings, and camera error flows
- Add release smoke coverage and voice troubleshooting docs for permission re-grant scenarios
- Ignore local Codex/graphify helper artifacts

## Testing

- `npm.cmd run lint`
- `npm.cmd run test:run`
- `npm.cmd run build`
- `cargo check --locked`
- `git diff --check`
- `graphify update .`

## Notes

Manual production smoke test for OS permission re-grant flow will be completed after merge/deploy.

Closes #72
