### PR TITLE
feat: add AutoMod feature with rules for blocked keywords, invite lin…

### DIFF
--- a/apps/server/migrations/034_server_automod_rules.sql
+++ b/apps/server/migrations/034_server_automod_rules.sql
@@ -1,0 +1,24 @@
+CREATE TABLE server_automod_rules (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    server_id UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    name VARCHAR(80) NOT NULL,
+    trigger_type VARCHAR(32) NOT NULL CHECK (trigger_type IN ('blocked_keyword', 'invite_filter', 'link_filter', 'mention_spam')),
+    pattern TEXT,
+    mention_limit INTEGER,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    exempt_role_ids UUID[] NOT NULL DEFAULT '{}',
+    exempt_channel_ids UUID[] NOT NULL DEFAULT '{}',
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT server_automod_rule_keyword_pattern CHECK (
+        trigger_type <> 'blocked_keyword' OR (pattern IS NOT NULL AND LENGTH(BTRIM(pattern)) BETWEEN 2 AND 128)
+    ),
+    CONSTRAINT server_automod_rule_mention_limit CHECK (
+        trigger_type <> 'mention_spam' OR (mention_limit IS NOT NULL AND mention_limit BETWEEN 2 AND 50)
+    )
+);
+
+CREATE INDEX idx_server_automod_rules_server_enabled ON server_automod_rules(server_id, enabled, created_at);
+

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -17,6 +17,7 @@ use crate::{
         SendMessageRequest,
     },
     services::{
+        automod,
         permissions::{self, Permissions},
         rate_limit::enforce_rate_limit,
     },
@@ -676,6 +677,17 @@ async fn send_message(
             "Message must be 1-4000 characters".into(),
         ));
     }
+    let server_id = server_id_for_channel(&state.db, channel_id).await?;
+    if let Some(matched) =
+        automod::evaluate_message(&state.db, server_id, channel_id, claims.sub, &content).await?
+    {
+        automod::log_blocked_message(&state.db, claims.sub, server_id, channel_id, &matched, &content)
+            .await?;
+        return Err(AppError::Forbidden(format!(
+            "Message blocked by AutoMod rule: {}",
+            matched.rule_name
+        )));
+    }
 
     // Insert and fetch with author in one round-trip using CTE
     let row = sqlx::query_as::<_, MessageRow>(
@@ -825,6 +837,17 @@ async fn edit_message(
             "Message must be 1-4000 characters".into(),
         ));
     }
+    let server_id = server_id_for_channel(&state.db, channel_id).await?;
+    if let Some(matched) =
+        automod::evaluate_message(&state.db, server_id, channel_id, claims.sub, &content).await?
+    {
+        automod::log_blocked_message(&state.db, claims.sub, server_id, channel_id, &matched, &content)
+            .await?;
+        return Err(AppError::Forbidden(format!(
+            "Message blocked by AutoMod rule: {}",
+            matched.rule_name
+        )));
+    }
 
     sqlx::query("UPDATE messages SET content = $1, edited_at = NOW() WHERE id = $2")
         .bind(&content)
@@ -832,10 +855,6 @@ async fn edit_message(
         .execute(&state.db)
         .await?;
 
-    let server_id: Uuid = sqlx::query_scalar("SELECT server_id FROM channels WHERE id = $1")
-        .bind(channel_id)
-        .fetch_one(&state.db)
-        .await?;
     let (before_preview, before_truncated) = audit_content_preview(&previous_content);
     let (after_preview, after_truncated) = audit_content_preview(&content);
     crate::services::audit::log(
@@ -1083,6 +1102,14 @@ async fn remove_message_reaction(
     .await;
 
     Ok(Json(msg_with_author))
+}
+
+async fn server_id_for_channel(db: &sqlx::PgPool, channel_id: Uuid) -> Result<Uuid, AppError> {
+    sqlx::query_scalar("SELECT server_id FROM channels WHERE id = $1")
+        .bind(channel_id)
+        .fetch_optional(db)
+        .await?
+        .ok_or(AppError::NotFound("Channel not found".into()))
 }
 
 /// Check if a user has access to a channel (via server membership).

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     services::{
         audit,
+        automod::AutoModRule,
         auth::generate_invite_code,
         permissions::{self, Permissions},
         rate_limit::enforce_rate_limit,
@@ -141,6 +142,28 @@ struct ServerReportEntry {
     resolved_by_username: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct CreateAutoModRuleRequest {
+    name: String,
+    trigger_type: String,
+    pattern: Option<String>,
+    mention_limit: Option<i32>,
+    enabled: Option<bool>,
+    exempt_role_ids: Option<Vec<Uuid>>,
+    exempt_channel_ids: Option<Vec<Uuid>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct UpdateAutoModRuleRequest {
+    name: Option<String>,
+    trigger_type: Option<String>,
+    pattern: Option<String>,
+    mention_limit: Option<i32>,
+    enabled: Option<bool>,
+    exempt_role_ids: Option<Vec<Uuid>>,
+    exempt_channel_ids: Option<Vec<Uuid>>,
+}
+
 pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
     Router::new()
         .route("/invite/{invite_code}", get(get_invite_preview))
@@ -178,6 +201,14 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
                 .route("/{server_id}/reports/user", post(report_user))
                 .route("/{server_id}/reports/message", post(report_message))
                 .route(
+                    "/{server_id}/automod-rules",
+                    get(list_automod_rules).post(create_automod_rule),
+                )
+                .route(
+                    "/{server_id}/automod-rules/{rule_id}",
+                    patch(update_automod_rule).delete(delete_automod_rule),
+                )
+                .route(
                     "/{server_id}/reports/{report_id}/resolve",
                     post(resolve_report),
                 )
@@ -186,6 +217,82 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
                 .route("/{server_id}/leave", post(leave_server))
                 .route_layer(middleware::from_fn_with_state(state, require_auth)),
         )
+}
+
+fn normalize_automod_name(name: &str) -> Result<String, AppError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.len() > 80 {
+        return Err(AppError::Validation(
+            "AutoMod rule name must be 1-80 characters".into(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalize_automod_trigger(trigger_type: &str) -> Result<String, AppError> {
+    match trigger_type.trim() {
+        "blocked_keyword" | "invite_filter" | "link_filter" | "mention_spam" => {
+            Ok(trigger_type.trim().to_string())
+        }
+        _ => Err(AppError::Validation("Unsupported AutoMod trigger type".into())),
+    }
+}
+
+fn normalize_automod_rule_values(
+    trigger_type: &str,
+    pattern: Option<String>,
+    mention_limit: Option<i32>,
+) -> Result<(Option<String>, Option<i32>), AppError> {
+    match trigger_type {
+        "blocked_keyword" => {
+            let pattern = pattern
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .ok_or(AppError::Validation(
+                    "Blocked keyword rules require a keyword".into(),
+                ))?;
+            if pattern.len() < 2 || pattern.len() > 128 {
+                return Err(AppError::Validation(
+                    "Blocked keyword must be 2-128 characters".into(),
+                ));
+            }
+            Ok((Some(pattern), None))
+        }
+        "mention_spam" => {
+            let limit = mention_limit.unwrap_or(5);
+            if !(2..=50).contains(&limit) {
+                return Err(AppError::Validation(
+                    "Mention spam limit must be between 2 and 50".into(),
+                ));
+            }
+            Ok((None, Some(limit)))
+        }
+        "invite_filter" | "link_filter" => Ok((None, None)),
+        _ => Err(AppError::Validation("Unsupported AutoMod trigger type".into())),
+    }
+}
+
+fn validate_automod_exemptions(role_ids: &[Uuid], channel_ids: &[Uuid]) -> Result<(), AppError> {
+    if role_ids.len() > 100 || channel_ids.len() > 100 {
+        return Err(AppError::Validation(
+            "AutoMod rule exemptions cannot include more than 100 roles or channels".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn ensure_automod_manage_permission(
+    state: &AppState,
+    server_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    permissions::ensure_server_permission(
+        &state.db,
+        server_id,
+        user_id,
+        Permissions::MANAGE_MESSAGES,
+    )
+    .await
 }
 
 fn visible_presence(status: &str, has_session: bool) -> String {
@@ -1781,6 +1888,200 @@ async fn ban_member(
         "message": "Member banned",
         "removed_member": removed_member
     })))
+}
+
+async fn list_automod_rules(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path(server_id): Path<Uuid>,
+) -> Result<Json<Vec<AutoModRule>>, AppError> {
+    ensure_automod_manage_permission(&state, server_id, claims.sub).await?;
+
+    let rules = sqlx::query_as::<_, AutoModRule>(
+        r#"SELECT id, server_id, name, trigger_type, pattern, mention_limit, enabled,
+                  exempt_role_ids, exempt_channel_ids, created_by, updated_by, created_at, updated_at
+           FROM server_automod_rules
+           WHERE server_id = $1
+           ORDER BY created_at ASC"#,
+    )
+    .bind(server_id)
+    .fetch_all(&state.db)
+    .await?;
+
+    Ok(Json(rules))
+}
+
+async fn create_automod_rule(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path(server_id): Path<Uuid>,
+    Json(body): Json<CreateAutoModRuleRequest>,
+) -> Result<Json<AutoModRule>, AppError> {
+    ensure_automod_manage_permission(&state, server_id, claims.sub).await?;
+
+    let name = normalize_automod_name(&body.name)?;
+    let trigger_type = normalize_automod_trigger(&body.trigger_type)?;
+    let (pattern, mention_limit) =
+        normalize_automod_rule_values(&trigger_type, body.pattern, body.mention_limit)?;
+    let exempt_role_ids = body.exempt_role_ids.unwrap_or_default();
+    let exempt_channel_ids = body.exempt_channel_ids.unwrap_or_default();
+    validate_automod_exemptions(&exempt_role_ids, &exempt_channel_ids)?;
+
+    let rule = sqlx::query_as::<_, AutoModRule>(
+        r#"INSERT INTO server_automod_rules (
+                id, server_id, name, trigger_type, pattern, mention_limit, enabled,
+                exempt_role_ids, exempt_channel_ids, created_by, updated_by, created_at, updated_at
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10, NOW(), NOW())
+           RETURNING id, server_id, name, trigger_type, pattern, mention_limit, enabled,
+                     exempt_role_ids, exempt_channel_ids, created_by, updated_by, created_at, updated_at"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(server_id)
+    .bind(name)
+    .bind(trigger_type)
+    .bind(pattern)
+    .bind(mention_limit)
+    .bind(body.enabled.unwrap_or(true))
+    .bind(exempt_role_ids)
+    .bind(exempt_channel_ids)
+    .bind(claims.sub)
+    .fetch_one(&state.db)
+    .await?;
+
+    audit::log(
+        &state.db,
+        claims.sub,
+        Some(server_id),
+        "automod_rule_create",
+        "automod_rule",
+        Some(rule.id),
+        Some(serde_json::json!({
+            "name": &rule.name,
+            "trigger_type": &rule.trigger_type,
+            "enabled": rule.enabled
+        })),
+    )
+    .await?;
+
+    Ok(Json(rule))
+}
+
+async fn update_automod_rule(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path((server_id, rule_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<UpdateAutoModRuleRequest>,
+) -> Result<Json<AutoModRule>, AppError> {
+    ensure_automod_manage_permission(&state, server_id, claims.sub).await?;
+
+    let current = sqlx::query_as::<_, AutoModRule>(
+        r#"SELECT id, server_id, name, trigger_type, pattern, mention_limit, enabled,
+                  exempt_role_ids, exempt_channel_ids, created_by, updated_by, created_at, updated_at
+           FROM server_automod_rules
+           WHERE id = $1 AND server_id = $2"#,
+    )
+    .bind(rule_id)
+    .bind(server_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or(AppError::NotFound("AutoMod rule not found".into()))?;
+
+    let name = match body.name {
+        Some(value) => normalize_automod_name(&value)?,
+        None => current.name,
+    };
+    let trigger_type = match body.trigger_type {
+        Some(value) => normalize_automod_trigger(&value)?,
+        None => current.trigger_type,
+    };
+    let (pattern, mention_limit) = normalize_automod_rule_values(
+        &trigger_type,
+        body.pattern.or(current.pattern),
+        body.mention_limit.or(current.mention_limit),
+    )?;
+    let exempt_role_ids = body.exempt_role_ids.unwrap_or(current.exempt_role_ids);
+    let exempt_channel_ids = body
+        .exempt_channel_ids
+        .unwrap_or(current.exempt_channel_ids);
+    validate_automod_exemptions(&exempt_role_ids, &exempt_channel_ids)?;
+
+    let rule = sqlx::query_as::<_, AutoModRule>(
+        r#"UPDATE server_automod_rules
+           SET name = $3,
+               trigger_type = $4,
+               pattern = $5,
+               mention_limit = $6,
+               enabled = $7,
+               exempt_role_ids = $8,
+               exempt_channel_ids = $9,
+               updated_by = $10,
+               updated_at = NOW()
+           WHERE id = $1 AND server_id = $2
+           RETURNING id, server_id, name, trigger_type, pattern, mention_limit, enabled,
+                     exempt_role_ids, exempt_channel_ids, created_by, updated_by, created_at, updated_at"#,
+    )
+    .bind(rule_id)
+    .bind(server_id)
+    .bind(name)
+    .bind(trigger_type)
+    .bind(pattern)
+    .bind(mention_limit)
+    .bind(body.enabled.unwrap_or(current.enabled))
+    .bind(exempt_role_ids)
+    .bind(exempt_channel_ids)
+    .bind(claims.sub)
+    .fetch_one(&state.db)
+    .await?;
+
+    audit::log(
+        &state.db,
+        claims.sub,
+        Some(server_id),
+        "automod_rule_update",
+        "automod_rule",
+        Some(rule.id),
+        Some(serde_json::json!({
+            "name": &rule.name,
+            "trigger_type": &rule.trigger_type,
+            "enabled": rule.enabled
+        })),
+    )
+    .await?;
+
+    Ok(Json(rule))
+}
+
+async fn delete_automod_rule(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path((server_id, rule_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    ensure_automod_manage_permission(&state, server_id, claims.sub).await?;
+
+    let deleted = sqlx::query_scalar::<_, String>(
+        r#"DELETE FROM server_automod_rules
+           WHERE id = $1 AND server_id = $2
+           RETURNING name"#,
+    )
+    .bind(rule_id)
+    .bind(server_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or(AppError::NotFound("AutoMod rule not found".into()))?;
+
+    audit::log(
+        &state.db,
+        claims.sub,
+        Some(server_id),
+        "automod_rule_delete",
+        "automod_rule",
+        Some(rule_id),
+        Some(serde_json::json!({ "name": deleted })),
+    )
+    .await?;
+
+    Ok(Json(serde_json::json!({ "message": "AutoMod rule deleted" })))
 }
 
 async fn report_user(

--- a/apps/server/src/services/automod.rs
+++ b/apps/server/src/services/automod.rs
@@ -1,0 +1,229 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{errors::AppError, services::audit};
+
+#[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
+pub struct AutoModRule {
+    pub id: Uuid,
+    pub server_id: Uuid,
+    pub name: String,
+    pub trigger_type: String,
+    pub pattern: Option<String>,
+    pub mention_limit: Option<i32>,
+    pub enabled: bool,
+    pub exempt_role_ids: Vec<Uuid>,
+    pub exempt_channel_ids: Vec<Uuid>,
+    pub created_by: Option<Uuid>,
+    pub updated_by: Option<Uuid>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutoModMatch {
+    pub rule_id: Uuid,
+    pub rule_name: String,
+    pub trigger_type: String,
+    pub matched_value: Option<String>,
+}
+
+pub fn content_preview(content: &str) -> (String, bool) {
+    let mut out = String::new();
+    let mut chars = content.chars();
+    for _ in 0..160 {
+        let Some(ch) = chars.next() else {
+            return (out, false);
+        };
+        out.push(ch);
+    }
+    (out, chars.next().is_some())
+}
+
+fn has_link(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    lower.contains("http://")
+        || lower.contains("https://")
+        || lower.contains("www.")
+        || lower.contains(".com")
+        || lower.contains(".net")
+        || lower.contains(".org")
+}
+
+fn has_invite_link(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    lower.contains("discord.gg/")
+        || lower.contains("discord.com/invite/")
+        || lower.contains("discordapp.com/invite/")
+        || lower.contains("/invite/")
+}
+
+fn is_mention_boundary_char(ch: Option<char>) -> bool {
+    match ch {
+        None => true,
+        Some(c) => !(c.is_ascii_alphanumeric() || c == '_' || c == '.'),
+    }
+}
+
+pub fn mention_count(content: &str) -> usize {
+    let mut count = 0usize;
+    let mut idx = 0usize;
+    while idx < content.len() {
+        let ch = content[idx..]
+            .chars()
+            .next()
+            .expect("valid UTF-8 character boundary");
+        let ch_len = ch.len_utf8();
+
+        if ch == '@' {
+            let prev_char = content[..idx].chars().next_back();
+            let next_char = content[idx + ch_len..].chars().next();
+            if is_mention_boundary_char(prev_char)
+                && next_char
+                    .map(|c| c.is_ascii_alphanumeric() || c == '_')
+                    .unwrap_or(false)
+            {
+                count += 1;
+            }
+        }
+
+        idx += ch_len;
+    }
+    count
+}
+
+fn evaluate_rule(rule: &AutoModRule, content: &str) -> Option<AutoModMatch> {
+    match rule.trigger_type.as_str() {
+        "blocked_keyword" => {
+            let pattern = rule.pattern.as_deref()?.trim();
+            if pattern.is_empty() {
+                return None;
+            }
+            if content
+                .to_ascii_lowercase()
+                .contains(&pattern.to_ascii_lowercase())
+            {
+                Some(AutoModMatch {
+                    rule_id: rule.id,
+                    rule_name: rule.name.clone(),
+                    trigger_type: rule.trigger_type.clone(),
+                    matched_value: Some(pattern.to_string()),
+                })
+            } else {
+                None
+            }
+        }
+        "invite_filter" if has_invite_link(content) => Some(AutoModMatch {
+            rule_id: rule.id,
+            rule_name: rule.name.clone(),
+            trigger_type: rule.trigger_type.clone(),
+            matched_value: Some("invite_link".into()),
+        }),
+        "link_filter" if has_link(content) => Some(AutoModMatch {
+            rule_id: rule.id,
+            rule_name: rule.name.clone(),
+            trigger_type: rule.trigger_type.clone(),
+            matched_value: Some("link".into()),
+        }),
+        "mention_spam" => {
+            let limit = rule.mention_limit.unwrap_or(5).max(1) as usize;
+            let mentions = mention_count(content);
+            if mentions >= limit {
+                Some(AutoModMatch {
+                    rule_id: rule.id,
+                    rule_name: rule.name.clone(),
+                    trigger_type: rule.trigger_type.clone(),
+                    matched_value: Some(mentions.to_string()),
+                })
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+pub async fn evaluate_message(
+    db: &PgPool,
+    server_id: Uuid,
+    channel_id: Uuid,
+    user_id: Uuid,
+    content: &str,
+) -> Result<Option<AutoModMatch>, AppError> {
+    if content.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let rules = sqlx::query_as::<_, AutoModRule>(
+        r#"SELECT id, server_id, name, trigger_type, pattern, mention_limit, enabled,
+                  exempt_role_ids, exempt_channel_ids, created_by, updated_by, created_at, updated_at
+           FROM server_automod_rules
+           WHERE server_id = $1
+             AND enabled = TRUE
+             AND NOT ($2 = ANY(exempt_channel_ids))
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM server_member_roles smr
+                 WHERE smr.server_id = $1
+                   AND smr.user_id = $3
+                   AND smr.role_id = ANY(exempt_role_ids)
+             )
+           ORDER BY created_at ASC"#,
+    )
+    .bind(server_id)
+    .bind(channel_id)
+    .bind(user_id)
+    .fetch_all(db)
+    .await?;
+
+    Ok(rules.iter().find_map(|rule| evaluate_rule(rule, content)))
+}
+
+pub async fn log_blocked_message(
+    db: &PgPool,
+    user_id: Uuid,
+    server_id: Uuid,
+    channel_id: Uuid,
+    matched: &AutoModMatch,
+    content: &str,
+) -> Result<(), AppError> {
+    let (preview, truncated) = content_preview(content);
+    audit::log(
+        db,
+        user_id,
+        Some(server_id),
+        "automod_message_block",
+        "message",
+        None,
+        Some(serde_json::json!({
+            "rule_id": matched.rule_id,
+            "rule_name": matched.rule_name,
+            "trigger_type": matched.trigger_type,
+            "matched_value": matched.matched_value,
+            "channel_id": channel_id,
+            "content_preview": preview,
+            "content_truncated": truncated
+        })),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mention_count_ignores_email_like_text() {
+        assert_eq!(mention_count("hello @one @two test@example.com"), 2);
+    }
+
+    #[test]
+    fn content_preview_reports_truncation() {
+        let input = "a".repeat(161);
+        let (preview, truncated) = content_preview(&input);
+        assert_eq!(preview.len(), 160);
+        assert!(truncated);
+    }
+}
+

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod attachments;
 pub mod audit;
+pub mod automod;
 pub mod auth;
 pub mod email;
 pub mod jwt_blacklist;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,7 @@
 export type {
     AuditLogEntry,
+    AutoModRule,
+    AutoModTriggerType,
     AuthResponse,
     AuthToken,
     Channel,

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -167,6 +167,24 @@ export interface ServerReportEntry {
     resolved_by_username: string | null
 }
 
+export type AutoModTriggerType = 'blocked_keyword' | 'invite_filter' | 'link_filter' | 'mention_spam'
+
+export interface AutoModRule {
+    id: string
+    server_id: string
+    name: string
+    trigger_type: AutoModTriggerType
+    pattern: string | null
+    mention_limit: number | null
+    enabled: boolean
+    exempt_role_ids: string[]
+    exempt_channel_ids: string[]
+    created_by: string | null
+    updated_by: string | null
+    created_at: string
+    updated_at: string
+}
+
 export interface UploadedAttachment {
     id: string
     url: string

--- a/apps/web/src/api/servers.ts
+++ b/apps/web/src/api/servers.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client'
-import type { AuditLogEntry, AuthToken, Channel, MemberInfo, Server, ServerBanEntry, ServerDetail, ServerInvitePreview, ServerReportEntry, ServerRole } from './contracts'
+import type { AuditLogEntry, AuthToken, AutoModRule, AutoModTriggerType, Channel, MemberInfo, Server, ServerBanEntry, ServerDetail, ServerInvitePreview, ServerReportEntry, ServerRole } from './contracts'
 
 export const serverApi = {
     getInvitePreview: (inviteCode: string) =>
@@ -38,6 +38,54 @@ export const serverApi = {
 
     listReports: (serverId: string, token: AuthToken) =>
         apiFetch<ServerReportEntry[]>(`/api/servers/${serverId}/reports`, { token }),
+
+    listAutoModRules: (serverId: string, token: AuthToken) =>
+        apiFetch<AutoModRule[]>(`/api/servers/${serverId}/automod-rules`, { token }),
+
+    createAutoModRule: (
+        serverId: string,
+        payload: {
+            name: string
+            trigger_type: AutoModTriggerType
+            pattern?: string | null
+            mention_limit?: number | null
+            enabled?: boolean
+            exempt_role_ids?: string[]
+            exempt_channel_ids?: string[]
+        },
+        token: AuthToken,
+    ) =>
+        apiFetch<AutoModRule>(`/api/servers/${serverId}/automod-rules`, {
+            method: 'POST',
+            body: payload,
+            token,
+        }),
+
+    updateAutoModRule: (
+        serverId: string,
+        ruleId: string,
+        payload: Partial<{
+            name: string
+            trigger_type: AutoModTriggerType
+            pattern: string | null
+            mention_limit: number | null
+            enabled: boolean
+            exempt_role_ids: string[]
+            exempt_channel_ids: string[]
+        }>,
+        token: AuthToken,
+    ) =>
+        apiFetch<AutoModRule>(`/api/servers/${serverId}/automod-rules/${ruleId}`, {
+            method: 'PATCH',
+            body: payload,
+            token,
+        }),
+
+    deleteAutoModRule: (serverId: string, ruleId: string, token: AuthToken) =>
+        apiFetch<void>(`/api/servers/${serverId}/automod-rules/${ruleId}`, {
+            method: 'DELETE',
+            token,
+        }),
 
     reportUser: (
         serverId: string,

--- a/apps/web/src/components/ServerSettingsAutoMod.tsx
+++ b/apps/web/src/components/ServerSettingsAutoMod.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useState } from 'react'
+import { serverApi, type AuthToken, type AutoModRule, type AutoModTriggerType, type Channel, type ServerRole } from '../api'
+
+type ServerSettingsAutoModProps = {
+    serverId: string
+    token: AuthToken
+}
+
+type DraftState = {
+    name: string
+    triggerType: AutoModTriggerType
+    pattern: string
+    mentionLimit: number
+    enabled: boolean
+    exemptRoleIds: string[]
+    exemptChannelIds: string[]
+}
+
+const TRIGGER_OPTIONS: Array<{ value: AutoModTriggerType; label: string }> = [
+    { value: 'blocked_keyword', label: 'Blocked keyword' },
+    { value: 'invite_filter', label: 'Invite links' },
+    { value: 'link_filter', label: 'Links' },
+    { value: 'mention_spam', label: 'Mention spam' },
+]
+
+const DEFAULT_DRAFT: DraftState = {
+    name: '',
+    triggerType: 'blocked_keyword',
+    pattern: '',
+    mentionLimit: 5,
+    enabled: true,
+    exemptRoleIds: [],
+    exemptChannelIds: [],
+}
+
+function triggerLabel(value: AutoModTriggerType) {
+    return TRIGGER_OPTIONS.find((option) => option.value === value)?.label ?? value
+}
+
+function testRule(rule: Pick<AutoModRule, 'trigger_type' | 'pattern' | 'mention_limit'>, text: string) {
+    const lower = text.toLowerCase()
+    if (rule.trigger_type === 'blocked_keyword') {
+        const pattern = rule.pattern?.trim().toLowerCase()
+        return !!pattern && lower.includes(pattern)
+    }
+    if (rule.trigger_type === 'invite_filter') {
+        return lower.includes('discord.gg/')
+            || lower.includes('discord.com/invite/')
+            || lower.includes('discordapp.com/invite/')
+            || lower.includes('/invite/')
+    }
+    if (rule.trigger_type === 'link_filter') {
+        return lower.includes('http://')
+            || lower.includes('https://')
+            || lower.includes('www.')
+            || lower.includes('.com')
+            || lower.includes('.net')
+            || lower.includes('.org')
+    }
+    const mentionCount = text.match(/(^|[^A-Za-z0-9_.])@[A-Za-z0-9_]+/g)?.length ?? 0
+    return mentionCount >= (rule.mention_limit ?? 5)
+}
+
+export default function ServerSettingsAutoMod({ serverId, token }: ServerSettingsAutoModProps) {
+    const [rules, setRules] = useState<AutoModRule[]>([])
+    const [roles, setRoles] = useState<ServerRole[]>([])
+    const [channels, setChannels] = useState<Channel[]>([])
+    const [draft, setDraft] = useState<DraftState>(DEFAULT_DRAFT)
+    const [testText, setTestText] = useState('')
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [saving, setSaving] = useState(false)
+    const [busyRuleId, setBusyRuleId] = useState<string | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        setError(null)
+        Promise.all([
+            serverApi.listAutoModRules(serverId, token),
+            serverApi.channels(serverId, token).catch(() => []),
+            serverApi.listRoles(serverId, token, { includeSystem: true }).catch(() => []),
+        ]).then(([nextRules, nextChannels, nextRoles]) => {
+            if (cancelled) return
+            setRules(nextRules)
+            setChannels(nextChannels.filter((channel) => channel.channel_type === 'text'))
+            setRoles(nextRoles)
+        }).catch((err) => {
+            if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load AutoMod rules.')
+        }).finally(() => {
+            if (!cancelled) setLoading(false)
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [serverId, token])
+
+    const draftTestResult = useMemo(() => {
+        if (!testText.trim()) return null
+        return testRule({
+            trigger_type: draft.triggerType,
+            pattern: draft.pattern || null,
+            mention_limit: draft.mentionLimit,
+        }, testText)
+    }, [draft.mentionLimit, draft.pattern, draft.triggerType, testText])
+
+    const canCreate = draft.name.trim().length > 0
+        && (draft.triggerType !== 'blocked_keyword' || draft.pattern.trim().length >= 2)
+
+    const toggleDraftRole = (roleId: string) => {
+        setDraft((prev) => ({
+            ...prev,
+            exemptRoleIds: prev.exemptRoleIds.includes(roleId)
+                ? prev.exemptRoleIds.filter((id) => id !== roleId)
+                : [...prev.exemptRoleIds, roleId],
+        }))
+    }
+
+    const toggleDraftChannel = (channelId: string) => {
+        setDraft((prev) => ({
+            ...prev,
+            exemptChannelIds: prev.exemptChannelIds.includes(channelId)
+                ? prev.exemptChannelIds.filter((id) => id !== channelId)
+                : [...prev.exemptChannelIds, channelId],
+        }))
+    }
+
+    const createRule = async () => {
+        if (!canCreate) return
+        setSaving(true)
+        setError(null)
+        try {
+            const rule = await serverApi.createAutoModRule(serverId, {
+                name: draft.name.trim(),
+                trigger_type: draft.triggerType,
+                pattern: draft.triggerType === 'blocked_keyword' ? draft.pattern.trim() : null,
+                mention_limit: draft.triggerType === 'mention_spam' ? draft.mentionLimit : null,
+                enabled: draft.enabled,
+                exempt_role_ids: draft.exemptRoleIds,
+                exempt_channel_ids: draft.exemptChannelIds,
+            }, token)
+            setRules((prev) => [...prev, rule])
+            setDraft(DEFAULT_DRAFT)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to create AutoMod rule.')
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    const toggleRule = async (rule: AutoModRule) => {
+        setBusyRuleId(rule.id)
+        setError(null)
+        try {
+            const updated = await serverApi.updateAutoModRule(serverId, rule.id, { enabled: !rule.enabled }, token)
+            setRules((prev) => prev.map((item) => item.id === updated.id ? updated : item))
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to update AutoMod rule.')
+        } finally {
+            setBusyRuleId(null)
+        }
+    }
+
+    const deleteRule = async (rule: AutoModRule) => {
+        setBusyRuleId(rule.id)
+        setError(null)
+        try {
+            await serverApi.deleteAutoModRule(serverId, rule.id, token)
+            setRules((prev) => prev.filter((item) => item.id !== rule.id))
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to delete AutoMod rule.')
+        } finally {
+            setBusyRuleId(null)
+        }
+    }
+
+    return (
+        <section className="server-settings-card server-settings-card--stack server-settings-card--list-section">
+            <h3 className="server-settings-card__title">AutoMod</h3>
+            {error && <div className="auth-error" style={{ marginBottom: 12 }}>{error}</div>}
+            {loading ? (
+                <div className="server-settings-empty-state">Loading AutoMod rules...</div>
+            ) : (
+                <div className="server-report-list">
+                    {rules.length === 0 && (
+                        <div className="server-settings-empty-state">No AutoMod rules yet.</div>
+                    )}
+                    {rules.map((rule) => (
+                        <div key={rule.id} className="server-report-row">
+                            <div className="server-report-meta">
+                                <div className="server-report-head">
+                                    <strong>{rule.name}</strong>
+                                    <span className={`server-report-status ${rule.enabled ? 'is-open' : 'is-resolved'}`}>
+                                        {rule.enabled ? 'Enabled' : 'Disabled'}
+                                    </span>
+                                </div>
+                                <div className="server-report-tags">
+                                    <span className="server-report-tag server-report-tag--reason">
+                                        {triggerLabel(rule.trigger_type)}
+                                    </span>
+                                    {rule.pattern && <span className="server-report-tag">{rule.pattern}</span>}
+                                    {rule.mention_limit && <span className="server-report-tag">{rule.mention_limit} mentions</span>}
+                                    {(rule.exempt_role_ids.length > 0 || rule.exempt_channel_ids.length > 0) && (
+                                        <span className="server-report-tag">
+                                            {rule.exempt_role_ids.length + rule.exempt_channel_ids.length} exemptions
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                            <div className="server-report-actions">
+                                <button
+                                    type="button"
+                                    className="btn btn-secondary btn-sm"
+                                    disabled={busyRuleId === rule.id}
+                                    onClick={() => void toggleRule(rule)}
+                                >
+                                    {rule.enabled ? 'Disable' : 'Enable'}
+                                </button>
+                                <button
+                                    type="button"
+                                    className="btn btn-danger-outline btn-sm"
+                                    disabled={busyRuleId === rule.id}
+                                    onClick={() => void deleteRule(rule)}
+                                >
+                                    Delete
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <div className="server-settings-automod-create" style={{ marginTop: 14 }}>
+                <h3 className="server-settings-card__title">Create rule</h3>
+                <div className="server-overview-profile__form">
+                    <div className="form-group">
+                        <label>Rule name</label>
+                        <input value={draft.name} maxLength={80} onChange={(e) => setDraft((prev) => ({ ...prev, name: e.target.value }))} />
+                    </div>
+                    <div className="form-group">
+                        <label>Trigger</label>
+                        <select value={draft.triggerType} onChange={(e) => setDraft((prev) => ({ ...prev, triggerType: e.target.value as AutoModTriggerType }))}>
+                            {TRIGGER_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>{option.label}</option>
+                            ))}
+                        </select>
+                    </div>
+                    {draft.triggerType === 'blocked_keyword' && (
+                        <div className="form-group">
+                            <label>Keyword</label>
+                            <input value={draft.pattern} maxLength={128} onChange={(e) => setDraft((prev) => ({ ...prev, pattern: e.target.value }))} />
+                        </div>
+                    )}
+                    {draft.triggerType === 'mention_spam' && (
+                        <div className="form-group">
+                            <label>Mention limit</label>
+                            <input type="number" min={2} max={50} value={draft.mentionLimit} onChange={(e) => setDraft((prev) => ({ ...prev, mentionLimit: Number(e.target.value) || 5 }))} />
+                        </div>
+                    )}
+                    <label className="server-role-permission-item">
+                        <input type="checkbox" checked={draft.enabled} onChange={(e) => setDraft((prev) => ({ ...prev, enabled: e.target.checked }))} />
+                        <span>Enabled</span>
+                    </label>
+                    {roles.length > 0 && (
+                        <div className="server-role-permission-group">
+                            <div className="server-role-permission-group-title">Exempt roles</div>
+                            <div className="server-role-permission-group-items">
+                                {roles.map((role) => (
+                                    <label key={role.id} className="server-role-permission-item">
+                                        <input type="checkbox" checked={draft.exemptRoleIds.includes(role.id)} onChange={() => toggleDraftRole(role.id)} />
+                                        <span>{role.name}</span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                    {channels.length > 0 && (
+                        <div className="server-role-permission-group">
+                            <div className="server-role-permission-group-title">Exempt channels</div>
+                            <div className="server-role-permission-group-items">
+                                {channels.map((channel) => (
+                                    <label key={channel.id} className="server-role-permission-item">
+                                        <input type="checkbox" checked={draft.exemptChannelIds.includes(channel.id)} onChange={() => toggleDraftChannel(channel.id)} />
+                                        <span>#{channel.name}</span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                    <div className="form-group">
+                        <label>Test text</label>
+                        <input value={testText} onChange={(e) => setTestText(e.target.value)} />
+                        {draftTestResult != null && (
+                            <div className="server-report-subline">
+                                {draftTestResult ? 'This rule would block the test text.' : 'This rule would allow the test text.'}
+                            </div>
+                        )}
+                    </div>
+                    <button type="button" className="btn btn-primary btn-sm" disabled={!canCreate || saving} onClick={() => void createRule()}>
+                        {saving ? 'Creating...' : 'Create rule'}
+                    </button>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/apps/web/src/components/ServerSidebar.tsx
+++ b/apps/web/src/components/ServerSidebar.tsx
@@ -11,7 +11,7 @@ interface ServerSidebarProps {
   onJoinServer: () => void
   onOpenServerSettings?: (
     serverId: string,
-    initialTab?: 'overview' | 'roles' | 'audit' | 'reports' | 'bans' | 'danger',
+    initialTab?: 'overview' | 'roles' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger',
   ) => void
   onSelectServer?: (serverId: string) => void
   displayActiveServerId?: string | null

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -12,10 +12,11 @@ import CategoryPermissionsModal from '../components/CategoryPermissionsModal'
 import ChatArea from '../components/ChatArea'
 import MemberSidebar from '../components/MemberSidebar'
 import ServerSettingsAuditLog from '../components/ServerSettingsAuditLog'
+import ServerSettingsAutoMod from '../components/ServerSettingsAutoMod'
 import ServerRolesSidebar from '../components/ServerRolesSidebar'
 import ServerRoleEditor from '../components/ServerRoleEditor'
 import { useToastStore } from '../stores/toast'
-import { AlertTriangle, Ban, Flag, LayoutDashboard, MessageSquare, Mic, ScrollText, ShieldCheck, X } from 'lucide-react'
+import { AlertTriangle, Ban, Flag, LayoutDashboard, MessageSquare, Mic, ScrollText, ShieldAlert, ShieldCheck, X } from 'lucide-react'
 import { isTauri } from '../secureStorage'
 import { MAX_CHAT_ATTACHMENT_BYTES, getMaxChatAttachmentMb } from '../attachments'
 import {
@@ -65,6 +66,11 @@ const SERVER_SETTINGS_SECTION_META = {
         eyebrow: 'Trust & Safety',
         title: 'Reports',
         hint: 'Review community reports, investigate context, and resolve issues quickly.',
+    },
+    automod: {
+        eyebrow: 'Safety',
+        title: 'AutoMod',
+        hint: 'Create server-level filters that block risky messages before they reach channels.',
     },
     bans: {
         eyebrow: 'Safety',
@@ -331,7 +337,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [joinServerError, setJoinServerError] = useState<string | null>(null)
     const [showServerSettings, setShowServerSettings] = useState(false)
     const [serverSettingsServerId, setServerSettingsServerId] = useState<string | null>(null)
-    const [serverSettingsTab, setServerSettingsTab] = useState<'overview' | 'roles' | 'audit' | 'reports' | 'bans' | 'danger'>('overview')
+    const [serverSettingsTab, setServerSettingsTab] = useState<'overview' | 'roles' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger'>('overview')
     const [isMobileViewport, setIsMobileViewport] = useState(() =>
         typeof window !== 'undefined' ? window.matchMedia('(max-width: 900px)').matches : false,
     )
@@ -1555,7 +1561,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     }
     const openServerSettingsModal = (
         serverId?: string | null,
-        initialTab: 'overview' | 'roles' | 'audit' | 'reports' | 'bans' | 'danger' = 'overview',
+        initialTab: 'overview' | 'roles' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger' = 'overview',
     ) => {
         if (isMobileViewport) {
             pushToast({
@@ -1575,7 +1581,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     }
     const openServerSettingsForServer = (
         serverId: string,
-        initialTab: 'overview' | 'roles' | 'audit' | 'reports' | 'bans' | 'danger' = 'overview',
+        initialTab: 'overview' | 'roles' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger' = 'overview',
     ) => {
         if (activeServerId !== serverId) setActiveServer(serverId)
         openServerSettingsModal(serverId, initialTab)
@@ -1614,6 +1620,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const settingsServerId = settingsServer?.id ?? null
     const settingsServerInviteLink = settingsServer ? `${inviteBaseUrl}/invite/${settingsServer.invite_code}` : ''
     const isOwner = !!(settingsServer && user && settingsServer.owner_id === user.id)
+    const canManageAutoMod = isOwner || (activePerms & PERM_MANAGE_MESSAGES) === PERM_MANAGE_MESSAGES
     const canViewReports = isOwner || canViewAuditLog || canManageBans
     const trimmedServerSettingsName = serverSettingsName.trim()
     const hasNameChanges = !!(
@@ -3209,6 +3216,22 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                     </span>
                                                 </button>
                                             )}
+                                            {canManageAutoMod && (
+                                                <button
+                                                    type="button"
+                                                    className={
+                                                        serverSettingsTab === 'automod'
+                                                            ? 'server-settings-nav__item server-settings-nav__item--active'
+                                                            : 'server-settings-nav__item'
+                                                    }
+                                                    onClick={() => setServerSettingsTab('automod')}
+                                                >
+                                                    <span className="server-settings-nav__icon"><ShieldAlert size={16} /></span>
+                                                    <span className="server-settings-nav__copy">
+                                                        <span className="server-settings-nav__label">AutoMod</span>
+                                                    </span>
+                                                </button>
+                                            )}
                                             {(isOwner || canManageBans) && (
                                                 <button
                                                     type="button"
@@ -3247,6 +3270,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                     {serverSettingsTab === 'roles' && <ShieldCheck size={18} />}
                                                     {serverSettingsTab === 'audit' && <ScrollText size={18} />}
                                                     {serverSettingsTab === 'reports' && <Flag size={18} />}
+                                                    {serverSettingsTab === 'automod' && <ShieldAlert size={18} />}
                                                     {serverSettingsTab === 'bans' && <Ban size={18} />}
                                                     {serverSettingsTab === 'danger' && <AlertTriangle size={18} />}
                                                 </div>
@@ -3556,6 +3580,13 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                         </div>
                                                     )}
                                                 </section>
+                                            )}
+
+                                            {serverSettingsTab === 'automod' && settingsServerId && canManageAutoMod && (
+                                                <ServerSettingsAutoMod
+                                                    serverId={settingsServerId}
+                                                    token={token}
+                                                />
                                             )}
 
                                             {serverSettingsTab === 'bans' && (isOwner || canManageBans) && (

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -3,7 +3,7 @@ import { persist } from 'zustand/middleware'
 import type { Server, Channel, MemberInfo, Friend, DmChannel } from '../api'
 import type { SavedMediaItem } from '../types'
 
-export type ServerSettingsTab = 'overview' | 'roles' | 'audit' | 'reports' | 'bans' | 'danger'
+export type ServerSettingsTab = 'overview' | 'roles' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger'
 
 interface AppState {
     // Servers

--- a/docs/API.md
+++ b/docs/API.md
@@ -104,6 +104,13 @@ Notes:
 - `GET /api/servers/:server_id/bans` (requires `BAN_MEMBERS`)
 - `DELETE /api/servers/:server_id/bans/:user_id` (requires `BAN_MEMBERS`)
 - `GET /api/servers/:server_id/audit-log` (requires `VIEW_AUDIT_LOG`)
+- `GET /api/servers/:server_id/automod-rules` (requires `MANAGE_MESSAGES`)
+- `POST /api/servers/:server_id/automod-rules` (requires `MANAGE_MESSAGES`)
+- `PATCH /api/servers/:server_id/automod-rules/:rule_id` (requires `MANAGE_MESSAGES`)
+- `DELETE /api/servers/:server_id/automod-rules/:rule_id` (requires `MANAGE_MESSAGES`)
+  - `trigger_type` values: `blocked_keyword`, `invite_filter`, `link_filter`, `mention_spam`.
+  - Rules support `exempt_role_ids` and `exempt_channel_ids`.
+  - Enabled rules block matching server-channel sends/edits before persistence or broadcast.
 
 ## Channel & Category Endpoints
 
@@ -153,6 +160,7 @@ Notes:
 - `POST /api/messages/:channel_id` (requires `SEND_MESSAGES`)
 - `PATCH /api/messages/item/:message_id` (author only)
 - `DELETE /api/messages/item/:message_id` (author or `MANAGE_MESSAGES`)
+- Enabled AutoMod rules are evaluated before server-channel sends/edits are stored or broadcast.
 
 ### Pins
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -15,6 +15,7 @@ users
  |                       +--< server_channel_categories --< channel_category_role_overrides
  |                       +--< server_bans
  |                       +--< server_reports
+ |                       +--< server_automod_rules
  |                       +--< audit_log
  |
  +--< friend_requests
@@ -152,6 +153,12 @@ Uniqueness (case-insensitive):
 - moderation fields: `reason`, `details`, `status`, `resolved_at`, `resolved_by`
 - timeline: `created_at`
 
+### `server_automod_rules`
+
+- Server-level AutoMod configuration for blocked keywords, invite links, links, and mention spam.
+- Key fields: `trigger_type`, `pattern`, `mention_limit`, `enabled`, `exempt_role_ids`, `exempt_channel_ids`.
+- Matching rules block server-channel sends/edits before message persistence and write `automod_message_block` audit entries.
+
 ### `password_reset_tokens`
 
 - `id`, `user_id` (unique), `token_hash`, `expires_at`, `created_at`
@@ -210,6 +217,7 @@ All migrations currently present:
 - `031_channel_descriptions.sql`
 - `032_user_storage_used_bytes.sql`
 - `033_email_verification.sql`
+- `034_server_automod_rules.sql`
 
 ## Notes
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -32,6 +32,7 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Server/channel/category permission scenarios work.
 - [ ] Voice join/leave works.
 - [ ] Moderation flows (kick/ban) work.
+- [ ] AutoMod rule create/enable/disable/delete works and blocked messages do not persist or broadcast.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -298,6 +298,8 @@ add_header Content-Security-Policy "default-src 'self'; connect-src 'self' wss:/
 
 Audit logging is implemented for core moderation/server actions (for example role updates, kick, ban, and server settings updates) and exposed via server audit endpoints.
 
+AutoMod rules are server-scoped and require `MANAGE_MESSAGES` to manage. Enabled rules can block server-channel sends/edits for blocked keywords, invite links, links, or mention spam before persistence/broadcast. AutoMod blocks write audit entries with rule metadata and a truncated content preview.
+
 ## Dependency Security
 
 **Rust**:


### PR DESCRIPTION
## Summary

- **AutoMod enforcement** — Blocked keywords, invite/link filter, and mention spam rules evaluated before message DB write and WS broadcast.
- **Rule management API** — GET/POST/PATCH/DELETE `/api/servers/:server_id/automod-rules` with exempt roles and channels.
- **Moderator UI** — New AutoMod tab in Server Settings: rule creation, enable/disable, delete, exemption selection, and test text field.
- **Audit logging** — Blocked message attempts logged as `automod_message_block` audit events.
- **Database migration** — `034_server_automod_rules` table for per-server rule storage.

## New files

- `apps/server/migrations/034_server_automod_rules.sql`
- `apps/server/src/services/automod.rs`
- `apps/web/src/components/ServerSettingsAutoMod.tsx`

## Validation

- `cargo check --locked`
- `cargo test automod --lib`
- `npm run lint` ✓
- `npm run build` ✓
- `npm run test:run` — 60 tests passed

## Docs updated

- `docs/API.md`
- `docs/DATABASE.md`
- `docs/SECURITY.md`
- `docs/RELEASE_SMOKE_TEST_CHECKLIST.md`