### PR TITLE
feat: implement message reconciliation and enhance mobile chat layout

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13246,7 +13246,11 @@ textarea {
   }
 
   .home-main .social-content {
+    overflow-x: hidden;
+    overflow-y: auto;
     padding-bottom: calc(12px + var(--mobile-bottom-dock-height) + var(--mobile-voice-callbar-offset) + env(safe-area-inset-bottom, 0px));
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
 
   .home-main-dm .social-content-dm {

--- a/apps/web/src/messageResilience.test.ts
+++ b/apps/web/src/messageResilience.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { reconcileConfirmedMessage } from './messageResilience'
+
+type TestMessage = {
+  id: string
+  created_at: string
+  content: string
+  clientId?: string
+  clientStatus?: 'sending' | 'failed'
+}
+
+const created_at = '2026-05-12T12:00:00.000Z'
+
+describe('messageResilience', () => {
+  it('replaces an optimistic message with the confirmed server message id', () => {
+    const optimistic: TestMessage = {
+      id: 'local-client-1',
+      clientId: 'client-1',
+      clientStatus: 'sending',
+      content: 'hello',
+      created_at,
+    }
+    const confirmed: TestMessage = {
+      id: 'server-1',
+      content: 'hello',
+      created_at,
+    }
+
+    expect(reconcileConfirmedMessage([optimistic], 'client-1', confirmed)).toEqual([confirmed])
+  })
+
+  it('removes the optimistic copy if realtime already inserted the confirmed message', () => {
+    const optimistic: TestMessage = {
+      id: 'local-client-1',
+      clientId: 'client-1',
+      clientStatus: 'sending',
+      content: 'hello',
+      created_at,
+    }
+    const confirmed: TestMessage = {
+      id: 'server-1',
+      content: 'hello',
+      created_at,
+    }
+
+    expect(reconcileConfirmedMessage([optimistic, confirmed], 'client-1', confirmed)).toEqual([confirmed])
+  })
+})

--- a/apps/web/src/messageResilience.ts
+++ b/apps/web/src/messageResilience.ts
@@ -33,3 +33,30 @@ export function mergeRemoteWithRetryableLocals<T extends RetryableMessage>(remot
   merged.sort((a, b) => toTimestamp(a.created_at) - toTimestamp(b.created_at))
   return merged
 }
+
+export function reconcileConfirmedMessage<T extends RetryableMessage>(
+  current: T[],
+  clientId: string,
+  confirmed: T,
+): T[] {
+  const confirmedIdx = current.findIndex((message) => message.id === confirmed.id)
+  const optimisticIdx = current.findIndex((message) => message.clientId === clientId)
+
+  if (confirmedIdx >= 0 && optimisticIdx >= 0 && confirmedIdx !== optimisticIdx) {
+    return current
+      .filter((_, index) => index !== optimisticIdx)
+      .map((message) => (message.id === confirmed.id ? confirmed : message))
+  }
+
+  if (confirmedIdx >= 0) {
+    return current.map((message) => (message.id === confirmed.id ? confirmed : message))
+  }
+
+  if (optimisticIdx >= 0) {
+    const next = [...current]
+    next[optimisticIdx] = confirmed
+    return next
+  }
+
+  return [...current, confirmed]
+}

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -30,7 +30,7 @@ import {
     setDraftAttachmentUploading,
     type DraftAttachmentItem,
 } from '../draftAttachments'
-import { mergeRemoteWithRetryableLocals } from '../messageResilience'
+import { mergeRemoteWithRetryableLocals, reconcileConfirmedMessage } from '../messageResilience'
 import { playMessageNotificationSound, shouldPlayNotificationSound } from '../notificationSound'
 import {
     getServerNotificationPreference,
@@ -1389,14 +1389,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         try {
             const msg = await messageApi.send(channelId, content, attachments, token)
             const applySentMessage = (current: UiMessage[]) => {
-                if (current.some((m) => m.id === msg.id)) return current
-                const idx = current.findIndex((m) => m.clientId === clientId)
-                if (idx < 0) {
-                    return [...current, msg]
-                }
-                const next = [...current]
-                next[idx] = { ...msg, id: next[idx].id }
-                return next
+                return reconcileConfirmedMessage(current, clientId, msg)
             }
             if (activeChannelIdRef.current === channelId) {
                 setMessages((prev) => {

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -29,7 +29,7 @@ import {
   setDraftAttachmentUploading,
   type DraftAttachmentItem,
 } from '../draftAttachments'
-import { mergeRemoteWithRetryableLocals } from '../messageResilience'
+import { mergeRemoteWithRetryableLocals, reconcileConfirmedMessage } from '../messageResilience'
 import { createSavedMediaItem } from '../savedMedia'
 import { clearPendingSavedMediaJump, getPendingSavedMediaJump, setPendingSavedMediaJump } from '../savedMediaJump'
 import { type SocialView, getPersistedSocialView, setPersistedSocialView } from '../socialView'
@@ -859,14 +859,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       const msg = await dmApi.sendMessage(channelId, content, attachmentsToSend, token)
       clearDmUnread(channelId)
       const applySentDm = (current: UiDmMessage[]) => {
-        if (current.some((m) => m.id === msg.id)) return current
-        const idx = current.findIndex((m) => m.clientId === clientId)
-        if (idx < 0) {
-          return [...current, msg]
-        }
-        const next = [...current]
-        next[idx] = msg
-        return next
+        return reconcileConfirmedMessage(current, clientId, msg)
       }
       if (activeDmChannelIdRef.current === channelId) {
         setDmMessages((prev) => {

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -34,6 +34,8 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.
 - [ ] Timed-out members cannot send/edit server-channel messages or add new reactions until cleared or expired.
+- [ ] Mobile server chat shows one visible message after send, including after the API response and WebSocket echo both arrive.
+- [ ] Mobile Social/Friends list scrolls when the visible friend or request list exceeds the viewport.
 - [ ] Safety moderation view shows open reports, active timeouts, and recent raid events.
 - [ ] Server Settings opens and remains scrollable on desktop; mobile still shows the desktop-only guidance instead of a broken settings modal.
 - [ ] AutoMod rule create/edit/enable/disable/delete works and blocked messages do not persist or broadcast.


### PR DESCRIPTION
## Summary

Fixes two mobile regressions: Social/Friends scrolling on mobile and duplicate-looking optimistic chat messages after sending.

## Related

Closes mobile friends list scrolling regression.
Closes mobile chat send deduplication regression on optimistic messages.

## Changes

- Added a shared `reconcileConfirmedMessage` helper for replacing optimistic messages with confirmed server messages.
- Updated server chat and DM send flows to keep the confirmed server message ID, preventing later WebSocket echoes from rendering a duplicate.
- Added regression tests for optimistic message reconciliation when API and realtime events arrive in different orders.
- Restored mobile Social/Friends scrolling with explicit touch-friendly overflow behavior.
- Added mobile chat/social regression checks to the release smoke checklist.

## Validation

npm.cmd --prefix apps/web run lint
npm.cmd --prefix apps/web run test:run
npm.cmd --prefix apps/web run build
git diff --check
graphify update .

## Security / Privacy Impact

- [x] No new secrets added
- [x] No auth/permission regression
- [x] No sensitive data added to logs

## Docs

- [x] API docs updated if endpoint/behavior changed
- [x] DB docs updated if schema/migration changed
- [x] Security docs updated if auth/permission/security behavior changed

## Checklist

- [x] CI passes locally where applicable
- [x] Backward compatibility considered
- [x] Tests added/updated where needed