### PR TITLE
feat: add server rules management

### DIFF
--- a/apps/server/migrations/036_server_rules.sql
+++ b/apps/server/migrations/036_server_rules.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS server_rules (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    server_id UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    rule_text TEXT NOT NULL,
+    position INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_server_rules_server ON server_rules(server_id);
+CREATE INDEX idx_server_rules_position ON server_rules(server_id, position);

--- a/apps/server/src/models/server.rs
+++ b/apps/server/src/models/server.rs
@@ -84,3 +84,24 @@ pub struct MemberInfo {
     #[serde(default)]
     pub roles: Vec<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ServerRule {
+    pub id: Uuid,
+    pub server_id: Uuid,
+    pub rule_text: String,
+    pub position: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateServerRuleRequest {
+    pub rule_text: String,
+    pub position: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateServerRuleRequest {
+    pub rule_text: Option<String>,
+    pub position: Option<i32>,
+}

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -17,7 +17,7 @@ use crate::{
     middleware::auth::{require_auth, Claims},
     models::{
         Channel, CreateServerRequest, JoinServerRequest, MemberInfo, Server, ServerDetail,
-        ServerInvitePreview, ServerWithMembers,
+        ServerInvitePreview, ServerRule, ServerWithMembers, UpdateServerRuleRequest,
     },
     services::{
         audit,
@@ -167,6 +167,7 @@ struct UpdateAutoModRuleRequest {
 pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
     Router::new()
         .route("/invite/{invite_code}", get(get_invite_preview))
+        .route("/{server_id}/rules", get(list_server_rules))
         .merge(
             Router::new()
                 .route("/", get(list_servers).post(create_server))
@@ -207,6 +208,14 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
                 .route(
                     "/{server_id}/automod-rules/{rule_id}",
                     patch(update_automod_rule).delete(delete_automod_rule),
+                )
+                .route(
+                    "/{server_id}/rules",
+                    post(create_server_rule),
+                )
+                .route(
+                    "/{server_id}/rules/{rule_id}",
+                    patch(update_server_rule).delete(delete_server_rule),
                 )
                 .route(
                     "/{server_id}/reports/{report_id}/resolve",
@@ -2463,4 +2472,168 @@ async fn kick_member(
     crate::ws::publish_event(&state, WsEvent::MemberLeft { server_id, user_id }).await;
 
     Ok(Json(serde_json::json!({ "message": "Member kicked" })))
+}
+
+/// GET /api/servers/:server_id/rules — list server rules (public for invite preview).
+async fn list_server_rules(
+    State(state): State<Arc<AppState>>,
+    Path(server_id): Path<Uuid>,
+) -> Result<Json<Vec<ServerRule>>, AppError> {
+    let rules = sqlx::query_as::<_, ServerRule>(
+        r#"SELECT id, server_id, rule_text, position, created_at
+           FROM server_rules
+           WHERE server_id = $1
+           ORDER BY position ASC, created_at ASC"#,
+    )
+    .bind(server_id)
+    .fetch_all(&state.db)
+    .await?;
+
+    Ok(Json(rules))
+}
+
+/// POST /api/servers/:server_id/rules — create a server rule (owner only).
+async fn create_server_rule(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path(server_id): Path<Uuid>,
+    Json(body): Json<crate::models::CreateServerRuleRequest>,
+) -> Result<Json<ServerRule>, AppError> {
+    permissions::ensure_server_permission(
+        &state.db,
+        server_id,
+        claims.sub,
+        Permissions::MANAGE_SERVER,
+    )
+    .await?;
+
+    let trimmed = body.rule_text.trim();
+    if trimmed.is_empty() || trimmed.len() > 1000 {
+        return Err(AppError::Validation(
+            "Rule text must be 1-1000 characters".into(),
+        ));
+    }
+
+    let max_position: Option<i32> =
+        sqlx::query_scalar("SELECT MAX(position) FROM server_rules WHERE server_id = $1")
+            .bind(server_id)
+            .fetch_optional(&state.db)
+            .await?
+            .flatten();
+
+    let position = body.position.unwrap_or(max_position.map(|p| p + 1).unwrap_or(0));
+
+    let rule = sqlx::query_as::<_, ServerRule>(
+        r#"INSERT INTO server_rules (id, server_id, rule_text, position, created_at)
+           VALUES ($1, $2, $3, $4, NOW())
+           RETURNING *"#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(server_id)
+    .bind(trimmed)
+    .bind(position)
+    .fetch_one(&state.db)
+    .await?;
+
+    crate::services::audit::log(
+        &state.db,
+        claims.sub,
+        Some(server_id),
+        "server_rule_create",
+        "server",
+        Some(server_id),
+        Some(serde_json::json!({ "rule_id": rule.id, "position": rule.position })),
+    )
+    .await?;
+
+    Ok(Json(rule))
+}
+
+/// PATCH /api/servers/:server_id/rules/:rule_id — update a server rule (owner only).
+async fn update_server_rule(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path((server_id, rule_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<UpdateServerRuleRequest>,
+) -> Result<Json<ServerRule>, AppError> {
+    permissions::ensure_server_permission(
+        &state.db,
+        server_id,
+        claims.sub,
+        Permissions::MANAGE_SERVER,
+    )
+    .await?;
+
+    let existing = sqlx::query_as::<_, ServerRule>(
+        "SELECT * FROM server_rules WHERE id = $1 AND server_id = $2",
+    )
+    .bind(rule_id)
+    .bind(server_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or(AppError::NotFound("Rule not found".into()))?;
+
+    let next_text = match &body.rule_text {
+        Some(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() || trimmed.len() > 1000 {
+                return Err(AppError::Validation(
+                    "Rule text must be 1-1000 characters".into(),
+                ));
+            }
+            trimmed.to_string()
+        }
+        None => existing.rule_text,
+    };
+
+    let next_position = body.position.unwrap_or(existing.position);
+
+    let updated = sqlx::query_as::<_, ServerRule>(
+        r#"UPDATE server_rules SET rule_text = $1, position = $2 WHERE id = $3 RETURNING *"#,
+    )
+    .bind(next_text)
+    .bind(next_position)
+    .bind(rule_id)
+    .fetch_one(&state.db)
+    .await?;
+
+    Ok(Json(updated))
+}
+
+/// DELETE /api/servers/:server_id/rules/:rule_id — delete a server rule (owner only).
+async fn delete_server_rule(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path((server_id, rule_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    permissions::ensure_server_permission(
+        &state.db,
+        server_id,
+        claims.sub,
+        Permissions::MANAGE_SERVER,
+    )
+    .await?;
+
+    let deleted = sqlx::query("DELETE FROM server_rules WHERE id = $1 AND server_id = $2")
+        .bind(rule_id)
+        .bind(server_id)
+        .execute(&state.db)
+        .await?;
+
+    if deleted.rows_affected() == 0 {
+        return Err(AppError::NotFound("Rule not found".into()));
+    }
+
+    crate::services::audit::log(
+        &state.db,
+        claims.sub,
+        Some(server_id),
+        "server_rule_delete",
+        "server",
+        Some(server_id),
+        Some(serde_json::json!({ "rule_id": rule_id })),
+    )
+    .await?;
+
+    Ok(Json(serde_json::json!({ "message": "Rule deleted" })))
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -27,6 +27,7 @@ export type {
     ServerInvitePreview,
     ServerReportEntry,
     ServerRole,
+    ServerRule,
     SignalingMessage,
     SystemFeatures,
     TurnCredentials,

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -132,6 +132,14 @@ export interface ServerRole {
     permissions: number
 }
 
+export interface ServerRule {
+    id: string
+    server_id: string
+    rule_text: string
+    position: number
+    created_at: string
+}
+
 export interface ChannelOverride {
     role_id: string
     allow: number

--- a/apps/web/src/api/servers.ts
+++ b/apps/web/src/api/servers.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client'
-import type { AuditLogEntry, AuthToken, AutoModRule, AutoModTriggerType, Channel, MemberInfo, Server, ServerBanEntry, ServerDetail, ServerInvitePreview, ServerReportEntry, ServerRole } from './contracts'
+import type { AuditLogEntry, AuthToken, AutoModRule, AutoModTriggerType, Channel, MemberInfo, Server, ServerBanEntry, ServerDetail, ServerInvitePreview, ServerReportEntry, ServerRole, ServerRule } from './contracts'
 
 export const serverApi = {
     getInvitePreview: (inviteCode: string) =>
@@ -186,6 +186,29 @@ export const serverApi = {
         apiFetch<void>(`/api/servers/${serverId}/members/${userId}/ban`, {
             method: 'POST',
             body: reason ? { reason } : {},
+            token,
+        }),
+
+    listRules: (serverId: string, token?: AuthToken) =>
+        apiFetch<ServerRule[]>(`/api/servers/${serverId}/rules`, { token }),
+
+    createRule: (serverId: string, ruleText: string, token: AuthToken) =>
+        apiFetch<ServerRule>(`/api/servers/${serverId}/rules`, {
+            method: 'POST',
+            body: { rule_text: ruleText },
+            token,
+        }),
+
+    updateRule: (serverId: string, ruleId: string, payload: { rule_text?: string; position?: number }, token: AuthToken) =>
+        apiFetch<ServerRule>(`/api/servers/${serverId}/rules/${ruleId}`, {
+            method: 'PATCH',
+            body: payload,
+            token,
+        }),
+
+    deleteRule: (serverId: string, ruleId: string, token: AuthToken) =>
+        apiFetch<void>(`/api/servers/${serverId}/rules/${ruleId}`, {
+            method: 'DELETE',
             token,
         }),
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6006,6 +6006,107 @@ body {
   margin-bottom: 0;
 }
 
+.invite-rules-loading {
+  padding: 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-muted);
+  border-radius: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.invite-rules-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(9, 16, 34, 0.3);
+}
+
+.invite-rules-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.invite-rules-eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.invite-rules-count {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.invite-rules-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.invite-rule-item {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.15);
+  align-items: flex-start;
+}
+
+.invite-rule-number {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(82, 145, 225, 0.2);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+}
+
+.invite-rule-text {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.invite-rules-accept {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(82, 145, 225, 0.08);
+  border: 1px solid rgba(82, 145, 225, 0.2);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.invite-rules-accept input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-primary);
+  cursor: pointer;
+}
+
 .invite-preview-actions {
   display: flex;
   flex-direction: column;
@@ -10762,6 +10863,146 @@ a.community-open-btn:hover {
     display: flex;
     flex-direction: column;
     gap: 4px;
+}
+
+.server-rules-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.server-rules-toolbar {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.02));
+}
+
+.server-rules-toolbar__copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.server-rules-toolbar__eyebrow {
+    color: var(--text-muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.server-rules-toolbar__title {
+    font-size: 14px;
+    line-height: 1.2;
+    color: var(--text-primary);
+}
+
+.server-rules-toolbar__hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.server-rules-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.server-rules-loading,
+.server-rules-empty {
+    padding: 16px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--text-muted);
+    border-radius: 12px;
+    border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.server-rule-item {
+    display: flex;
+    gap: 12px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.12);
+    align-items: flex-start;
+}
+
+.server-rule-item__number {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: rgba(82, 145, 225, 0.2);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 2px;
+}
+
+.server-rule-item__content {
+    flex: 1;
+    min-width: 0;
+}
+
+.server-rule-item__edit {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.server-rule-text {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.server-rule-textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(0, 0, 0, 0.2);
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+    font-family: inherit;
+}
+
+.server-rule-textarea:focus {
+    outline: none;
+    border-color: rgba(82, 145, 225, 0.5);
+    box-shadow: 0 0 0 2px rgba(82, 145, 225, 0.15);
+}
+
+.server-rule-item__actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.server-rules-add {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px;
+    border-radius: 12px;
+    border: 1px dashed rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.02);
 }
 
 .server-roles-toolbar__eyebrow {

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from '../stores/auth'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores/app'
 import { useSocketStore } from '../stores/socket'
-import { attachmentApi, serverApi, messageApi, channelApi, friendApi, type MessageWithAuthor, type Channel, type ServerRole, type AuditLogEntry, type ServerBanEntry, type ServerReportEntry } from '../api'
+import { attachmentApi, serverApi, messageApi, channelApi, friendApi, type MessageWithAuthor, type Channel, type ServerRole, type ServerRule, type AuditLogEntry, type ServerBanEntry, type ServerReportEntry } from '../api'
 import ServerSidebar from '../components/ServerSidebar'
 import ChannelSidebar from '../components/ChannelSidebar'
 import ChannelSettingsModal from '../components/ChannelSettingsModal'
@@ -16,7 +16,7 @@ import ServerSettingsAutoMod from '../components/ServerSettingsAutoMod'
 import ServerRolesSidebar from '../components/ServerRolesSidebar'
 import ServerRoleEditor from '../components/ServerRoleEditor'
 import { useToastStore } from '../stores/toast'
-import { AlertTriangle, Ban, Flag, LayoutDashboard, MessageSquare, Mic, ScrollText, ShieldAlert, ShieldCheck, X } from 'lucide-react'
+import { AlertTriangle, Ban, Flag, LayoutDashboard, ListChecks, MessageSquare, Mic, ScrollText, ShieldAlert, ShieldCheck, X } from 'lucide-react'
 import { isTauri } from '../secureStorage'
 import { MAX_CHAT_ATTACHMENT_BYTES, getMaxChatAttachmentMb } from '../attachments'
 import {
@@ -56,6 +56,11 @@ const SERVER_SETTINGS_SECTION_META = {
         eyebrow: 'Access Control',
         title: 'Roles',
         hint: 'Shape permissions, moderation powers, and the hierarchy your members see.',
+    },
+    rules: {
+        eyebrow: 'Community',
+        title: 'Rules',
+        hint: 'Set clear expectations for your community with server rules.',
     },
     audit: {
         eyebrow: 'Moderation',
@@ -338,7 +343,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [joinServerError, setJoinServerError] = useState<string | null>(null)
     const [showServerSettings, setShowServerSettings] = useState(false)
     const [serverSettingsServerId, setServerSettingsServerId] = useState<string | null>(null)
-    const [serverSettingsTab, setServerSettingsTab] = useState<'overview' | 'roles' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger'>('overview')
+    const [serverSettingsTab, setServerSettingsTab] = useState<'overview' | 'roles' | 'rules' | 'audit' | 'reports' | 'automod' | 'bans' | 'danger'>('overview')
     const [isMobileViewport, setIsMobileViewport] = useState(() =>
         typeof window !== 'undefined' ? window.matchMedia('(max-width: 900px)').matches : false,
     )
@@ -404,6 +409,12 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [roleEditPreAdminPermissions, setRoleEditPreAdminPermissions] = useState<number | null>(null)
     const [roleEditColor, setRoleEditColor] = useState<string | null>(null)
     const [deleteRoleConfirmId, setDeleteRoleConfirmId] = useState<string | null>(null)
+    const [serverRules, setServerRules] = useState<ServerRule[]>([])
+    const [rulesLoading, setRulesLoading] = useState(false)
+    const [rulesError, setRulesError] = useState<string | null>(null)
+    const [newRuleText, setNewRuleText] = useState('')
+    const [editingRuleId, setEditingRuleId] = useState<string | null>(null)
+    const [editingRuleText, setEditingRuleText] = useState('')
     const [auditLogEntries, setAuditLogEntries] = useState<AuditLogEntry[] | null>(null)
     const [auditLogLoading, setAuditLogLoading] = useState(false)
     const [auditLogError, setAuditLogError] = useState<string | null>(null)
@@ -1788,6 +1799,26 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 setRolesError(message)
             } finally {
                 setRolesLoading(false)
+            }
+        }
+        void load()
+    }, [showServerSettings, serverSettingsTab, isLoggedIn, settingsServerId, token])
+
+    // Load rules when Rules tab is opened.
+    useEffect(() => {
+        if (!showServerSettings || serverSettingsTab !== 'rules') return
+        if (!isLoggedIn || !settingsServerId) return
+        const load = async () => {
+            setRulesLoading(true)
+            setRulesError(null)
+            try {
+                const rules = await serverApi.listRules(settingsServerId, token)
+                setServerRules(rules)
+            } catch (err) {
+                const message = err instanceof Error ? err.message : 'Failed to load rules.'
+                setRulesError(message)
+            } finally {
+                setRulesLoading(false)
             }
         }
         void load()
@@ -3206,6 +3237,20 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                     </span>
                                                 </button>
                                             )}
+                                            {isOwner && (
+                                                <button
+                                                    type="button"
+                                                    className={`server-settings-nav__item ${
+                                                        serverSettingsTab === 'rules' ? 'server-settings-nav__item--active' : ''
+                                                    }`}
+                                                    onClick={() => setServerSettingsTab('rules')}
+                                                >
+                                                    <span className="server-settings-nav__icon"><ListChecks size={16} /></span>
+                                                    <span className="server-settings-nav__copy">
+                                                        <span className="server-settings-nav__label">Rules</span>
+                                                    </span>
+                                                </button>
+                                            )}
                                             {canViewAuditLog && (
                                                 <button
                                                     type="button"
@@ -3290,6 +3335,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                 <div className="server-settings-section-intro__icon">
                                                     {serverSettingsTab === 'overview' && <LayoutDashboard size={18} />}
                                                     {serverSettingsTab === 'roles' && <ShieldCheck size={18} />}
+                                                    {serverSettingsTab === 'rules' && <ListChecks size={18} />}
                                                     {serverSettingsTab === 'audit' && <ScrollText size={18} />}
                                                     {serverSettingsTab === 'reports' && <Flag size={18} />}
                                                     {serverSettingsTab === 'automod' && <ShieldAlert size={18} />}
@@ -3787,6 +3833,164 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                                     </div>
                                                                 </div>
                                                             )}
+                                                        </div>
+                                                    </div>
+                                                </section>
+                                            )}
+
+                                            {serverSettingsTab === 'rules' && isOwner && (
+                                                <section className="server-settings-card server-settings-card--rules">
+                                                    {rulesError && (
+                                                        <div className="auth-error" style={{ marginBottom: 12 }}>
+                                                            {rulesError}
+                                                        </div>
+                                                    )}
+                                                    <div className="server-rules-layout">
+                                                        <div className="server-rules-toolbar">
+                                                            <div className="server-rules-toolbar__copy">
+                                                                <span className="server-rules-toolbar__eyebrow">Rules</span>
+                                                                <strong className="server-rules-toolbar__title">{serverRules.length} rules</strong>
+                                                                <span className="server-rules-toolbar__hint">
+                                                                    Set clear expectations for your community. Rules are shown to users before they join.
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                        <div className="server-rules-list">
+                                                            {rulesLoading && (
+                                                                <div className="server-rules-loading">Loading rules...</div>
+                                                            )}
+                                                            {!rulesLoading && serverRules.length === 0 && (
+                                                                <div className="server-rules-empty">
+                                                                    No rules yet. Add your first rule below.
+                                                                </div>
+                                                            )}
+                                                            {serverRules.map((rule, index) => (
+                                                                <div key={rule.id} className="server-rule-item">
+                                                                    <div className="server-rule-item__number">{index + 1}</div>
+                                                                    {editingRuleId === rule.id ? (
+                                                                        <div className="server-rule-item__edit">
+                                                                            <textarea
+                                                                                value={editingRuleText}
+                                                                                onChange={(e) => setEditingRuleText(e.target.value)}
+                                                                                className="server-rule-textarea"
+                                                                                rows={2}
+                                                                                maxLength={1000}
+                                                                            />
+                                                                            <div className="server-rule-item__actions">
+                                                                                <button
+                                                                                    type="button"
+                                                                                    className="btn btn-secondary btn-sm"
+                                                                                    onClick={() => {
+                                                                                        setEditingRuleId(null)
+                                                                                        setEditingRuleText('')
+                                                                                    }}
+                                                                                >
+                                                                                    Cancel
+                                                                                </button>
+                                                                                <button
+                                                                                    type="button"
+                                                                                    className="btn btn-primary btn-sm"
+                                                                                    disabled={!editingRuleText.trim() || !settingsServer}
+                                                                                    onClick={() => {
+                                                                                        if (!settingsServer || !editingRuleText.trim()) return
+                                                                                        void (async () => {
+                                                                                            try {
+                                                                                                await serverApi.updateRule(
+                                                                                                    settingsServer.id,
+                                                                                                    rule.id,
+                                                                                                    { rule_text: editingRuleText.trim() },
+                                                                                                    token!,
+                                                                                                )
+                                                                                                setEditingRuleId(null)
+                                                                                                setEditingRuleText('')
+                                                                                                const rules = await serverApi.listRules(settingsServer.id, token!)
+                                                                                                setServerRules(rules)
+                                                                                            } catch (err: unknown) {
+                                                                                                setRulesError(err instanceof Error ? err.message : 'Failed to update rule')
+                                                                                            }
+                                                                                        })()
+                                                                                    }}
+                                                                                >
+                                                                                    Save
+                                                                                </button>
+                                                                            </div>
+                                                                        </div>
+                                                                    ) : (
+                                                                        <div className="server-rule-item__content">
+                                                                            <p className="server-rule-text">{rule.rule_text}</p>
+                                                                            <div className="server-rule-item__actions">
+                                                                                <button
+                                                                                    type="button"
+                                                                                    className="btn btn-secondary btn-sm"
+                                                                                    onClick={() => {
+                                                                                        setEditingRuleId(rule.id)
+                                                                                        setEditingRuleText(rule.rule_text)
+                                                                                    }}
+                                                                                >
+                                                                                    Edit
+                                                                                </button>
+                                                                                <button
+                                                                                    type="button"
+                                                                                    className="btn btn-danger-outline btn-sm"
+                                                                                    disabled={!settingsServer}
+                                                                                    onClick={() => {
+                                                                                        if (!settingsServer) return
+                                                                                        void (async () => {
+                                                                                            try {
+                                                                                                await serverApi.deleteRule(
+                                                                                                    settingsServer.id,
+                                                                                                    rule.id,
+                                                                                                    token!,
+                                                                                                )
+                                                                                                const rules = await serverApi.listRules(settingsServer.id, token!)
+                                                                                                setServerRules(rules)
+                                                                                            } catch (err: unknown) {
+                                                                                                setRulesError(err instanceof Error ? err.message : 'Failed to delete rule')
+                                                                                            }
+                                                                                        })()
+                                                                                    }}
+                                                                                >
+                                                                                    Delete
+                                                                                </button>
+                                                                            </div>
+                                                                        </div>
+                                                                    )}
+                                                                </div>
+                                                            ))}
+                                                        </div>
+                                                        <div className="server-rules-add">
+                                                            <textarea
+                                                                value={newRuleText}
+                                                                onChange={(e) => setNewRuleText(e.target.value)}
+                                                                className="server-rule-textarea"
+                                                                placeholder="Add a new rule..."
+                                                                rows={2}
+                                                                maxLength={1000}
+                                                            />
+                                                            <button
+                                                                type="button"
+                                                                className="btn btn-primary btn-sm"
+                                                                disabled={!newRuleText.trim() || !settingsServer}
+                                                                onClick={() => {
+                                                                    if (!settingsServer || !newRuleText.trim()) return
+                                                                    void (async () => {
+                                                                        try {
+                                                                            await serverApi.createRule(
+                                                                                settingsServer.id,
+                                                                                newRuleText.trim(),
+                                                                                token!,
+                                                                            )
+                                                                            setNewRuleText('')
+                                                                            const rules = await serverApi.listRules(settingsServer.id, token!)
+                                                                            setServerRules(rules)
+                                                                        } catch (err: unknown) {
+                                                                            setRulesError(err instanceof Error ? err.message : 'Failed to create rule')
+                                                                        }
+                                                                    })()
+                                                                }}
+                                                            >
+                                                                Add rule
+                                                            </button>
                                                         </div>
                                                     </div>
                                                 </section>

--- a/apps/web/src/pages/InvitePage.tsx
+++ b/apps/web/src/pages/InvitePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { useShallow } from 'zustand/react/shallow'
 import { serverApi } from '../api'
+import type { ServerRule } from '../api/contracts'
 import { ROUTES } from '../routes'
 import { useAuthStore } from '../stores/auth'
 import { useAppStore } from '../stores/app'
@@ -30,6 +31,9 @@ export default function InvitePage() {
     const [preview, setPreview] = useState<ServerInvitePreview | null>(null)
     const [previewLoading, setPreviewLoading] = useState(true)
     const [previewError, setPreviewError] = useState<string | null>(null)
+    const [rules, setRules] = useState<ServerRule[]>([])
+    const [rulesLoading, setRulesLoading] = useState(true)
+    const [acceptedRules, setAcceptedRules] = useState(false)
     const [joining, setJoining] = useState(false)
     const [joinError, setJoinError] = useState<string | null>(null)
 
@@ -39,6 +43,8 @@ export default function InvitePage() {
             setPreview(null)
             setPreviewError('Invalid invite code.')
             setPreviewLoading(false)
+            setRules([])
+            setRulesLoading(false)
             return
         }
         setPreviewLoading(true)
@@ -55,11 +61,29 @@ export default function InvitePage() {
             .finally(() => setPreviewLoading(false))
     }, [trimmedCode, user])
 
+    useEffect(() => {
+        if (!user || !preview) return
+        setRulesLoading(true)
+        serverApi
+            .listRules(preview.id, token)
+            .then((data) => {
+                setRules(data)
+                setAcceptedRules(data.length === 0)
+            })
+            .catch(() => {
+                setRules([])
+                setAcceptedRules(true)
+            })
+            .finally(() => setRulesLoading(false))
+    }, [preview, user, token])
+
     const invitePath = useMemo(() => ROUTES.invite(trimmedCode || ''), [trimmedCode])
     const loginUrl = `${ROUTES.login}?redirect=${encodeURIComponent(invitePath)}`
 
+    const canJoin = rules.length === 0 || acceptedRules
+
     const joinServer = async () => {
-        if (!user || !trimmedCode) return
+        if (!user || !trimmedCode || !canJoin) return
         setJoinError(null)
         setJoining(true)
         try {
@@ -115,6 +139,33 @@ export default function InvitePage() {
                             </div>
                         </div>
 
+                        {rulesLoading ? (
+                            <div className="invite-rules-loading">Loading rules...</div>
+                        ) : rules.length > 0 ? (
+                            <div className="invite-rules-section">
+                                <div className="invite-rules-header">
+                                    <span className="invite-rules-eyebrow">Server Rules</span>
+                                    <span className="invite-rules-count">{rules.length} {rules.length === 1 ? 'rule' : 'rules'}</span>
+                                </div>
+                                <ol className="invite-rules-list">
+                                    {rules.map((rule, index) => (
+                                        <li key={rule.id} className="invite-rule-item">
+                                            <span className="invite-rule-number">{index + 1}</span>
+                                            <span className="invite-rule-text">{rule.rule_text}</span>
+                                        </li>
+                                    ))}
+                                </ol>
+                                <label className="invite-rules-accept">
+                                    <input
+                                        type="checkbox"
+                                        checked={acceptedRules}
+                                        onChange={(e) => setAcceptedRules(e.target.checked)}
+                                    />
+                                    <span>I have read and agree to the server rules</span>
+                                </label>
+                            </div>
+                        ) : null}
+
                         {joinError && (
                             <div className="auth-error invite-preview-error" role="alert">
                                 {joinError}
@@ -122,7 +173,12 @@ export default function InvitePage() {
                         )}
 
                         <div className="invite-preview-actions">
-                            <button type="button" className="auth-btn" onClick={() => void joinServer()} disabled={joining}>
+                            <button
+                                type="button"
+                                className="auth-btn"
+                                onClick={() => void joinServer()}
+                                disabled={joining || !canJoin}
+                            >
                                 {joining ? 'Joining…' : 'Join server'}
                             </button>
                             <button


### PR DESCRIPTION
## Summary
- Add server rules management in Server Settings (owner only)
- Display rules on invite landing page with mandatory acceptance checkbox
- Implement backend CRUD endpoints: `GET/POST/PATCH/DELETE /api/servers/:id/rules`
- Add `server_rules` migration (036)

## Changes
### Backend
- Migration `036_server_rules.sql`: `server_rules` table (id, server_id, rule_text, position, created_at)
- Models: `ServerRule`, `CreateServerRuleRequest`, `UpdateServerRuleRequest`
- Endpoints:
  - `GET /api/servers/:id/rules` — public (for invite preview)
  - `POST /api/servers/:id/rules` — owner only (MANAGE_SERVER)
  - `PATCH /api/servers/:id/rules/:rule_id` — owner only
  - `DELETE /api/servers/:id/rules/:rule_id` — owner only
- Audit logging for rule create/delete

### Frontend
- Server Settings: New "Rules" tab with CRUD UI (add, edit inline, delete)
- InvitePage: Fetch rules, display list, require "I agree" checkbox before join
- API: `ServerRule` type, `serverApi.listRules/createRule/updateRule/deleteRule`
- CSS: Styles for rules layout, numbered list, inline editing, invite rules section

## Validation
- [x] `cargo check --locked`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:run` (60 tests passed)

## Notes
- `GET /rules` is intentionally public to support unauthenticated invite preview
- Rules text limited to 1-1000 characters
- Position auto-incremented on create; manual position supported in API