### PR TITLE
feat: add optional description field to server model and update relat…

### DIFF
--- a/apps/server/migrations/035_server_description.sql
+++ b/apps/server/migrations/035_server_description.sql
@@ -1,0 +1,2 @@
+ALTER TABLE servers
+ADD COLUMN IF NOT EXISTS description TEXT;

--- a/apps/server/src/models/server.rs
+++ b/apps/server/src/models/server.rs
@@ -10,6 +10,7 @@ pub struct Server {
     pub id: Uuid,
     pub name: String,
     pub icon_url: Option<String>,
+    pub description: Option<String>,
     pub owner_id: Uuid,
     pub invite_code: String,
     pub created_at: DateTime<Utc>,
@@ -30,6 +31,7 @@ pub struct ServerWithMembers {
     pub id: Uuid,
     pub name: String,
     pub icon_url: Option<String>,
+    pub description: Option<String>,
     pub owner_id: Uuid,
     pub invite_code: String,
     pub created_at: DateTime<Utc>,
@@ -40,6 +42,7 @@ pub struct ServerWithMembers {
 pub struct CreateServerRequest {
     pub name: String,
     pub icon_url: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,6 +55,7 @@ pub struct ServerInvitePreview {
     pub id: Uuid,
     pub name: String,
     pub icon_url: Option<String>,
+    pub description: Option<String>,
     pub invite_code: String,
     pub member_count: i64,
 }

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -381,11 +381,11 @@ async fn get_invite_preview(
     }
 
     let preview = sqlx::query_as::<_, ServerInvitePreview>(
-        r#"SELECT s.id, s.name, s.icon_url, s.invite_code, COUNT(sm.user_id) AS member_count
+        r#"SELECT s.id, s.name, s.icon_url, s.description, s.invite_code, COUNT(sm.user_id) AS member_count
            FROM servers s
            LEFT JOIN server_members sm ON sm.server_id = s.id
            WHERE s.invite_code = $1
-           GROUP BY s.id, s.name, s.icon_url, s.invite_code"#,
+           GROUP BY s.id, s.name, s.icon_url, s.description, s.invite_code"#,
     )
     .bind(code)
     .fetch_optional(&state.db)
@@ -402,13 +402,13 @@ async fn list_servers(
     Extension(claims): Extension<Claims>,
 ) -> Result<Json<Vec<ServerWithMembers>>, AppError> {
     let rows = sqlx::query_as::<_, ServerWithMembers>(
-        r#"SELECT s.id, s.name, s.icon_url, s.owner_id, s.invite_code, s.created_at,
+        r#"SELECT s.id, s.name, s.icon_url, s.description, s.owner_id, s.invite_code, s.created_at,
                   COUNT(sm2.user_id) as member_count
            FROM servers s
            INNER JOIN server_members sm ON s.id = sm.server_id
            INNER JOIN server_members sm2 ON s.id = sm2.server_id
            WHERE sm.user_id = $1
-           GROUP BY s.id, s.name, s.icon_url, s.owner_id, s.invite_code, s.created_at
+           GROUP BY s.id, s.name, s.icon_url, s.description, s.owner_id, s.invite_code, s.created_at
            ORDER BY MIN(sm.joined_at) ASC"#,
     )
     .bind(claims.sub)
@@ -512,13 +512,14 @@ async fn create_server(
     let invite_code = generate_invite_code();
 
     let server = sqlx::query_as::<_, Server>(
-        r#"INSERT INTO servers (id, name, icon_url, owner_id, invite_code, created_at)
-           VALUES ($1, $2, $3, $4, $5, NOW())
+        r#"INSERT INTO servers (id, name, icon_url, description, owner_id, invite_code, created_at)
+           VALUES ($1, $2, $3, $4, $5, $6, NOW())
            RETURNING *"#,
     )
     .bind(server_id)
     .bind(&body.name)
     .bind(&icon_url)
+    .bind(&body.description)
     .bind(claims.sub)
     .bind(&invite_code)
     .fetch_one(&state.db)
@@ -1242,6 +1243,7 @@ async fn delete_server(
 struct UpdateServerRequest {
     name: Option<String>,
     icon_url: Option<String>,
+    description: Option<String>,
     clear_icon: Option<bool>,
 }
 
@@ -1291,14 +1293,26 @@ async fn update_server(
         next_icon = validate_server_icon_url(Some(trimmed))?;
     }
 
+    let mut next_description = current.description.clone();
+    if let Some(description) = body.description {
+        let trimmed = description.trim();
+        if trimmed.len() > 500 {
+            return Err(AppError::Validation(
+                "Server description must be under 500 characters".into(),
+            ));
+        }
+        next_description = if trimmed.is_empty() { None } else { Some(trimmed.to_string()) };
+    }
+
     let updated = sqlx::query_as::<_, Server>(
         r#"UPDATE servers
-           SET name = $1, icon_url = $2
-           WHERE id = $3
+           SET name = $1, icon_url = $2, description = $3
+           WHERE id = $4
            RETURNING *"#,
     )
     .bind(next_name)
     .bind(next_icon)
+    .bind(next_description)
     .bind(server_id)
     .fetch_one(&state.db)
     .await?;

--- a/apps/web/src/api/servers.ts
+++ b/apps/web/src/api/servers.ts
@@ -11,12 +11,12 @@ export const serverApi = {
     get: (serverId: string, token: AuthToken) =>
         apiFetch<ServerDetail>(`/api/servers/${serverId}`, { token }),
 
-    create: (name: string, token: AuthToken) =>
-        apiFetch<Server>('/api/servers', { method: 'POST', body: { name }, token }),
+    create: (name: string, description: string | undefined, token: AuthToken) =>
+        apiFetch<Server>('/api/servers', { method: 'POST', body: { name, description }, token }),
 
     update: (
         serverId: string,
-        payload: { name?: string; icon_url?: string; clear_icon?: boolean },
+        payload: { name?: string; icon_url?: string; description?: string; clear_icon?: boolean },
         token: AuthToken,
     ) =>
         apiFetch<Server>(`/api/servers/${serverId}`, { method: 'PATCH', body: payload, token }),

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -331,6 +331,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [draftAttachments, setDraftAttachments] = useState<DraftAttachmentItem[]>([])
     const [emptyInviteCopied, setEmptyInviteCopied] = useState(false)
     const [newServerName, setNewServerName] = useState('')
+    const [newServerDescription, setNewServerDescription] = useState('')
     const [inviteCode, setInviteCode] = useState('')
     const [createServerError, setCreateServerError] = useState<string | null>(null)
     const [isCreatingServer, setIsCreatingServer] = useState(false)
@@ -342,6 +343,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         typeof window !== 'undefined' ? window.matchMedia('(max-width: 900px)').matches : false,
     )
     const [serverSettingsName, setServerSettingsName] = useState('')
+    const [serverSettingsDescription, setServerSettingsDescription] = useState('')
     const [serverSettingsIconDraft, setServerSettingsIconDraft] = useState<string | null | undefined>(undefined)
     const [serverSettingsError, setServerSettingsError] = useState<string | null>(null)
     const [showDeleteServerConfirm, setShowDeleteServerConfirm] = useState(false)
@@ -1516,11 +1518,12 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         createServerInFlightRef.current = true
         setIsCreatingServer(true)
         try {
-            const server = await serverApi.create(newServerName, token)
+            const server = await serverApi.create(newServerName, newServerDescription.trim() || undefined, token)
             const allServers = await serverApi.list(token)
             setServers(allServers)
             setActiveServer(server.id)
             setNewServerName('')
+            setNewServerDescription('')
             setShowCreateServer(false)
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Failed to create server.'
@@ -1638,12 +1641,18 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         serverSettingsIconDraft !== undefined &&
         serverSettingsIconDraft !== (settingsServer.icon_url ?? null)
     )
-    const canSaveServerSettings = hasNameChanges || hasIconChanges
+    const hasDescriptionChanges = !!(
+        isOwner &&
+        settingsServer &&
+        serverSettingsDescription !== (settingsServer.description ?? '')
+    )
+    const canSaveServerSettings = hasNameChanges || hasIconChanges || hasDescriptionChanges
 
     useEffect(() => {
         setServerSettingsName(settingsServer?.name ?? '')
+        setServerSettingsDescription(settingsServer?.description ?? '')
         setServerSettingsIconDraft(undefined)
-    }, [settingsServer?.id, settingsServer?.name])
+    }, [settingsServer?.id, settingsServer?.name, settingsServer?.description])
 
     useEffect(() => {
         setEmptyInviteCopied(false)
@@ -2082,8 +2091,9 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         if (!canSaveServerSettings) return
         setServerSettingsError(null)
         try {
-            const payload: { name?: string; icon_url?: string; clear_icon?: boolean } = {}
+            const payload: { name?: string; icon_url?: string; description?: string; clear_icon?: boolean } = {}
             if (hasNameChanges) payload.name = trimmedServerSettingsName
+            if (hasDescriptionChanges) payload.description = serverSettingsDescription.trim() || undefined
             if (hasIconChanges) {
                 if (serverSettingsIconDraft == null) payload.clear_icon = true
                 else payload.icon_url = serverSettingsIconDraft
@@ -2103,11 +2113,12 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         setServerSettingsServerId(null)
         setCopiedInvite(null)
         setServerSettingsName(settingsServer?.name ?? '')
+        setServerSettingsDescription(settingsServer?.description ?? '')
         setServerSettingsIconDraft(undefined)
         setShowDeleteServerConfirm(false)
         setDeleteServerError(null)
         setDeleteServerInput('')
-    }, [settingsServer?.name])
+    }, [settingsServer?.name, settingsServer?.description])
 
     const handleCloseServerSettings = useCallback(() => {
         if (canSaveServerSettings) {
@@ -2923,6 +2934,17 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                         required
                                     />
                                 </div>
+                                <div className="form-group">
+                                    <label>Description <span style={{ opacity: 0.6 }}>(optional)</span></label>
+                                    <input
+                                        type="text"
+                                        value={newServerDescription}
+                                        onChange={(e) => setNewServerDescription(e.target.value)}
+                                        placeholder="What's this server about?"
+                                        maxLength={500}
+                                        disabled={isCreatingServer}
+                                    />
+                                </div>
                                 <div className="modal-actions">
                                     <button
                                         type="button"
@@ -3353,6 +3375,17 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                                         value={serverSettingsName}
                                                                         onChange={(e) => setServerSettingsName(e.target.value)}
                                                                         placeholder="Server name"
+                                                                        disabled={!isOwner}
+                                                                    />
+                                                                </div>
+                                                                <div className="form-group">
+                                                                    <label>Description</label>
+                                                                    <input
+                                                                        type="text"
+                                                                        value={serverSettingsDescription}
+                                                                        onChange={(e) => setServerSettingsDescription(e.target.value)}
+                                                                        placeholder="What's this server about?"
+                                                                        maxLength={500}
                                                                         disabled={!isOwner}
                                                                     />
                                                                 </div>

--- a/apps/web/src/pages/InvitePage.tsx
+++ b/apps/web/src/pages/InvitePage.tsx
@@ -106,6 +106,9 @@ export default function InvitePage() {
                             </div>
                             <div className="invite-preview-copy">
                                 <div className="invite-preview-title">{preview.name}</div>
+                                {preview.description && (
+                                    <div className="invite-preview-description">{preview.description}</div>
+                                )}
                                 <div className="invite-preview-meta">
                                     <span className="invite-preview-pill">{memberCountLabel(preview.member_count)}</span>
                                 </div>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -16,6 +16,7 @@ export interface Server {
     id: string;
     name: string;
     icon_url?: string;
+    description?: string;
     owner_id: string;
     invite_code: string;
 }
@@ -24,6 +25,7 @@ export interface ServerInvitePreview {
     id: string;
     name: string;
     icon_url?: string;
+    description?: string;
     invite_code: string;
     member_count: number;
 }


### PR DESCRIPTION
## Summary

- **Server description field** — Servers can now have an optional description (max 500 characters).
- Shown on the invite landing page to give users context before joining.
- Editable in Server Settings > Overview (owner only).
- Settable during server creation.

## Changed files

- `apps/server/migrations/035_server_description.sql` — new migration
- `apps/server/src/models/server.rs` — `Server`, `ServerWithMembers`, `ServerInvitePreview`, `CreateServerRequest` structs
- `apps/server/src/routes/servers.rs` — `get_invite_preview`, `list_servers`, `create_server`, `update_server` endpoints
- `apps/web/src/types/index.ts` — `Server` and `ServerInvitePreview` interfaces
- `apps/web/src/api/servers.ts` — `create` and `update` API calls
- `apps/web/src/pages/AppLayout.tsx` — Create Server modal + Settings Overview description input
- `apps/web/src/pages/InvitePage.tsx` — description display on invite landing

## Validation

- `cargo check --locked` ✓
- `npm run lint` ✓
- `npm run build` ✓
- `npm run test:run` — 60 tests passed