### PR TITLE
feat: implement camera stream preview attachment and cleanup in Activ…

### DIFF
--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -14,6 +14,7 @@ import {
   openDesktopMediaPermissionSettings,
 } from '../desktopMediaPermissions'
 import { ROUTES } from '../routes'
+import { attachMediaStreamPreview } from '../mediaStreamPreview'
 
 interface VoxperyTrack extends MediaStreamTrack {
   __voxpery_isCamera?: boolean
@@ -197,24 +198,46 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const perPeerAudioCtxRef = useRef<Map<string, { ctx: AudioContext; source: MediaElementAudioSourceNode; gain: GainNode }>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
+  const cameraPreviewCleanupRef = useRef<(() => void) | null>(null)
+  const cameraKeepaliveVideoRef = useRef<HTMLVideoElement | null>(null)
+  const cameraKeepaliveCleanupRef = useRef<(() => void) | null>(null)
   useEffect(() => {
     localStreamRef.current = state.localStream
   }, [state.localStream])
+  const attachCameraPreviewElement = useCallback((video: HTMLVideoElement | null) => {
+    cameraPreviewCleanupRef.current?.()
+    cameraPreviewCleanupRef.current = null
+    cameraVideoRef.current = video
+    if (!video || !state.cameraStream) return
+    cameraPreviewCleanupRef.current = attachMediaStreamPreview(video, state.cameraStream)
+  }, [state.cameraStream])
+  const attachCameraKeepaliveElement = useCallback((video: HTMLVideoElement | null) => {
+    cameraKeepaliveCleanupRef.current?.()
+    cameraKeepaliveCleanupRef.current = null
+    cameraKeepaliveVideoRef.current = video
+    if (!video || !state.cameraStream) return
+    cameraKeepaliveCleanupRef.current = attachMediaStreamPreview(video, state.cameraStream)
+  }, [state.cameraStream])
   useEffect(() => {
     const video = cameraVideoRef.current
     const stream = state.cameraStream
     if (!video || !stream) return
-    if (video.srcObject !== stream) {
-      video.srcObject = stream
-      const play = () => void video.play().catch(() => { })
-      video.addEventListener('loadeddata', play, { once: true })
-      video.addEventListener('loadedmetadata', play, { once: true })
-      if (video.readyState >= 2) play()
-      const t = setTimeout(play, 150)
-      return () => {
-        clearTimeout(t)
-        if (video.srcObject === stream) video.srcObject = null
-      }
+    cameraPreviewCleanupRef.current?.()
+    cameraPreviewCleanupRef.current = attachMediaStreamPreview(video, stream)
+    return () => {
+      cameraPreviewCleanupRef.current?.()
+      cameraPreviewCleanupRef.current = null
+    }
+  }, [state.cameraStream])
+  useEffect(() => {
+    const video = cameraKeepaliveVideoRef.current
+    const stream = state.cameraStream
+    if (!video || !stream) return
+    cameraKeepaliveCleanupRef.current?.()
+    cameraKeepaliveCleanupRef.current = attachMediaStreamPreview(video, stream)
+    return () => {
+      cameraKeepaliveCleanupRef.current?.()
+      cameraKeepaliveCleanupRef.current = null
     }
   }, [state.cameraStream])
   useEffect(() => {
@@ -920,6 +943,17 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
   return (
     <>
+      {state.cameraStream && (
+        <video
+          ref={attachCameraKeepaliveElement}
+          autoPlay
+          muted
+          playsInline
+          aria-hidden="true"
+          tabIndex={-1}
+          style={{ position: 'fixed', width: 1, height: 1, opacity: 0, pointerEvents: 'none', left: -9999, top: -9999 }}
+        />
+      )}
       {typeof document !== 'undefined' && createPortal(screenShareModal, document.body)}
       {typeof document !== 'undefined' && createPortal(cameraModal, document.body)}
       {showActiveCallBar && (
@@ -950,7 +984,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               )}
               {state.cameraStream && (
                 <div className="screen-share-preview voice-stage-share-tile camera-preview" data-fullscreen-key="camera" onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
-                  <video ref={(el) => { cameraVideoRef.current = el }} autoPlay muted playsInline style={{ objectFit: 'cover', width: '100%', height: '100%', backgroundColor: '#000' }} />
+                  <video ref={attachCameraPreviewElement} autoPlay muted playsInline style={{ objectFit: 'cover', width: '100%', height: '100%', backgroundColor: '#000' }} />
                   <div className="screen-share-info-overlay"><span className="screen-share-info-text">Camera · You</span></div>
                   <div className="screen-share-controls-bar">
                     <div className="screen-share-controls-left" />

--- a/apps/web/src/mediaStreamPreview.test.ts
+++ b/apps/web/src/mediaStreamPreview.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { attachMediaStreamPreview } from './mediaStreamPreview'
+
+function createVideoElement() {
+  const video = document.createElement('video')
+  Object.defineProperty(video, 'srcObject', {
+    configurable: true,
+    writable: true,
+    value: null,
+  })
+  Object.defineProperty(video, 'play', {
+    configurable: true,
+    value: vi.fn().mockResolvedValue(undefined),
+  })
+  return video
+}
+
+describe('attachMediaStreamPreview', () => {
+  it('attaches the stream, retries playback, and clears the preview on cleanup', () => {
+    vi.useFakeTimers()
+    const video = createVideoElement()
+    const stream = new MediaStream()
+
+    const cleanup = attachMediaStreamPreview(video, stream)
+
+    expect(video.srcObject).not.toBe(stream)
+    expect((video.srcObject as MediaStream).getTracks()).toEqual([])
+    vi.advanceTimersByTime(150)
+    expect(video.play).toHaveBeenCalled()
+
+    cleanup()
+
+    expect(video.srcObject).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('can attach the same live stream to a newly mounted video element', () => {
+    vi.useFakeTimers()
+    const stream = new MediaStream()
+    const firstVideo = createVideoElement()
+    const firstCleanup = attachMediaStreamPreview(firstVideo, stream)
+    firstCleanup()
+
+    const nextVideo = createVideoElement()
+    const nextCleanup = attachMediaStreamPreview(nextVideo, stream)
+
+    expect(nextVideo.srcObject).not.toBe(stream)
+    expect((nextVideo.srcObject as MediaStream).getTracks()).toEqual([])
+    vi.advanceTimersByTime(150)
+    expect(nextVideo.play).toHaveBeenCalled()
+
+    nextCleanup()
+    vi.useRealTimers()
+  })
+})

--- a/apps/web/src/mediaStreamPreview.ts
+++ b/apps/web/src/mediaStreamPreview.ts
@@ -1,0 +1,24 @@
+export function attachMediaStreamPreview(video: HTMLVideoElement, stream: MediaStream) {
+  const tracks = stream.getTracks()
+  const previewStream = typeof MediaStream === 'function' ? new MediaStream(tracks) : stream
+  video.srcObject = previewStream
+
+  const play = () => {
+    void video.play().catch(() => { })
+  }
+
+  video.addEventListener('loadeddata', play, { once: true })
+  video.addEventListener('loadedmetadata', play, { once: true })
+  if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) play()
+
+  const retryTimer = setTimeout(play, 150)
+
+  return () => {
+    clearTimeout(retryTimer)
+    video.removeEventListener('loadeddata', play)
+    video.removeEventListener('loadedmetadata', play)
+    if (video.srcObject === previewStream) {
+      video.srcObject = null
+    }
+  }
+}

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -31,6 +31,7 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Google OAuth login works.
 - [ ] Server/channel/category permission scenarios work.
 - [ ] Voice join/leave works.
+- [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.
 - [ ] Timed-out members cannot send/edit server-channel messages or add new reactions until cleared or expired.
 - [ ] Safety moderation view shows open reports, active timeouts, and recent raid events.


### PR DESCRIPTION
## Summary
- Reattach the local camera preview when the voice stage remounts after switching chats, DMs, or servers.
- Use a fresh `MediaStream` wrapper for preview playback so the browser does not keep rendering a stale black video sink.
- Keep a hidden muted camera preview sink alive while camera is enabled to preserve the local render pipeline across navigation.
- Add regression coverage for reattaching the same camera stream to a newly mounted preview element.
- Add the camera self-preview navigation scenario to the release smoke checklist.

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Manual: joined voice with two users, turned camera on, switched away from the active voice channel, returned, and confirmed the local self-preview recovers while the remote user keeps seeing the camera feed.

## Notes
- Backend was not changed.
- Closes the P1 voice/video local camera preview regression.
