### PR TITLE
feat: implement server notification preferences and enhance channel m…

### DIFF
--- a/apps/server/migrations/036_server_rules.sql
+++ b/apps/server/migrations/036_server_rules.sql
@@ -6,5 +6,5 @@ CREATE TABLE IF NOT EXISTS server_rules (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_server_rules_server ON server_rules(server_id);
-CREATE INDEX idx_server_rules_position ON server_rules(server_id, position);
+CREATE INDEX IF NOT EXISTS idx_server_rules_server ON server_rules(server_id);
+CREATE INDEX IF NOT EXISTS idx_server_rules_position ON server_rules(server_id, position);

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -59,7 +59,7 @@ export default function ChannelSidebar({
 }: ChannelSidebarProps) {
     const channelTypeOrder = (type: Channel['channel_type']) => (type === 'text' ? 0 : 1)
     const user = useAuthStore((s) => s.user)
-    const { servers, activeServerId, activeChannelId, channels, members, membersByServerId, voiceStates, voiceStateServerIds, voiceSpeakingUserIds, voiceLocalSpeaking, setActiveChannel, closeMobileSidebar } = useAppStore(
+    const { servers, activeServerId, activeChannelId, channels, members, membersByServerId, voiceStates, voiceStateServerIds, voiceSpeakingUserIds, voiceLocalSpeaking, mutedChannelIds, setActiveChannel, toggleMutedChannel, closeMobileSidebar } = useAppStore(
         useShallow((s) => ({
             servers: s.servers,
             activeServerId: s.activeServerId,
@@ -71,7 +71,9 @@ export default function ChannelSidebar({
             voiceStateServerIds: s.voiceStateServerIds,
             voiceSpeakingUserIds: s.voiceSpeakingUserIds,
             voiceLocalSpeaking: s.voiceLocalSpeaking,
+            mutedChannelIds: s.mutedChannelIds,
             setActiveChannel: s.setActiveChannel,
+            toggleMutedChannel: s.toggleMutedChannel,
             closeMobileSidebar: s.closeMobileSidebar,
         }))
     )
@@ -430,10 +432,11 @@ export default function ChannelSidebar({
                                 })
                                 : []
                             const hasMention = (mentionByChannel[ch.id] ?? 0) > 0
+                            const isChannelMuted = mutedChannelIds.includes(ch.id)
                             return (
                                 <div key={ch.id}>
                                     <div
-                                        className={`channel-item ${isActive ? 'active' : ''} ${canManageChannels ? 'is-draggable' : ''} ${isVoiceLocked ? 'channel-item--disabled' : ''} ${dragOverChannel?.id === ch.id ? `drop-${dragOverChannel.position}` : ''}`}
+                                        className={`channel-item ${isActive ? 'active' : ''} ${canManageChannels ? 'is-draggable' : ''} ${isVoiceLocked ? 'channel-item--disabled' : ''} ${isChannelMuted ? 'is-muted' : ''} ${dragOverChannel?.id === ch.id ? `drop-${dragOverChannel.position}` : ''}`}
                                         onMouseEnter={() => { if (ch.channel_type === 'voice' && !isVoiceLocked) preloadRnnoiseWorklet() }}
                                         title={isVoiceLocked ? "You don't have permission to connect to this voice channel." : undefined}
                                         onClick={() => {
@@ -453,7 +456,7 @@ export default function ChannelSidebar({
                                             closeMobileSidebar()
                                         }}
                                         onContextMenu={(e) => {
-                                            if (!canManageChannels) return
+                                            if (!canManageChannels && ch.channel_type !== 'text') return
                                             e.preventDefault()
                                             closeAllContextMenus()
                                             setContextMenu({ channelId: ch.id, x: e.clientX, y: e.clientY })
@@ -510,6 +513,11 @@ export default function ChannelSidebar({
                                         {isVoiceLocked && (
                                             <span className="channel-item-lock" aria-hidden>
                                                 <Lock size={12} />
+                                            </span>
+                                        )}
+                                        {ch.channel_type === 'text' && isChannelMuted && (
+                                            <span className="channel-muted-indicator" title="Muted channel" aria-label="Muted channel">
+                                                <VolumeX size={12} />
                                             </span>
                                         )}
                                         {ch.channel_type === 'text' && (unreadByChannel[ch.id] ?? 0) > 0 && (
@@ -609,9 +617,12 @@ export default function ChannelSidebar({
                 ))}
             </div>
 
-            {contextMenu && canManageChannels && (() => {
+            {contextMenu && (() => {
                 const channel = channels.find((c) => c.id === contextMenu.channelId)
                 if (!channel) return null
+                const isTextChannel = channel.channel_type === 'text'
+                if (!canManageChannels && !isTextChannel) return null
+                const isMuted = mutedChannelIds.includes(channel.id)
                 return (
                     <div
                         ref={menuRef}
@@ -619,26 +630,43 @@ export default function ChannelSidebar({
                         style={{ left: contextMenu.x, top: contextMenu.y }}
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <button
-                            type="button"
-                            className="server-context-menu-item"
-                            onClick={() => {
-                                setContextMenu(null)
-                                onRenameChannel?.(channel)
-                            }}
-                        >
-                            Rename
-                        </button>
-                        <button
-                            type="button"
-                            className="server-context-menu-item danger"
-                            onClick={() => {
-                                setContextMenu(null)
-                                onDeleteChannel?.(channel)
-                            }}
-                        >
-                            Delete Channel
-                        </button>
+                        {isTextChannel && (
+                            <button
+                                type="button"
+                                className="server-context-menu-item"
+                                onClick={() => {
+                                    toggleMutedChannel(channel.id)
+                                    setContextMenu(null)
+                                }}
+                            >
+                                <VolumeX size={14} />
+                                {isMuted ? 'Unmute Channel' : 'Mute Channel'}
+                            </button>
+                        )}
+                        {canManageChannels && (
+                            <>
+                                <button
+                                    type="button"
+                                    className="server-context-menu-item"
+                                    onClick={() => {
+                                        setContextMenu(null)
+                                        onRenameChannel?.(channel)
+                                    }}
+                                >
+                                    Rename
+                                </button>
+                                <button
+                                    type="button"
+                                    className="server-context-menu-item danger"
+                                    onClick={() => {
+                                        setContextMenu(null)
+                                        onDeleteChannel?.(channel)
+                                    }}
+                                >
+                                    Delete Channel
+                                </button>
+                            </>
+                        )}
                     </div>
                 )
             })()}

--- a/apps/web/src/components/ServerSidebar.tsx
+++ b/apps/web/src/components/ServerSidebar.tsx
@@ -40,8 +40,10 @@ export default function ServerSidebar({
         setChannelsForServer,
         setMembersForServer,
         serverUnreadByChannel,
+        serverMentionsByChannel,
         clearServerUnread,
         mutedServerIds,
+        mutedChannelIds,
         toggleMutedServer,
         voiceStates,
         voiceStateServerIds,
@@ -56,8 +58,10 @@ export default function ServerSidebar({
             setChannelsForServer: s.setChannelsForServer,
             setMembersForServer: s.setMembersForServer,
             serverUnreadByChannel: s.serverUnreadByChannel,
+            serverMentionsByChannel: s.serverMentionsByChannel,
             clearServerUnread: s.clearServerUnread,
             mutedServerIds: s.mutedServerIds,
+            mutedChannelIds: s.mutedChannelIds,
             toggleMutedServer: s.toggleMutedServer,
             voiceStates: s.voiceStates,
             voiceStateServerIds: s.voiceStateServerIds,
@@ -81,11 +85,16 @@ export default function ServerSidebar({
         for (const server of servers) {
             if (mutedServerIds.includes(server.id)) continue
             const serverChannels = channelsByServerId[server.id] ?? []
-            const total = serverChannels.reduce((sum, channel) => sum + (serverUnreadByChannel[channel.id] ?? 0), 0)
+            const total = serverChannels.reduce((sum, channel) => {
+                if (mutedChannelIds.includes(channel.id)) {
+                    return sum + (serverMentionsByChannel[channel.id] ?? 0)
+                }
+                return sum + (serverUnreadByChannel[channel.id] ?? 0)
+            }, 0)
             if (total > 0) counts[server.id] = total
         }
         return counts
-    }, [channelsByServerId, mutedServerIds, serverUnreadByChannel, servers])
+    }, [channelsByServerId, mutedChannelIds, mutedServerIds, serverMentionsByChannel, serverUnreadByChannel, servers])
     const effectiveActiveId = displayActiveServerId !== undefined ? displayActiveServerId : activeServerId
 
     const [contextMenu, setContextMenu] = useState<{ id: string; x: number; y: number } | null>(null)

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -53,6 +53,12 @@ import {
   setPushNotificationsEnabled as persistPushNotificationsEnabled,
 } from '../pushNotifications'
 import {
+  getServerNotificationPreference,
+  SERVER_NOTIFICATION_PREFERENCE_OPTIONS,
+  setServerNotificationPreference as persistServerNotificationPreference,
+  type ServerNotificationPreference,
+} from '../notificationPreferences'
+import {
   DEFAULT_INPUT_DEVICE_LABEL,
   DEFAULT_OUTPUT_DEVICE_LABEL,
   enumerateVoiceDevices,
@@ -187,6 +193,7 @@ export default function UserBar() {
   const [soundEnabled, setSoundEnabled] = useState(true)
   const [pushNotificationsEnabled, setPushNotificationsEnabledState] = useState(true)
   const [pushNotificationPermission, setPushNotificationPermission] = useState<NotificationPermission | 'unsupported'>('unsupported')
+  const [serverNotificationPreference, setServerNotificationPreferenceState] = useState<ServerNotificationPreference>(() => getServerNotificationPreference())
   const [inputVolume, setInputVolume] = useState(DEFAULT_INPUT_VOLUME)
   const [outputVolume, setOutputVolume] = useState(DEFAULT_OUTPUT_VOLUME)
   const [inputDevices, setInputDevices] = useState<VoiceDeviceOption[]>([DEFAULT_INPUT_DEVICE_OPTION])
@@ -512,6 +519,7 @@ export default function UserBar() {
     const preset = localStorage.getItem(SPEAKING_PRESET_KEY)
     const profileRaw = localStorage.getItem(VOICE_INPUT_PROFILE_KEY)
     if (sound != null) setSoundEnabled(sound === '1')
+    setServerNotificationPreferenceState(getServerNotificationPreference())
     const enabled = getPushNotificationsEnabled()
     setPushNotificationsEnabledState(enabled)
     setPushNotificationPermission(getPushNotificationPermission())
@@ -1416,7 +1424,7 @@ export default function UserBar() {
                         ? 'This environment does not support system notifications.'
                         : pushNotificationPermission === 'denied'
                           ? 'Notifications are blocked in your browser or desktop shell.'
-                          : 'Show browser or desktop pop-up notifications for direct messages and friend requests.'}
+                          : 'Show browser or desktop pop-up notifications for direct messages, friend requests, and selected server messages.'}
                     </div>
                   </div>
                   <button
@@ -1445,6 +1453,29 @@ export default function UserBar() {
                           ? 'On'
                           : 'Off'}
                   </button>
+                </div>
+                <div className="user-setting-row user-setting-row--span-two">
+                  <div>
+                    <div className="user-setting-title">Server message notifications</div>
+                    <div className="user-setting-desc">
+                      Choose which server messages can play sounds or show browser notifications. Muted channels only alert for direct mentions.
+                    </div>
+                  </div>
+                  <select
+                    className="user-select"
+                    value={serverNotificationPreference}
+                    onChange={(e) => {
+                      const next = e.target.value as ServerNotificationPreference
+                      setServerNotificationPreferenceState(next)
+                      persistServerNotificationPreference(next)
+                    }}
+                  >
+                    {SERVER_NOTIFICATION_PREFERENCE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
                 <div className="user-setting-row user-setting-row--span-two">
                   <div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1399,6 +1399,15 @@ body {
   color: var(--text-primary);
 }
 
+.channel-item.is-muted {
+  color: var(--text-muted);
+}
+
+.channel-item.is-muted .channel-icon,
+.channel-item.is-muted .channel-name {
+  opacity: 0.62;
+}
+
 .channel-item--disabled {
   opacity: 0.56;
   cursor: not-allowed;
@@ -1426,6 +1435,18 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.channel-muted-indicator {
+  margin-left: auto;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.channel-muted-indicator + .channel-unread-badge {
+  margin-left: 4px;
 }
 
 .channel-unread-badge {

--- a/apps/web/src/notificationPreferences.test.ts
+++ b/apps/web/src/notificationPreferences.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  DEFAULT_SERVER_NOTIFICATION_PREFERENCE,
+  getServerNotificationPreference,
+  SERVER_NOTIFICATION_PREFERENCE_KEY,
+  setServerNotificationPreference,
+  shouldNotifyForServerMessage,
+  shouldTrackServerUnread,
+} from './notificationPreferences'
+
+describe('notification preferences', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults server notifications to mentions only', () => {
+    expect(getServerNotificationPreference()).toBe(DEFAULT_SERVER_NOTIFICATION_PREFERENCE)
+  })
+
+  it('persists the selected server notification preference', () => {
+    setServerNotificationPreference('all')
+    expect(localStorage.getItem(SERVER_NOTIFICATION_PREFERENCE_KEY)).toBe('all')
+    expect(getServerNotificationPreference()).toBe('all')
+  })
+
+  it('ignores invalid stored server notification preference values', () => {
+    localStorage.setItem(SERVER_NOTIFICATION_PREFERENCE_KEY, 'loud')
+    expect(getServerNotificationPreference()).toBe(DEFAULT_SERVER_NOTIFICATION_PREFERENCE)
+  })
+
+  it('tracks mentions in muted channels without tracking normal unread', () => {
+    expect(shouldTrackServerUnread({
+      isMention: false,
+      isMutedServer: false,
+      isMutedChannel: true,
+    })).toBe(false)
+
+    expect(shouldTrackServerUnread({
+      isMention: true,
+      isMutedServer: false,
+      isMutedChannel: true,
+    })).toBe(true)
+  })
+
+  it('suppresses server notifications based on mute state and preference', () => {
+    expect(shouldNotifyForServerMessage({
+      preference: 'mentions',
+      isMention: false,
+      isMutedServer: false,
+      isMutedChannel: false,
+    })).toBe(false)
+
+    expect(shouldNotifyForServerMessage({
+      preference: 'mentions',
+      isMention: true,
+      isMutedServer: false,
+      isMutedChannel: true,
+    })).toBe(true)
+
+    expect(shouldNotifyForServerMessage({
+      preference: 'all',
+      isMention: false,
+      isMutedServer: true,
+      isMutedChannel: false,
+    })).toBe(false)
+  })
+})

--- a/apps/web/src/notificationPreferences.ts
+++ b/apps/web/src/notificationPreferences.ts
@@ -1,0 +1,78 @@
+export type ServerNotificationPreference = 'all' | 'mentions' | 'none'
+
+export const SERVER_NOTIFICATION_PREFERENCE_KEY = 'voxpery-settings-server-notification-mode'
+export const DEFAULT_SERVER_NOTIFICATION_PREFERENCE: ServerNotificationPreference = 'mentions'
+
+export const SERVER_NOTIFICATION_PREFERENCE_OPTIONS: Array<{
+  value: ServerNotificationPreference
+  label: string
+  description: string
+}> = [
+  {
+    value: 'mentions',
+    label: 'Mentions only',
+    description: 'Notify for @mentions and @everyone in server channels.',
+  },
+  {
+    value: 'all',
+    label: 'All messages',
+    description: 'Notify for every unread server message unless the server or channel is muted.',
+  },
+  {
+    value: 'none',
+    label: 'Nothing',
+    description: 'Never show server message notifications.',
+  },
+]
+
+export function isServerNotificationPreference(value: unknown): value is ServerNotificationPreference {
+  return value === 'all' || value === 'mentions' || value === 'none'
+}
+
+export function getServerNotificationPreference(): ServerNotificationPreference {
+  try {
+    const stored = localStorage.getItem(SERVER_NOTIFICATION_PREFERENCE_KEY)
+    return isServerNotificationPreference(stored) ? stored : DEFAULT_SERVER_NOTIFICATION_PREFERENCE
+  } catch {
+    return DEFAULT_SERVER_NOTIFICATION_PREFERENCE
+  }
+}
+
+export function setServerNotificationPreference(preference: ServerNotificationPreference): void {
+  try {
+    localStorage.setItem(SERVER_NOTIFICATION_PREFERENCE_KEY, preference)
+  } catch {
+    // ignore storage failures
+  }
+}
+
+export function shouldTrackServerUnread({
+  isMention,
+  isMutedServer,
+  isMutedChannel,
+}: {
+  isMention: boolean
+  isMutedServer: boolean
+  isMutedChannel: boolean
+}): boolean {
+  if (isMutedServer) return false
+  if (isMutedChannel) return isMention
+  return true
+}
+
+export function shouldNotifyForServerMessage({
+  preference,
+  isMention,
+  isMutedServer,
+  isMutedChannel,
+}: {
+  preference: ServerNotificationPreference
+  isMention: boolean
+  isMutedServer: boolean
+  isMutedChannel: boolean
+}): boolean {
+  if (isMutedServer || preference === 'none') return false
+  if (isMutedChannel && !isMention) return false
+  if (preference === 'mentions' && !isMention) return false
+  return true
+}

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -30,6 +30,12 @@ import {
 } from '../draftAttachments'
 import { mergeRemoteWithRetryableLocals } from '../messageResilience'
 import { playMessageNotificationSound, shouldPlayNotificationSound } from '../notificationSound'
+import {
+    getServerNotificationPreference,
+    shouldNotifyForServerMessage,
+    shouldTrackServerUnread,
+} from '../notificationPreferences'
+import { shouldShowPushNotification, showPushNotification } from '../pushNotifications'
 import { createSavedMediaItem } from '../savedMedia'
 import { clearPendingSavedMediaJump, getPendingSavedMediaJump } from '../savedMediaJump'
 
@@ -270,6 +276,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         clearServerUnread,
         clearServerMention,
         mutedServerIds,
+        mutedChannelIds,
         setShowCreateServer, setShowJoinServer,
         showCreateServer, showJoinServer,
         openServerSettingsForServerId,
@@ -311,6 +318,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             clearServerUnread: s.clearServerUnread,
             clearServerMention: s.clearServerMention,
             mutedServerIds: s.mutedServerIds,
+            mutedChannelIds: s.mutedChannelIds,
             setShowCreateServer: s.setShowCreateServer,
             setShowJoinServer: s.setShowJoinServer,
             showCreateServer: s.showCreateServer,
@@ -1028,18 +1036,42 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                         }
                         if (incoming.author?.user_id !== user?.id) {
                             const incomingServerId = channelServerMapRef.current[incomingChannelId]
-                            if (!incomingServerId || !mutedServerIds.includes(incomingServerId)) {
+                            const isMention = messageMentionsUser(incoming.content, user?.username)
+                            const isMutedServer = !!incomingServerId && mutedServerIds.includes(incomingServerId)
+                            const isMutedChannel = mutedChannelIds.includes(incomingChannelId)
+                            if (shouldTrackServerUnread({ isMention, isMutedServer, isMutedChannel })) {
                                 incrementServerUnread(incomingChannelId)
-                                const isMention = messageMentionsUser(incoming.content, user?.username)
                                 if (isMention) {
                                     incrementServerMention(incomingChannelId)
                                 }
-                                if (
-                                    incomingServerId &&
-                                    isMention &&
-                                    shouldPlayNotificationSound(user?.status)
-                                ) {
+                            }
+
+                            if (
+                                incomingServerId
+                                && shouldNotifyForServerMessage({
+                                    preference: getServerNotificationPreference(),
+                                    isMention,
+                                    isMutedServer,
+                                    isMutedChannel,
+                                })
+                            ) {
+                                if (shouldPlayNotificationSound(user?.status)) {
                                     playMessageNotificationSound()
+                                }
+                                if (shouldShowPushNotification(user?.status)) {
+                                    const channelName =
+                                        channelsByServerId[incomingServerId]?.find((channel) => channel.id === incomingChannelId)?.name
+                                        ?? channels.find((channel) => channel.id === incomingChannelId)?.name
+                                        ?? 'channel'
+                                    showPushNotification({
+                                        title: isMention ? `Mention in #${channelName}` : `New message in #${channelName}`,
+                                        body: `${incoming.author?.username ?? 'Someone'}: ${incoming.content.slice(0, 120)}`,
+                                        tag: `server:${incomingServerId}:channel:${incomingChannelId}`,
+                                        onClick: () => {
+                                            setActiveServer(incomingServerId)
+                                            setActiveChannel(incomingChannelId)
+                                        },
+                                    })
                                 }
                             }
                         }
@@ -1220,7 +1252,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         } catch (err) {
             console.error('AppLayout WS handler error:', err)
         }
-    }, [incrementServerMention, incrementServerUnread, isViewActive, mutedServerIds, setChannels, user?.id, user?.status, user?.username])
+    }, [channels, channelsByServerId, incrementServerMention, incrementServerUnread, isViewActive, mutedChannelIds, mutedServerIds, setActiveChannel, setActiveServer, setChannels, user?.id, user?.status, user?.username])
 
     // Subscribe to WebSocket events (connection is managed globally by AppShell)
     useEffect(() => {

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -156,7 +156,12 @@ export default function AppShell() {
         if (state.mutedServerIds.includes(server.id)) return sum
         const serverChannels = state.channelsByServerId[server.id] ?? []
         const serverUnread = serverChannels.reduce(
-          (serverSum, channel) => serverSum + (state.serverUnreadByChannel[channel.id] ?? 0),
+          (serverSum, channel) => {
+            if (state.mutedChannelIds.includes(channel.id)) {
+              return serverSum + (state.serverMentionsByChannel[channel.id] ?? 0)
+            }
+            return serverSum + (state.serverUnreadByChannel[channel.id] ?? 0)
+          },
           0,
         )
         return sum + serverUnread
@@ -194,10 +199,12 @@ export default function AppShell() {
         state.dmUnread !== prev.dmUnread
         || state.dmChannels !== prev.dmChannels
         || state.serverUnreadByChannel !== prev.serverUnreadByChannel
+        || state.serverMentionsByChannel !== prev.serverMentionsByChannel
         || state.incomingRequestCount !== prev.incomingRequestCount
         || state.channelsByServerId !== prev.channelsByServerId
         || state.servers !== prev.servers
         || state.mutedServerIds !== prev.mutedServerIds
+        || state.mutedChannelIds !== prev.mutedChannelIds
       ) {
         syncUnreadFeedback(state)
       }

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -18,6 +18,9 @@ interface AppState {
     mutedServerIds: string[]
     toggleMutedServer: (serverId: string) => void
     setMutedServer: (serverId: string, muted: boolean) => void
+    mutedChannelIds: string[]
+    toggleMutedChannel: (channelId: string) => void
+    setMutedChannel: (channelId: string, muted: boolean) => void
 
     // Channels (current + cache per server for instant switch-back)
     channels: Channel[]
@@ -157,6 +160,42 @@ export const useAppStore = create<AppState>()(
                         ? (s.mutedServerIds.includes(serverId) ? s.mutedServerIds : [...s.mutedServerIds, serverId])
                         : s.mutedServerIds.filter((id) => id !== serverId),
                 })),
+            mutedChannelIds: [],
+            toggleMutedChannel: (channelId) =>
+                set((s) => {
+                    const isMuted = s.mutedChannelIds.includes(channelId)
+                    const serverUnreadByChannel = { ...s.serverUnreadByChannel }
+                    const serverMentionsByChannel = { ...s.serverMentionsByChannel }
+                    if (!isMuted) {
+                        delete serverUnreadByChannel[channelId]
+                        delete serverMentionsByChannel[channelId]
+                    }
+                    return {
+                        mutedChannelIds: isMuted
+                            ? s.mutedChannelIds.filter((id) => id !== channelId)
+                            : [...s.mutedChannelIds, channelId],
+                        serverUnreadByChannel,
+                        serverMentionsByChannel,
+                    }
+                }),
+            setMutedChannel: (channelId, muted) =>
+                set((s) => {
+                    const isMuted = s.mutedChannelIds.includes(channelId)
+                    if (isMuted === muted) return s
+                    const serverUnreadByChannel = { ...s.serverUnreadByChannel }
+                    const serverMentionsByChannel = { ...s.serverMentionsByChannel }
+                    if (muted) {
+                        delete serverUnreadByChannel[channelId]
+                        delete serverMentionsByChannel[channelId]
+                    }
+                    return {
+                        mutedChannelIds: muted
+                            ? [...s.mutedChannelIds, channelId]
+                            : s.mutedChannelIds.filter((id) => id !== channelId),
+                        serverUnreadByChannel,
+                        serverMentionsByChannel,
+                    }
+                }),
 
             // Channels
             channels: [],
@@ -368,6 +407,7 @@ export const useAppStore = create<AppState>()(
                 serverUnreadByChannel: s.serverUnreadByChannel,
                 serverMentionsByChannel: s.serverMentionsByChannel,
                 mutedServerIds: s.mutedServerIds,
+                mutedChannelIds: s.mutedChannelIds,
                 savedMediaByUserId: s.savedMediaByUserId,
                 unseenSavedMediaIdsByUserId: s.unseenSavedMediaIdsByUserId,
             }),

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -37,6 +37,7 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] AutoMod rule create/enable/disable/delete works and blocked messages do not persist or broadcast.
 - [ ] Raid protection records message bursts, invite spikes, and join burst signals in audit/moderation activity without exposing private secrets.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
+- [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 
 ## 4) Desktop Smoke Tests (mandatory)


### PR DESCRIPTION
## Summary

Adds unread, mention, and notification polish for server channels.

- Adds per-channel mute/unmute from the channel context menu
- Keeps muted channels quiet for normal unread and notification events
- Preserves mention visibility for muted channels
- Adds server message notification preferences in User Settings
- Updates server unread aggregation and desktop unread feedback to respect muted channels
- Adds browser/desktop notifications for selected server mention/message events
- Makes the server rules migration index creation idempotent
- Updates release smoke coverage for unread, mute, and notification behavior
- Adds unit coverage for server notification preference behavior

## Validation

- `cargo check --locked`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `graphify update .`

## Manual Testing

- Muted channel suppresses normal unread/notification behavior
- Mention in muted channel still shows mention/unread signal
- Unmuting channel restores normal unread behavior
