### PR TITLE
fix: resolve chat message jitter by preserving message ID on update

### DIFF
--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -1283,7 +1283,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                     return [...current, msg]
                 }
                 const next = [...current]
-                next[idx] = msg
+                next[idx] = { ...msg, id: next[idx].id }
                 return next
             }
             if (activeChannelIdRef.current === channelId) {


### PR DESCRIPTION
## Summary

- **Fix chat message jitter on send** — Messages no longer shift position after the server response arrives.

## Root cause

- Optimistic messages are created with a `local-...` ID, then replaced by the server response which has a real UUID.
- `ChatArea.tsx` uses `key={msg.id}` for virtual list items, so the key change causes React to destroy and recreate the DOM node.
- The virtualizer re-measures the new element and recalculates `translateY`, producing a visible split-second shift.

## Fix

- `AppLayout.tsx` — preserve the optimistic `id` when merging the server response: `next[idx] = { ...msg, id: next[idx].id }`
- React key stays stable, DOM updates in place, no re-measure triggered.

## Changed files

- `apps/web/src/pages/AppLayout.tsx` (1 line)