### PR TITLE
feat: enhance voice quality diagnostics and cues

### DIFF
--- a/apps/server/src/routes/webrtc.rs
+++ b/apps/server/src/routes/webrtc.rs
@@ -154,15 +154,15 @@ async fn livekit_token(
     let ws_url = state
         .livekit_ws_url
         .clone()
-        .ok_or_else(|| AppError::Internal("LiveKit WS URL not configured".into()))?;
+        .ok_or_else(|| AppError::FeatureDisabled("Voice service is not configured.".into()))?;
     let api_key = state
         .livekit_api_key
         .clone()
-        .ok_or_else(|| AppError::Internal("LiveKit API key not configured".into()))?;
+        .ok_or_else(|| AppError::FeatureDisabled("Voice service is not configured.".into()))?;
     let api_secret = state
         .livekit_api_secret
         .clone()
-        .ok_or_else(|| AppError::Internal("LiveKit API secret not configured".into()))?;
+        .ok_or_else(|| AppError::FeatureDisabled("Voice service is not configured.".into()))?;
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -13,6 +13,11 @@ import {
   isMediaPermissionDeniedError,
   openDesktopMediaPermissionSettings,
 } from '../desktopMediaPermissions'
+import {
+  classifyVoiceError,
+  formatMetric,
+  getVoicePingLevel,
+} from '../webrtc/voiceDiagnostics'
 import { ROUTES } from '../routes'
 import { attachMediaStreamPreview } from '../mediaStreamPreview'
 
@@ -178,6 +183,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   })
   const [fullscreenTileKey, setFullscreenTileKey] = useState<string | null>(null)
+  const lastVoiceQualityWarningRef = useRef<string | null>(null)
   useEffect(() => {
     const onFullscreenChange = () => {
       const key = document.fullscreenElement?.getAttribute('data-fullscreen-key')
@@ -606,27 +612,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     if (state.lastError === lastShownErrorRef.current) return
     lastShownErrorRef.current = state.lastError
 
-    const raw = state.lastError
-    const lower = raw.toLowerCase()
-    let message = raw
-    let title = 'Voice action failed'
-    let level: 'error' | 'info' = 'error'
-    if (
-      lower.includes('voice access denied')
-      || lower.includes('missing required permission')
-      || lower.includes('forbidden')
-    ) {
-      title = 'Voice access denied'
-      level = 'info'
-      message = "You don't have permission to connect to this voice channel."
-    } else
-    if (lower.includes('notallowederror') || lower.includes('permission denied') || lower.includes('permission')) {
-      message = desktopMediaPermissionRecoveryMessage('microphone')
-    } else if (lower.includes('notfounderror') || lower.includes('device not found')) {
-      message = 'No microphone device detected. Connect a microphone and retry.'
-    } else if (lower.includes('websocket is not connected')) {
-      message = 'Voice service is reconnecting. Wait a few seconds and try again.'
-    }
+    const { level, title, message } = classifyVoiceError(state.lastError)
 
     pushToast({
       level,
@@ -864,46 +850,54 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const stageColumns = getStageColumns(totalStageTiles)
   const roomState = state.livekit.roomState
   const roomConnected = roomState === 'connected'
-  const roomConnecting = state.isJoining || roomState === 'connecting'
   const roomReconnecting = roomState === 'reconnecting'
   const joiningTargetChannelId = state.isJoining ? selectedVoiceChannelId : null
   const hasActiveVoiceSession = !!(state.joinedChannelId || joiningTargetChannelId)
-  const participantIds = new Set(channelParticipants.map((member) => member.user_id))
-  if (state.joinedChannelId && user?.id) participantIds.add(user.id)
-  const participantCount = participantIds.size
-  const participantLabel = `${participantCount}`
-  const connectionLabel = !hasActiveVoiceSession ? 'Offline' : roomConnecting ? 'Connecting...' : roomReconnecting ? 'Reconnecting...' : roomConnected ? `Connected (${participantLabel})` : 'Offline'
-  const connectionTitle = roomConnected ? 'Connected' : connectionLabel
   const isDisconnectVisualActive = hasActiveVoiceSession
   const isDisconnectPendingVisual = hasActiveVoiceSession && !roomConnected
-  const packetLossPct = state.diagnostics.packetLossPct
-  const networkJitterMs = state.diagnostics.jitterMs
-  const pingJitterMs = state.diagnostics.pingJitterMs
-  const qualityLevel =
-    !hasActiveVoiceSession || state.pingMs == null
-      ? 'unknown'
-      : (state.pingMs >= 220 || (packetLossPct ?? 0) >= 5 || (networkJitterMs ?? 0) >= 45)
-        ? 'poor'
-        : (state.pingMs >= 120 || (packetLossPct ?? 0) >= 2 || (networkJitterMs ?? 0) >= 25 || (pingJitterMs ?? 0) >= 35)
-          ? 'fair'
-          : 'good'
+  const pingLevel = getVoicePingLevel(hasActiveVoiceSession, state.pingMs)
   const pingStateClass =
-    qualityLevel === 'good'
+    pingLevel === 'good'
       ? 'is-good'
-      : qualityLevel === 'fair'
+      : pingLevel === 'fair'
         ? 'is-mid'
-        : qualityLevel === 'poor'
+        : pingLevel === 'poor'
           ? 'is-bad'
           : 'is-unknown'
-  const pingTooltip = !hasActiveVoiceSession
-    ? 'Quality: N/A'
-    : [
-      `Quality: ${qualityLevel === 'good' ? 'Good' : qualityLevel === 'fair' ? 'Fair' : qualityLevel === 'poor' ? 'Poor' : 'Measuring'}`,
-      state.pingMs != null ? `Ping: ${state.pingMs} ms` : null,
-    ]
-      .filter(Boolean)
-      .join(' • ')
-  const connectionStateClass = !hasActiveVoiceSession ? 'is-offline' : roomConnecting || roomReconnecting ? 'is-connecting' : roomConnected ? 'is-connected' : 'is-offline'
+  const pingDisplay = formatMetric(state.pingMs, 'ms', '...')
+  const pingAriaLabel = !hasActiveVoiceSession
+    ? 'Voice ping: not in voice'
+    : `Voice ping: ${pingDisplay}.`
+  const micControlLabel = muted
+    ? 'Unmute microphone'
+    : (serverMuted || serverDeafened)
+      ? 'Muted by server'
+      : 'Mute microphone'
+  const deafenControlLabel = deafened
+    ? 'Undeafen'
+    : serverDeafened
+      ? 'Deafened by server'
+      : 'Deafen'
+  const cameraControlLabel = state.cameraStream ? 'Turn off camera' : 'Turn on camera'
+  const screenShareControlLabel = state.isScreenSharing ? 'Stop sharing' : 'Share screen'
+  const disconnectControlLabel = isDisconnectVisualActive ? 'Leave voice channel' : 'Join voice channel'
+
+  useEffect(() => {
+    if (!hasActiveVoiceSession) {
+      lastVoiceQualityWarningRef.current = null
+      return
+    }
+
+    const warningKey = roomReconnecting ? 'reconnecting' : null
+    if (!warningKey || lastVoiceQualityWarningRef.current === warningKey) return
+    lastVoiceQualityWarningRef.current = warningKey
+
+    pushToast({
+      level: 'info',
+      title: 'Voice reconnecting',
+      message: 'Voice is reconnecting. Stay in the channel while Voxpery resyncs.',
+    })
+  }, [hasActiveVoiceSession, pushToast, roomReconnecting])
 
   const screenShareModal = showScreenShareConfirm && (
     <div className="modal-overlay modal-overlay--compact" onClick={() => setShowScreenShareConfirm(false)}>
@@ -1119,13 +1113,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   onClick={toggleMute}
                   disabled={!state.joinedChannelId || !state.localStream || deafened}
                   className={`callbar-control-btn ${muted ? 'is-off' : (serverMuted || serverDeafened) ? 'is-server-off' : ''}`}
-                  title={
-                    muted
-                      ? 'Unmute (self)'
-                      : (serverMuted || serverDeafened)
-                        ? 'Muted by server'
-                        : 'Mute'
-                  }
+                  aria-label={micControlLabel}
                 >
                   {(muted || serverMuted || serverDeafened) ? <MicOff size={16} /> : <Mic size={16} />}
                 </button>
@@ -1133,34 +1121,29 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   onClick={toggleDeafen}
                   disabled={!state.joinedChannelId}
                   className={`callbar-control-btn ${deafened ? 'is-off' : serverDeafened ? 'is-server-off' : ''}`}
-                  title={deafened ? 'Enable headphones (self)' : serverDeafened ? 'Deafened by server' : 'Disable headphones'}
+                  aria-label={deafenControlLabel}
                 >
                   {(deafened || serverDeafened) ? <VolumeX size={16} /> : <Volume2 size={16} />}
                 </button>
-                <button onClick={handleCamera} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.cameraStream ? 'is-live' : ''}`} title={state.cameraStream ? 'Turn off camera' : 'Turn on camera'}>
+                <button onClick={handleCamera} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.cameraStream ? 'is-live' : ''}`} aria-label={cameraControlLabel}>
                   {state.cameraStream ? <Video size={16} /> : <VideoOff size={16} />}
                 </button>
                 {!isMobileViewport && (
-                  <button onClick={handleScreenShare} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.isScreenSharing ? 'is-live' : ''}`} title={state.isScreenSharing ? 'Stop sharing' : 'Share screen'}>
+                  <button onClick={handleScreenShare} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.isScreenSharing ? 'is-live' : ''}`} aria-label={screenShareControlLabel}>
                     <Monitor size={16} />
                   </button>
                 )}
               </div>
               <div className="callbar-controls-right">
                 <span className="callbar-connection-inline">
-                  <span className={`active-call-subtitle active-call-subtitle-inline ${connectionStateClass}`} title={connectionTitle}>
-                    {(roomConnecting || roomReconnecting) && <span className="active-call-subtitle-spinner" />}
-                    {connectionLabel}
-                  </span>
-                  <span
-                    className={`callbar-ping-inline-icon ${pingStateClass}`}
-                    title={pingTooltip}
-                    aria-label={pingTooltip}
-                  >
-                    <Wifi size={14} />
+                  <span className={`callbar-ping-chip ${pingStateClass}`} role="status" aria-label={pingAriaLabel}>
+                    <span className="callbar-ping-inline-icon" aria-hidden="true">
+                      <Wifi size={14} />
+                    </span>
+                    <span className="callbar-ping-value">{pingDisplay}</span>
                   </span>
                 </span>
-                <button onClick={handleJoinLeave} disabled={state.isJoining} className={`callbar-control-btn callbar-control-btn-disconnect danger ${isDisconnectVisualActive ? 'is-live is-disconnect-state' : ''} ${isDisconnectPendingVisual ? 'is-disconnect-pending' : ''}`} title={isDisconnectVisualActive ? 'Leave voice channel' : 'Join voice channel'}>
+                <button onClick={handleJoinLeave} disabled={state.isJoining} className={`callbar-control-btn callbar-control-btn-disconnect danger ${isDisconnectVisualActive ? 'is-live is-disconnect-state' : ''} ${isDisconnectPendingVisual ? 'is-disconnect-pending' : ''}`} aria-label={disconnectControlLabel}>
                   <PhoneOff size={16} style={{ transform: isDisconnectVisualActive ? 'none' : 'rotate(135deg)' }} />
                 </button>
               </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -71,6 +71,7 @@
   --composer-bottom-gap: 0px;
   --composer-mobile-side-gap: 0px;
   --composer-mobile-bottom-gap: 0px;
+  --voice-stage-gap: 14px;
 
   /* Typography */
   --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -8385,7 +8386,7 @@ a.community-open-btn:hover {
   right: var(--member-sidebar-width);
   bottom: 0;
   height: 80px;              /* match user-bar-wrap height */
-  z-index: 85;
+  z-index: 130;
   pointer-events: none;
   padding: 0 12px;
   box-sizing: border-box;
@@ -8455,19 +8456,18 @@ a.community-open-btn:hover {
 
 .screen-share-stage {
   position: fixed;
-  left: calc(var(--server-bar-width) + var(--channel-sidebar-width) + 20px);
-  right: calc(var(--member-sidebar-width) + 20px);
+  left: calc(var(--server-bar-width) + var(--channel-sidebar-width) + var(--voice-stage-gap));
+  right: calc(var(--member-sidebar-width) + var(--voice-stage-gap));
   top: calc(var(--header-height) + 64px);
-  bottom: 84px;
+  bottom: calc(80px + var(--voice-stage-gap));
   z-index: 70;
   display: grid;
   grid-template-columns: repeat(1, minmax(0, 1fr));
   grid-auto-rows: minmax(180px, 1fr);
   gap: 12px;
-  align-content: start;
+  align-content: stretch;
   align-items: stretch;
   justify-items: stretch;
-  padding-top: 4px;
   pointer-events: none;
 }
 
@@ -8940,32 +8940,6 @@ a.community-open-btn:hover {
   justify-content: flex-end;
 }
 
-.active-call-subtitle-inline {
-  width: auto;
-  min-width: 76px;
-  max-width: 86px;
-  justify-content: flex-start;
-  font-size: 11px;
-  padding-left: 0;
-  line-height: 1.2;
-  flex: 0 0 auto;
-}
-
-.active-call-subtitle-inline::before {
-  display: none;
-}
-
-.active-call-subtitle-spinner {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 1.5px solid rgba(250, 166, 26, 0.28);
-  border-top-color: var(--text-warning);
-  border-right-color: var(--text-warning);
-  animation: callbarSpin 0.85s linear infinite;
-  flex: 0 0 auto;
-}
-
 .callbar-connection-inline {
   display: inline-flex;
   align-items: center;
@@ -8973,38 +8947,57 @@ a.community-open-btn:hover {
   flex: 0 0 auto;
 }
 
+.callbar-ping-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  min-width: 74px;
+  padding: 0 8px;
+  border-radius: 9px;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+
 .callbar-ping-inline-icon {
-    width: 30px;
-    height: 28px;
-    border-radius: 9px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    flex-shrink: 0;
-    cursor: default;
-    transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
-  }
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
 
-.callbar-ping-inline-icon:hover,
-.callbar-ping-inline-icon:focus-visible {
-    background: rgba(255, 255, 255, 0.12);
-    border-color: rgba(255, 255, 255, 0.22);
-    outline: none;
-  }
+.callbar-ping-value {
+  min-width: 32px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
 
-.callbar-ping-inline-icon.is-good {
+.callbar-ping-chip.is-good .callbar-ping-inline-icon,
+.callbar-ping-chip.is-good .callbar-ping-value {
   color: var(--text-positive);
 }
 
-.callbar-ping-inline-icon.is-mid {
+.callbar-ping-chip.is-mid .callbar-ping-inline-icon,
+.callbar-ping-chip.is-mid .callbar-ping-value {
   color: var(--text-warning);
 }
 
-.callbar-ping-inline-icon.is-bad {
+.callbar-ping-chip.is-bad .callbar-ping-inline-icon,
+.callbar-ping-chip.is-bad .callbar-ping-value {
   color: var(--text-danger);
+}
+
+.callbar-ping-chip.is-unknown .callbar-ping-inline-icon,
+.callbar-ping-chip.is-unknown .callbar-ping-value {
+  color: var(--text-muted);
 }
 
 .callbar-ping {
@@ -9026,92 +9019,6 @@ a.community-open-btn:hover {
   color: var(--text-danger);
 }
 
-/* Diagnostic stats row - better spacing and layout */
-.callbar-stats-row {
-  display: grid !important;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px;
-  padding: 5px;
-  margin-top: 0;
-  border-top: 0;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 6px;
-  width: 100%;
-  box-sizing: border-box;
-  min-height: auto;
-  flex-shrink: 0;
-}
-
-.callbar-ping-label {
-  display: block !important;
-  font-size: 11px;
-  color: var(--text-secondary);
-  font-weight: 600;
-  padding: 6px 10px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.06);
-  width: 100%;
-  box-sizing: border-box;
-  margin: 0;
-  line-height: 1.4;
-}
-
-.callbar-stats-row-mode {
-  display: flex !important;
-  align-items: center;
-  justify-content: space-between !important;
-  gap: 4px;
-  color: var(--text-primary);
-  font-size: 10px;
-  font-weight: 600;
-  padding: 6px 6px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.06);
-  width: 100%;
-  box-sizing: border-box;
-  margin: 0;
-  line-height: 1.4;
-  min-width: 0;
-}
-
-.callbar-stats-row-mode-value-only {
-  justify-content: center !important;
-}
-
-.callbar-stats-row-mode-wide {
-  grid-column: 1 / -1;
-}
-
-.callbar-stat-key {
-  color: var(--text-secondary) !important;
-  flex: 0 0 auto;
-  font-size: 9px;
-}
-
-.callbar-stat-value {
-  color: var(--text-primary) !important;
-  font-weight: 700;
-  font-size: 10px;
-  margin-left: auto;
-  text-align: right;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-
-.callbar-stat-value-mode {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.2;
-  margin-left: 0;
-  text-align: center;
-}
-
 .callbar-inline-stats-sep {
   color: var(--text-muted);
   font-weight: 500;
@@ -9128,6 +9035,7 @@ a.community-open-btn:hover {
   text-overflow: ellipsis;
   min-width: 0;
 }
+
 
 /* Center zone — media controls */
 .callbar-controls-center {
@@ -12577,7 +12485,7 @@ textarea {
 
   /* Screen share stage: no member sidebar on right */
   .screen-share-stage {
-    right: 16px;
+    right: var(--voice-stage-gap);
   }
 
   /* Topbar: truncate username */
@@ -13192,7 +13100,7 @@ textarea {
     padding: 0;
     background: transparent;
     border-top: none;
-    z-index: 124;
+    z-index: 130;
     width: auto;
     max-width: none;
   }
@@ -13304,10 +13212,6 @@ textarea {
     margin: 0 auto;
   }
 
-  .active-call-subtitle-inline {
-    display: none;
-  }
-
   .callbar-ping-inline-icon {
     width: 18px;
     height: 18px;
@@ -13339,14 +13243,6 @@ textarea {
   .callbar-control-btn svg {
     width: 13px;
     height: 13px;
-  }
-
-  .callbar-ping-popover {
-    right: -6px;
-    bottom: calc(100% + 6px);
-    min-width: 148px;
-    max-width: min(220px, calc(100vw - 32px));
-    padding: 7px 8px;
   }
 
   .home-main .social-content {

--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -245,14 +245,15 @@ export function useAudioEngine() {
         switch (kind) {
             case 'join':
                 playCueStack(ctx, [
-                    { from: 520, to: 620, durationSec: 0.1, peak: 0.016, type: 'sine', overtoneGain: 0.07, filterHz: 1600 },
-                    { from: 760, to: 900, offsetSec: 0.08, durationSec: 0.12, peak: 0.013, type: 'triangle', overtoneGain: 0.1, filterHz: 2200 },
+                    { from: 430, to: 520, durationSec: 0.085, peak: 0.02, type: 'triangle', overtoneGain: 0.12, filterHz: 1800, q: 0.9 },
+                    { from: 640, to: 780, offsetSec: 0.07, durationSec: 0.1, peak: 0.023, type: 'triangle', overtoneGain: 0.14, filterHz: 2400, q: 0.9 },
+                    { from: 960, to: 1160, offsetSec: 0.155, durationSec: 0.13, peak: 0.026, type: 'sine', overtoneGain: 0.08, filterHz: 3200, q: 0.75 },
                 ])
                 break
             case 'leave':
                 playCueStack(ctx, [
-                    { from: 760, to: 620, durationSec: 0.1, peak: 0.015, type: 'sine', overtoneGain: 0.06, filterHz: 1700 },
-                    { from: 480, to: 380, offsetSec: 0.08, durationSec: 0.125, peak: 0.012, type: 'triangle', overtoneGain: 0.08, filterHz: 1500 },
+                    { from: 820, to: 610, durationSec: 0.11, peak: 0.024, type: 'triangle', overtoneGain: 0.1, filterHz: 2300, q: 0.85 },
+                    { from: 430, to: 300, offsetSec: 0.095, durationSec: 0.16, peak: 0.022, type: 'sine', overtoneGain: 0.05, filterHz: 1200, q: 0.7 },
                 ])
                 break
             case 'mute':

--- a/apps/web/src/webrtc/hooks/useVoiceActivity.ts
+++ b/apps/web/src/webrtc/hooks/useVoiceActivity.ts
@@ -123,8 +123,10 @@ export function useVoiceActivity(options: {
         cleanupSilentTrack()
     }, [cleanupSilentTrack, localAudioTrackRef])
 
-    const applyVoiceActivityGate = useCallback((speaking: boolean) => {
-        voiceActivitySpeakingRef.current = speaking
+    const applyVoiceActivityGate = useCallback((speaking: boolean, options?: { updateSpeakingRef?: boolean }) => {
+        if (options?.updateSpeakingRef !== false) {
+            voiceActivitySpeakingRef.current = speaking
+        }
         const { mode } = getVoiceModeSettings()
         if (mode !== 'voice_activity') return
         // Don't override manual mute/deafen
@@ -298,6 +300,28 @@ export function useVoiceActivity(options: {
             window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged as EventListener)
         }
     }, [applyPushToTalkGate, applyVoiceActivityGate, getVoiceModeSettings, joinedChannelId])
+
+    useEffect(() => {
+        if (!joinedChannelId) return
+
+        const onVisibilityChange = () => {
+            const { mode } = getVoiceModeSettings()
+            if (mode !== 'voice_activity') return
+
+            if (document.hidden) {
+                // Browsers throttle requestAnimationFrame while backgrounded.
+                // Keep the real mic sender attached so voice activity mode does
+                // not get stuck publishing the silent gate track.
+                applyVoiceActivityGate(true, { updateSpeakingRef: false })
+                return
+            }
+
+            applyVoiceActivityGate(voiceActivitySpeakingRef.current)
+        }
+
+        document.addEventListener('visibilitychange', onVisibilityChange)
+        return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+    }, [applyVoiceActivityGate, getVoiceModeSettings, joinedChannelId])
 
     const stopLocalSpeakingMonitor = useCallback(() => {
         if (inlineMonitorIntervalRef.current != null) {

--- a/apps/web/src/webrtc/useWebRTCVoice.ts
+++ b/apps/web/src/webrtc/useWebRTCVoice.ts
@@ -386,12 +386,13 @@ export function useWebRTCVoice() {
 
     switch (kind) {
       case 'join':
-        playTone({ from: 640, to: 820, offsetSec: 0, durationSec: 0.075, wave: 'triangle', peak: 0.024 })
-        playTone({ from: 980, to: 1220, offsetSec: 0.085, durationSec: 0.1, wave: 'triangle', peak: 0.026 })
+        playTone({ from: 430, to: 520, offsetSec: 0, durationSec: 0.085, wave: 'triangle', peak: 0.02 })
+        playTone({ from: 640, to: 780, offsetSec: 0.07, durationSec: 0.1, wave: 'triangle', peak: 0.023 })
+        playTone({ from: 960, to: 1160, offsetSec: 0.155, durationSec: 0.13, wave: 'sine', peak: 0.026 })
         break
       case 'leave':
-        playTone({ from: 760, to: 600, offsetSec: 0, durationSec: 0.08, wave: 'triangle', peak: 0.024 })
-        playTone({ from: 520, to: 390, offsetSec: 0.085, durationSec: 0.11, wave: 'sine', peak: 0.023 })
+        playTone({ from: 820, to: 610, offsetSec: 0, durationSec: 0.11, wave: 'triangle', peak: 0.024 })
+        playTone({ from: 430, to: 300, offsetSec: 0.095, durationSec: 0.16, wave: 'sine', peak: 0.022 })
         break
       case 'mute':
         playTone({ from: 430, to: 350, offsetSec: 0, durationSec: 0.07, wave: 'square', peak: 0.019 })

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyVoiceError,
+  getVoiceNetworkQuality,
+  getVoiceQualityAdvice,
+  getVoicePingLevel,
+  voiceQualityLabel,
+} from './voiceDiagnostics'
+
+describe('voiceDiagnostics', () => {
+  it('classifies healthy, fair, and poor network quality', () => {
+    expect(getVoiceNetworkQuality({
+      hasActiveVoiceSession: true,
+      pingMs: 48,
+      packetLossPct: 0,
+      jitterMs: 4,
+      pingJitterMs: 6,
+    }).level).toBe('good')
+
+    expect(getVoiceNetworkQuality({
+      hasActiveVoiceSession: true,
+      pingMs: 130,
+      packetLossPct: 0.5,
+      jitterMs: 8,
+      pingJitterMs: 12,
+    }).level).toBe('fair')
+
+    expect(getVoiceNetworkQuality({
+      hasActiveVoiceSession: true,
+      pingMs: 80,
+      packetLossPct: 6,
+      jitterMs: 8,
+      pingJitterMs: 12,
+    }).level).toBe('poor')
+  })
+
+  it('colors the compact ping indicator from visible ping only', () => {
+    expect(getVoicePingLevel(false, null)).toBe('unknown')
+    expect(getVoicePingLevel(true, 2)).toBe('good')
+    expect(getVoicePingLevel(true, 140)).toBe('fair')
+    expect(getVoicePingLevel(true, 260)).toBe('poor')
+  })
+
+  it('classifies unavailable voice service errors without leaking raw internals', () => {
+    const result = classifyVoiceError(new Error('FEATURE_DISABLED:Voice service is not configured.'))
+
+    expect(result.title).toBe('Voice service unavailable')
+    expect(result.message).toContain('Voice media service is unavailable')
+  })
+
+  it('classifies permission and device failures', () => {
+    expect(classifyVoiceError(new Error('Microphone permission denied')).title).toBe('Microphone access required')
+    expect(classifyVoiceError(new Error('No microphone device detected')).title).toBe('No microphone detected')
+    expect(classifyVoiceError(new Error('Microphone is in use by another app')).title).toBe('Microphone is busy')
+  })
+
+  it('returns concise labels and advice', () => {
+    const summary = getVoiceNetworkQuality({
+      hasActiveVoiceSession: true,
+      pingMs: 240,
+      packetLossPct: 0,
+      jitterMs: 2,
+      pingJitterMs: 3,
+    })
+
+    expect(voiceQualityLabel(summary.level)).toBe('Poor voice quality')
+    expect(getVoiceQualityAdvice(summary, 'connected')).toContain('steadier connection')
+    expect(getVoiceQualityAdvice(summary, 'reconnecting')).toContain('reconnecting')
+  })
+})

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -1,0 +1,172 @@
+export type VoiceQualityLevel = 'unknown' | 'good' | 'fair' | 'poor'
+
+export interface VoiceNetworkMetrics {
+  hasActiveVoiceSession: boolean
+  pingMs: number | null
+  packetLossPct: number | null
+  jitterMs: number | null
+  pingJitterMs: number | null
+}
+
+export interface VoiceQualitySummary {
+  level: VoiceQualityLevel
+  reason: string
+}
+
+export interface VoiceErrorInfo {
+  level: 'error' | 'info'
+  title: string
+  message: string
+}
+
+export function getVoiceNetworkQuality(metrics: VoiceNetworkMetrics): VoiceQualitySummary {
+  const { hasActiveVoiceSession, pingMs, packetLossPct, jitterMs, pingJitterMs } = metrics
+  if (!hasActiveVoiceSession || pingMs == null) {
+    return { level: 'unknown', reason: 'Voice quality is being measured.' }
+  }
+
+  if (pingMs >= 220 || (packetLossPct ?? 0) >= 5 || (jitterMs ?? 0) >= 45) {
+    return { level: 'poor', reason: 'High latency, packet loss, or jitter may affect voice.' }
+  }
+
+  if (pingMs >= 120 || (packetLossPct ?? 0) >= 2 || (jitterMs ?? 0) >= 25 || (pingJitterMs ?? 0) >= 35) {
+    return { level: 'fair', reason: 'Voice is usable, but the connection is not ideal.' }
+  }
+
+  return { level: 'good', reason: 'Voice connection looks healthy.' }
+}
+
+export function getVoicePingLevel(hasActiveVoiceSession: boolean, pingMs: number | null): VoiceQualityLevel {
+  if (!hasActiveVoiceSession || pingMs == null) return 'unknown'
+  if (pingMs >= 220) return 'poor'
+  if (pingMs >= 120) return 'fair'
+  return 'good'
+}
+
+export function voiceQualityLabel(level: VoiceQualityLevel): string {
+  if (level === 'good') return 'Good voice quality'
+  if (level === 'fair') return 'Fair voice quality'
+  if (level === 'poor') return 'Poor voice quality'
+  return 'Measuring voice quality'
+}
+
+export function formatMetric(value: number | null, suffix: string, fallback = 'Measuring'): string {
+  return value == null ? fallback : `${value}${suffix}`
+}
+
+export function getVoiceQualityAdvice(
+  summary: VoiceQualitySummary,
+  roomState: string,
+): string {
+  if (roomState === 'reconnecting') {
+    return 'Voice is reconnecting. Stay in the channel; Voxpery will resync when the network returns.'
+  }
+  if (summary.level === 'poor') {
+    return 'Try a steadier connection, close heavy downloads, or move closer to your router.'
+  }
+  if (summary.level === 'fair') {
+    return 'If audio breaks up, reduce network load or switch to a more stable connection.'
+  }
+  if (summary.level === 'good') {
+    return 'No action needed.'
+  }
+  return 'Stats appear after the media room connects and the first samples arrive.'
+}
+
+export function buildVoiceDiagnosticRows(metrics: VoiceNetworkMetrics, voiceMode: string) {
+  return [
+    { label: 'Ping', value: formatMetric(metrics.pingMs, ' ms') },
+    { label: 'Loss', value: formatMetric(metrics.packetLossPct, '%') },
+    { label: 'Jitter', value: formatMetric(metrics.jitterMs, ' ms') },
+    { label: 'Mode', value: voiceMode === 'push_to_talk' ? 'Push to talk' : 'Voice activity' },
+  ]
+}
+
+export function classifyVoiceError(err: unknown): VoiceErrorInfo {
+  const raw = err instanceof Error ? err.message : String(err ?? '')
+  const lower = raw.toLowerCase()
+
+  if (
+    lower.includes('voice access denied') ||
+    lower.includes('missing required permission') ||
+    lower.includes('forbidden')
+  ) {
+    return {
+      level: 'info',
+      title: 'Voice access denied',
+      message: "You don't have permission to connect to this voice channel.",
+    }
+  }
+
+  if (
+    lower.includes('feature_disabled') ||
+    lower.includes('voice service is not configured') ||
+    (lower.includes('livekit') && lower.includes('not configured')) ||
+    lower.includes('internal server error')
+  ) {
+    return {
+      level: 'error',
+      title: 'Voice service unavailable',
+      message: 'Voice media service is unavailable right now. Try again after the server voice configuration is fixed.',
+    }
+  }
+
+  if (lower.includes('connection_error') || lower.includes('websocket is not connected')) {
+    return {
+      level: 'error',
+      title: 'Voice service reconnecting',
+      message: 'The app is reconnecting to the server. Wait a few seconds and try joining voice again.',
+    }
+  }
+
+  if (lower.includes('timeout')) {
+    return {
+      level: 'error',
+      title: 'Voice connection timed out',
+      message: 'Voxpery could not reach the voice media service in time. Check your network and retry.',
+    }
+  }
+
+  if (lower.includes('permission denied') || lower.includes('notallowederror') || lower.includes('microphone permission')) {
+    return {
+      level: 'error',
+      title: 'Microphone access required',
+      message: 'Allow microphone access in your browser or system settings, then retry voice.',
+    }
+  }
+
+  if (lower.includes('notfounderror') || lower.includes('device not found') || lower.includes('no microphone')) {
+    return {
+      level: 'error',
+      title: 'No microphone detected',
+      message: 'Connect a microphone or choose another input device, then retry voice.',
+    }
+  }
+
+  if (lower.includes('notreadableerror') || lower.includes('in use by another app') || lower.includes('microphone is in use')) {
+    return {
+      level: 'error',
+      title: 'Microphone is busy',
+      message: 'Close other apps using the microphone, then retry voice.',
+    }
+  }
+
+  if (
+    lower.includes('ice') ||
+    lower.includes('failed to connect') ||
+    lower.includes('network') ||
+    lower.includes('disconnected')
+  ) {
+    return {
+      level: 'error',
+      title: 'Voice connection failed',
+      message: 'The voice media connection failed. Check your network, VPN, firewall, or LiveKit reachability and retry.',
+    }
+  }
+
+  return {
+    level: 'error',
+    title: 'Voice action failed',
+    message: raw || 'Voice action failed. Try again in a few seconds.',
+  }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -228,6 +228,7 @@ Attachment note:
 - `GET /api/webrtc/turn-credentials`
 - `GET /api/webrtc/livekit-token?channel_id=<voice-channel-uuid>`
   - Requires effective voice access (`VIEW_SERVER` + `CONNECT_VOICE` on the target channel).
+  - Returns `503` with `FEATURE_DISABLED` when the voice media service is not configured.
 
 ## Health
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -58,6 +58,9 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Linux desktop test host has `xdg-desktop-portal` + (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` running.
 - [ ] First voice join shows OS/browser microphone permission prompt when needed.
 - [ ] Voice join succeeds after permission grant.
+- [ ] Active call bar quality indicator shows a colored Wi-Fi icon and current ping while connected, and the visible color matches the visible ping value.
+- [ ] Voice join and leave cues are distinct enough to tell whether a member entered or left the channel.
+- [ ] Reconnecting state shows a clear one-time warning without disconnecting the user from the channel.
 - [ ] Denying desktop microphone permission shows recovery guidance, opens OS privacy settings from Voice & Audio, and succeeds after permission is restored and retried.
 - [ ] Denying desktop camera permission shows OS-specific recovery guidance, opens OS privacy settings when supported, and succeeds after permission is restored and retried.
 - [ ] Voice settings mic test with noise suppression on and `Noisy room` selected does not pass normal keyboard, mouse, fan, or breath noise as speech.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -39,8 +39,8 @@ Microphone -> getUserMedia -> AudioContext pipeline -> LiveKit Room -> SFU -> Re
 
 - `TrackSubscribed`: Remote peer published audio/video -> add to `remoteStreams`
 - `TrackUnsubscribed`: Remote peer unpublished -> remove from `remoteStreams`
-- `ParticipantConnected`: New user joined -> play join sound
-- `ParticipantDisconnected`: User left -> play leave sound, cleanup
+- `ParticipantConnected`: New user joined -> play a distinct rising join cue
+- `ParticipantDisconnected`: User left -> play a distinct descending leave cue, cleanup
 - `Reconnecting`/`Reconnected`: Network blip -> re-subscribe tracks, refresh stats
 - `Disconnected`: Lost connection -> backend WS resync handles re-join
 
@@ -232,6 +232,28 @@ await room.localParticipant.publishTrack(videoTrack, {
 3. For camera denial, open the OS camera privacy settings, allow Voxpery or desktop apps to use the camera, then retry the camera toggle.
 4. Restart Voxpery if the OS requires a restart before WebView permissions refresh.
 5. Return to Voxpery and click `Retry mic access` or retry the camera action.
+
+### Voice quality diagnostics
+
+The active call bar shows a compact voice quality indicator while connected. The indicator combines a colored Wi-Fi icon with the current ping so users can understand call health at a glance. The visible chip color follows the visible ping value, while internal diagnostics can still classify the call as good, fair, poor, or measuring from ping, packet loss, and jitter.
+
+- Poor internal quality means latency, packet loss, or jitter crossed the diagnostic threshold.
+- Reconnecting state shows a short warning and keeps the user in the channel while LiveKit/WebSocket state resyncs.
+- Poor internal quality does not show a proactive toast on its own; the compact indicator should stay calm unless the room is reconnecting.
+- Missing LiveKit configuration returns `FEATURE_DISABLED` from the token endpoint so the client can show a clear "voice service unavailable" message instead of a generic join failure.
+
+When debugging a production voice report, capture:
+
+1. The call bar ping color and visible ping.
+2. Whether the room was connected, connecting, or reconnecting.
+3. Whether the user recently changed microphone, camera, VPN, firewall, or network.
+
+### Voice cues
+
+- Join and leave cues are intentionally different so members can identify someone entering or leaving without watching the channel list.
+- Join uses a short rising three-note motif.
+- Leave uses a lower descending two-note motif.
+- Mute, unmute, deafen, and undeafen keep shorter local-only cues.
 
 ### Echo or feedback
 


### PR DESCRIPTION
## Summary

Polishes the voice call experience with clearer connection feedback, calmer diagnostics, and more reliable voice behavior.

## Related

Closes the current voice diagnostics/polish task.

## Changes

- Added shared voice diagnostics helpers and unit coverage for voice error handling and ping quality states.
- Improved voice join error messages, including clearer handling when LiveKit voice service is not configured.
- Simplified the active call bar by removing the redundant `Connected (n)` label and showing only a compact Wi-Fi + ping indicator.
- Made the ping indicator color match the visible ping value instead of hidden packet loss/jitter metrics.
- Removed noisy hover tooltips and the oversized diagnostic popover from call controls.
- Kept proactive warnings limited to actual reconnecting state so users are not alarmed by transient quality samples.
- Fixed voice activity behavior when the browser window is backgrounded.
- Updated join/leave voice cues to be more distinct.
- Adjusted voice stage spacing so tiles sit evenly inside the available call area.
- Updated voice API/system docs and release smoke checklist.

## Validation

```bash
npm.cmd --prefix apps/web run lint
npm.cmd --prefix apps/web run test:run
npm.cmd --prefix apps/web run build
git diff --check
graphify update .
