### PR TITLE
feat: implement RNNoise integration for enhanced voice suppression an…

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'voxpery-static-v1'
+const CACHE_NAME = 'voxpery-static-v2'
 const PRECACHE_URLS = ['/manifest.webmanifest', '/pwa-192.png', '/pwa-512.png']
 
 self.addEventListener('install', (event) => {
@@ -26,6 +26,7 @@ function isCacheableStaticAsset(request) {
   if (request.mode === 'navigate') return false
   if (url.pathname.startsWith('/api/') || url.pathname === '/ws') return false
   if (url.pathname === '/' || url.pathname.endsWith('.html')) return false
+  if (url.pathname === '/assets/rnnoise-worklet.js') return false
 
   return (
     url.pathname.startsWith('/assets/') ||

--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -7,6 +7,7 @@ import {
     shouldUseAggressiveVoiceIsolation,
     type VoiceSuppressionTuning,
 } from '../voiceInputProfile'
+import { updateVoiceDiagnostics } from '../voiceDiagnostics'
 
 const SOUND_KEY = 'voxpery-settings-sound-enabled'
 const NOISE_SUPPRESSION_KEY = 'voxpery-settings-noise-suppression'
@@ -69,6 +70,9 @@ function getSpeechIsolationTarget(
     const boomyNoise = lowNoiseDb > bodyDb + 2.5
     const clickyNoise = highNoiseDb > presenceDb + 2.5
 
+    if (aggressiveIsolation && clickyNoise) return quietish ? 0.18 : 0.42
+    if (aggressiveIsolation && boomyNoise && quietish) return 0.24
+
     if (!speechLike) {
         if (rms <= lowFloorThr || quietish) return aggressiveIsolation ? 0.035 : 0.16
         return clickyNoise || boomyNoise
@@ -91,6 +95,7 @@ function isLikelySpeechFrame(
     frequencyData: Float32Array,
     sampleRate: number,
     fftSize: number,
+    aggressiveIsolation: boolean,
 ): boolean {
     const presenceDb = getBandAverageDb(frequencyData, sampleRate, fftSize, 220, 1400)
     const speechBodyDb = getBandAverageDb(frequencyData, sampleRate, fftSize, 180, 2200)
@@ -106,7 +111,13 @@ function isLikelySpeechFrame(
         highNoiseDb > presenceDb + 3.2
         && highNoiseDb > speechBodyDb + 4.2
         && lowNoiseDb < speechBodyDb - 6
-    return score >= -2.8 && !clicky
+    const noiseDominant =
+        highNoiseDb > presenceDb + 2.2
+        && highNoiseDb > speechBodyDb + 2.8
+        && upperSpeechDb < highNoiseDb + 1.2
+    return score >= (aggressiveIsolation ? -0.8 : -2.8)
+        && !clicky
+        && (!aggressiveIsolation || !noiseDominant)
 }
 
 export type VoiceCueKind = 'join' | 'leave' | 'mute' | 'unmute' | 'deafen' | 'undeafen'
@@ -136,6 +147,13 @@ function buildSuppressionConfig(
     const profile = getStoredVoiceInputProfile()
     const aggressiveIsolation = shouldUseAggressiveVoiceIsolation(profile, noiseSuppressionEnabled)
     const suppressionTuning = getStoredVoiceSuppressionTuning(noiseSuppressionEnabled)
+
+    updateVoiceDiagnostics({
+        noiseSuppressionEnabled,
+        voiceInputProfile: profile,
+        suppressionTuning,
+        aggressiveIsolation,
+    })
 
     return {
         aggressiveIsolation,
@@ -337,6 +355,9 @@ export function useAudioEngine() {
         rnnoiseRef.current?.destroy()
         const rnnoise = await createRnnoiseNode(ctx, noiseSuppressionEnabled)
         rnnoiseRef.current = rnnoise
+        if (noiseSuppressionEnabled) {
+            await rnnoise.waitUntilReady()
+        }
 
         // Tame sharp keyboard peaks before the final send gain.
         const transientCompressor = ctx.createDynamicsCompressor()
@@ -517,6 +538,7 @@ export function useAudioEngine() {
                         frequencyBuffer,
                         ctx.sampleRate,
                         refinementAnalyser.fftSize,
+                        liveSuppressionConfig.aggressiveIsolation,
                     )
                     // When we detect speech, avoid over-attenuating the send floor.
                     // This keeps syllables intact while retaining strong suppression in non-speech frames.

--- a/apps/web/src/webrtc/rnnoise-worklet-processor.ts
+++ b/apps/web/src/webrtc/rnnoise-worklet-processor.ts
@@ -47,6 +47,8 @@ class RnnoiseProcessor extends AudioWorkletProcessor {
   private denoiseState: DenoiseState | null = null
   private isEnabled: boolean
   private destroyed = false
+  private loadFailed = false
+  private processFailureReported = false
 
   /* ring buffers (zero-alloc in the hot path) */
   private readonly inRing  = new Float32Array(RING_SIZE)
@@ -70,6 +72,7 @@ class RnnoiseProcessor extends AudioWorkletProcessor {
       if (data.type === 'set-enabled') {
         this.isEnabled = data.enabled ?? true
         if (this.isEnabled && !this.denoiseState && !this.destroyed) {
+          this.loadFailed = false
           void this.loadWasm()
         }
       } else if (data.type === 'destroy') {
@@ -87,12 +90,18 @@ class RnnoiseProcessor extends AudioWorkletProcessor {
 
   private async loadWasm(): Promise<void> {
     try {
+      this.loadFailed = false
       const rnnoise = await Rnnoise.load()
       if (!this.destroyed) {
         this.denoiseState = rnnoise.createDenoiseState()
         this.port.postMessage({ type: 'ready' })
       }
     } catch (err) {
+      this.loadFailed = true
+      this.port.postMessage({
+        type: 'load-failed',
+        message: err instanceof Error ? err.message : 'RNNoise WASM failed to load',
+      })
       console.error('[RnnoiseProcessor] Failed to load WASM:', err)
     }
   }
@@ -114,9 +123,15 @@ class RnnoiseProcessor extends AudioWorkletProcessor {
     if (!input || !output) return true
 
     try {
-      /* passthrough when disabled or WASM not yet loaded */
-      if (!this.isEnabled || !this.denoiseState) {
+      /* passthrough when disabled or after a confirmed load failure */
+      if (!this.isEnabled || this.loadFailed) {
         output.set(input)
+        return true
+      }
+
+      /* avoid leaking raw background noise during the short WASM startup window */
+      if (!this.denoiseState) {
+        output.fill(0)
         return true
       }
 
@@ -160,6 +175,13 @@ class RnnoiseProcessor extends AudioWorkletProcessor {
         output[i] = 0
       }
     } catch (err) {
+      if (!this.processFailureReported) {
+        this.processFailureReported = true
+        this.port.postMessage({
+          type: 'process-failed',
+          message: err instanceof Error ? err.message : 'RNNoise process loop failed',
+        })
+      }
       console.error('[RnnoiseProcessor] Exception in process loop:', err)
       output.set(input)
     }

--- a/apps/web/src/webrtc/rnnoise.ts
+++ b/apps/web/src/webrtc/rnnoise.ts
@@ -2,16 +2,16 @@
  * RNNoise WASM integration for ML-based noise suppression.
  *
  * Uses an AudioWorkletNode to feed mic audio through RNNoise's
- * denoiser in 480-sample frames (10 ms at 48 kHz).  A ring-buffer
+ * denoiser in 480-sample frames (10 ms at 48 kHz). A ring buffer
  * inside the worklet processor bridges the 128-sample render quanta
  * with the 480-frame size so no audio is lost or sped up.
  *
- * Adds ~10 ms latency — imperceptible for voice chat.
+ * Adds about 10 ms latency, which is imperceptible for voice chat.
  */
 
-/* ── module-level worklet registration ──────────────────────────── */
+import { updateVoiceDiagnostics, type RnnoiseRuntimeStatus } from './voiceDiagnostics'
 
-// Prod: define injects URL so main bundle has no worklet dependency (no extra chunk). Dev: Vite serves from source.
+// Prod: define injects URL so main bundle has no worklet dependency. Dev: Vite serves from source.
 declare const __RNNOISE_PROCESSOR_URL__: string | undefined
 const processorUrl =
   typeof __RNNOISE_PROCESSOR_URL__ !== 'undefined'
@@ -22,12 +22,13 @@ const processorUrl =
 
 /**
  * Tracks whether addModule has already been called for a given
- * AudioContext so we don't re-register the processor needlessly.
+ * AudioContext so we do not re-register the processor needlessly.
  */
 const registeredContexts = new WeakSet<AudioContext>()
 
 async function ensureWorkletRegistered(ctx: AudioContext): Promise<void> {
   if (registeredContexts.has(ctx)) return
+  updateVoiceDiagnostics({ rnnoiseWorkletUrl: processorUrl })
   await ctx.audioWorklet.addModule(processorUrl)
   registeredContexts.add(ctx)
 }
@@ -36,9 +37,9 @@ let preloadStarted = false
 
 /**
  * Preload the worklet script (fetch + parse) so the first voice join is faster.
- * Call after a user gesture (e.g. first click) or on voice channel hover. Uses a temporary
- * AudioContext then closes it; the script is cached so the real join only pays parse/compile cost.
- * Idempotent: only runs once per page load.
+ * Call after a user gesture or on voice channel hover. Uses a temporary
+ * AudioContext then closes it; the script is cached so the real join only pays
+ * parse/compile cost. Idempotent: only runs once per page load.
  */
 export function preloadRnnoiseWorklet(): void {
   if (preloadStarted) return
@@ -51,11 +52,13 @@ export function preloadRnnoiseWorklet(): void {
     .catch(() => ctx.close())
 }
 
-/* ── public interface ───────────────────────────────────────────── */
-
 export interface RnnoiseNode {
   /** AudioWorkletNode to insert into the Web Audio graph. */
   node: AudioWorkletNode
+  /** Current runtime state for production parity diagnostics. */
+  getStatus: () => RnnoiseRuntimeStatus
+  /** Wait for the denoiser to become ready, or return the terminal/timeout status. */
+  waitUntilReady: (timeoutMs?: number) => Promise<RnnoiseRuntimeStatus>
   /** Toggle noise suppression on/off without rebuilding the graph. */
   setEnabled: (v: boolean) => void
   /** Release WASM memory and disconnect the node. */
@@ -65,8 +68,9 @@ export interface RnnoiseNode {
 /**
  * Create an AudioWorkletNode that runs RNNoise on every mic frame.
  *
- * When `enabled` is false (or while WASM is still loading) the node
- * acts as a transparent passthrough — zero processing cost.
+ * When `enabled` is false the node acts as a transparent passthrough.
+ * While WASM is still loading it briefly outputs silence so raw background
+ * noise does not leak before RNNoise is ready.
  */
 export async function createRnnoiseNode(
   ctx: AudioContext,
@@ -83,17 +87,84 @@ export async function createRnnoiseNode(
   })
 
   let destroyed = false
+  let status: RnnoiseRuntimeStatus = enabled ? 'loading' : 'disabled'
+  let hasReadyProcessor = false
+  let fallbackAfterTimeout = false
+  let readyListeners: Array<(status: RnnoiseRuntimeStatus) => void> = []
+
+  const setStatus = (next: RnnoiseRuntimeStatus, rnnoiseError?: string) => {
+    status = next
+    updateVoiceDiagnostics({
+      rnnoiseStatus: next,
+      rnnoiseError,
+      rnnoiseWorkletUrl: processorUrl,
+    })
+    if (next === 'ready' || next === 'failed' || next === 'disabled') {
+      const listeners = readyListeners
+      readyListeners = []
+      listeners.forEach((listener) => listener(next))
+    }
+  }
+
+  type ProcessorMessage = {
+    type: 'ready' | 'load-failed' | 'process-failed'
+    message?: string
+  }
+
+  setStatus(status)
+
+  node.port.onmessage = (event: MessageEvent<ProcessorMessage>) => {
+    if (destroyed) return
+    const data = event.data
+    if (data.type === 'ready') {
+      hasReadyProcessor = true
+      if (!fallbackAfterTimeout) setStatus('ready')
+    } else if (data.type === 'load-failed' || data.type === 'process-failed') {
+      setStatus('failed', data.message ?? 'RNNoise processor failed')
+    }
+  }
+
+  node.onprocessorerror = () => {
+    if (!destroyed) setStatus('failed', 'RNNoise AudioWorklet processor crashed')
+  }
 
   return {
     node,
+    getStatus() {
+      return status
+    },
+    waitUntilReady(timeoutMs = 3500) {
+      if (status === 'ready' || status === 'failed' || status === 'disabled') {
+        return Promise.resolve(status)
+      }
+      return new Promise((resolve) => {
+        let settled = false
+        const finish = (next: RnnoiseRuntimeStatus) => {
+          if (settled) return
+          settled = true
+          window.clearTimeout(timeout)
+          resolve(next)
+        }
+        const timeout = window.setTimeout(() => {
+          fallbackAfterTimeout = true
+          setStatus('failed', `RNNoise did not become ready within ${timeoutMs}ms`)
+          node.port.postMessage({ type: 'set-enabled', enabled: false })
+          finish('failed')
+        }, timeoutMs)
+        readyListeners.push(finish)
+      })
+    },
     setEnabled(v: boolean) {
       if (!destroyed) {
+        if (v) fallbackAfterTimeout = false
+        setStatus(v ? (hasReadyProcessor ? 'ready' : 'loading') : 'disabled')
         node.port.postMessage({ type: 'set-enabled', enabled: v })
       }
     },
     destroy() {
       if (destroyed) return
       destroyed = true
+      setStatus('disabled')
       node.port.postMessage({ type: 'destroy' })
       node.disconnect()
     },

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -4,6 +4,7 @@ import {
   getVoiceNetworkQuality,
   getVoiceQualityAdvice,
   getVoicePingLevel,
+  updateVoiceDiagnostics,
   voiceQualityLabel,
 } from './voiceDiagnostics'
 
@@ -66,5 +67,24 @@ describe('voiceDiagnostics', () => {
     expect(voiceQualityLabel(summary.level)).toBe('Poor voice quality')
     expect(getVoiceQualityAdvice(summary, 'connected')).toContain('steadier connection')
     expect(getVoiceQualityAdvice(summary, 'reconnecting')).toContain('reconnecting')
+  })
+
+  it('exposes RNNoise runtime diagnostics for release smoke checks', () => {
+    updateVoiceDiagnostics({
+      rnnoiseStatus: 'ready',
+      noiseSuppressionEnabled: true,
+      voiceInputProfile: 'custom',
+      suppressionTuning: 'high',
+      aggressiveIsolation: true,
+    })
+
+    expect(window.__VOXPERY_VOICE_DIAGNOSTICS__).toMatchObject({
+      rnnoiseStatus: 'ready',
+      noiseSuppressionEnabled: true,
+      voiceInputProfile: 'custom',
+      suppressionTuning: 'high',
+      aggressiveIsolation: true,
+    })
+    expect(window.__VOXPERY_VOICE_DIAGNOSTICS__?.updatedAt).toEqual(expect.any(String))
   })
 })

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -1,3 +1,32 @@
+export type RnnoiseRuntimeStatus = 'disabled' | 'loading' | 'ready' | 'failed'
+
+export interface VoiceRuntimeDiagnostics {
+  rnnoiseStatus?: RnnoiseRuntimeStatus
+  rnnoiseError?: string
+  rnnoiseWorkletUrl?: string
+  noiseSuppressionEnabled?: boolean
+  voiceInputProfile?: string
+  suppressionTuning?: string
+  aggressiveIsolation?: boolean
+  updatedAt?: string
+}
+
+declare global {
+  interface Window {
+    __VOXPERY_VOICE_DIAGNOSTICS__?: VoiceRuntimeDiagnostics
+  }
+}
+
+export function updateVoiceDiagnostics(patch: VoiceRuntimeDiagnostics): void {
+  if (typeof window === 'undefined') return
+
+  window.__VOXPERY_VOICE_DIAGNOSTICS__ = {
+    ...(window.__VOXPERY_VOICE_DIAGNOSTICS__ ?? {}),
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
 export type VoiceQualityLevel = 'unknown' | 'good' | 'fair' | 'poor'
 
 export interface VoiceNetworkMetrics {

--- a/apps/web/src/webrtc/voiceInputProfile.test.ts
+++ b/apps/web/src/webrtc/voiceInputProfile.test.ts
@@ -18,10 +18,11 @@ describe('voiceInputProfile suppression tuning', () => {
     expect(getVoiceSuppressionTuning('studio', 70, true)).toBe('off')
   })
 
-  it('applies aggressive isolation only for isolation profile with suppression enabled', () => {
+  it('keeps aggressive isolation for custom settings when suppression is enabled', () => {
     expect(shouldUseAggressiveVoiceIsolation('isolation', true)).toBe(true)
-    expect(shouldUseAggressiveVoiceIsolation('custom', true)).toBe(false)
+    expect(shouldUseAggressiveVoiceIsolation('custom', true)).toBe(true)
     expect(shouldUseAggressiveVoiceIsolation('isolation', false)).toBe(false)
+    expect(shouldUseAggressiveVoiceIsolation('studio', true)).toBe(false)
   })
 
   it('marks pipeline rebuild only when suppression tier changes', () => {

--- a/apps/web/src/webrtc/voiceInputProfile.ts
+++ b/apps/web/src/webrtc/voiceInputProfile.ts
@@ -62,7 +62,7 @@ export function getVoiceInputProfileConfig(profile: VoiceInputProfile): VoiceInp
 
 export function getVoiceProfileSummary(profile: VoiceInputProfile): string {
   if (profile === 'studio') return 'Raw voice with minimal processing for maximum natural tone.'
-  if (profile === 'custom') return 'Fine-tuned settings with manual control over sensitivity and mode.'
+  if (profile === 'custom') return 'Fine-tuned sensitivity and mode with noise isolation kept active when enabled.'
   return 'Default isolation profile optimized for keyboard and room-noise suppression.'
 }
 
@@ -71,8 +71,8 @@ export function shouldUseAggressiveVoiceIsolation(
   noiseSuppressionEnabled: boolean,
 ): boolean {
   if (!noiseSuppressionEnabled) return false
-  // Profile still controls the overall isolation style; preset tuning is layered on top.
-  return profile === 'isolation'
+  // Custom settings should not silently downgrade noise isolation; only Studio is intentionally raw.
+  return profile !== 'studio'
 }
 
 export function getVoiceSuppressionTuning(

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -20,10 +20,12 @@ function rnnoiseProdStripPlugin() {
 }
 
 // https://vite.dev/config/
+const RNNOISE_WORKLET_URL = `/assets/rnnoise-worklet.js?v=${Date.now().toString(36)}`
+
 export default defineConfig(({ mode }) => ({
   envDir: '../../',
   plugins: [react(), mode === 'production' ? rnnoiseProdStripPlugin() : null].filter(Boolean),
-  define: mode === 'production' ? { __RNNOISE_PROCESSOR_URL__: JSON.stringify('/assets/rnnoise-worklet.js') } : {},
+  define: mode === 'production' ? { __RNNOISE_PROCESSOR_URL__: JSON.stringify(RNNOISE_WORKLET_URL) } : {},
   build: {
     // Strip console in production to avoid leaking room/user IDs (e.g. from LiveKit SDK) and other debug output
     minify: 'esbuild',
@@ -31,7 +33,7 @@ export default defineConfig(({ mode }) => ({
       drop: mode === 'production' ? ['console', 'debugger'] : [],
     },
     rollupOptions: {
-      // Worklet as separate entry → one self-contained file. Main app uses fixed URL (no ?url = no extra chunk).
+      // Worklet as separate entry -> one self-contained file. Main app uses fixed URL (no ?url = no extra chunk).
       input: {
         main: 'index.html',
         worklet: 'src/webrtc/rnnoise-worklet-processor.ts',

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This folder is the source of truth for architecture, development, deployment, ro
 - **[API.md](API.md)** - REST API endpoints and auth behavior
 - **[WEBSOCKET_EVENTS.md](WEBSOCKET_EVENTS.md)** - Realtime protocol and event contracts
 - **[VOICE_SYSTEM.md](VOICE_SYSTEM.md)** - LiveKit integration and voice pipeline
+- **[VOICE_SUPPRESSION_SMOKE_TEST.md](VOICE_SUPPRESSION_SMOKE_TEST.md)** - release gate for RNNoise and voice suppression parity
 - **[PERFORMANCE_REVIEW.md](PERFORMANCE_REVIEW.md)** - Realtime workload risks and measurement plan
 - **[DATABASE.md](DATABASE.md)** - Schema, migrations, and key queries
 - **[SECURITY.md](SECURITY.md)** - Security model and hardening checklist

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -2,6 +2,8 @@
 
 Use this checklist for every production release candidate before tag/publish.
 
+For releases that touch voice, WebRTC, LiveKit, service workers, build output, or audio settings, also complete `docs/VOICE_SUPPRESSION_SMOKE_TEST.md`.
+
 ## Release Candidate Info
 
 - Version:
@@ -43,6 +45,7 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
 - [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
+- [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.
 
 ## 4) Desktop Smoke Tests (mandatory)
 
@@ -69,6 +72,9 @@ Use this checklist for every production release candidate before tag/publish.
 - [ ] Denying desktop microphone permission shows recovery guidance, opens OS privacy settings from Voice & Audio, and succeeds after permission is restored and retried.
 - [ ] Denying desktop camera permission shows OS-specific recovery guidance, opens OS privacy settings when supported, and succeeds after permission is restored and retried.
 - [ ] Voice settings mic test with noise suppression on and `Noisy room` selected does not pass normal keyboard, mouse, fan, or breath noise as speech.
+- [ ] Real production voice call with noise suppression on and `Noisy room` selected suppresses clap, keyboard, and room-noise bursts similarly to the local Docker build.
+- [ ] During the real production voice call, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
+- [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 
 ## 5) Final Sign-off

--- a/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
+++ b/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
@@ -1,0 +1,75 @@
+# Voice Suppression Smoke Test
+
+Use this smoke test before production releases that touch voice, WebRTC, LiveKit, service workers, build output, or audio settings. The goal is to confirm that local Docker and production candidates use the same suppression path and that RNNoise is actually active.
+
+## Required Setup
+
+- Use two users in the same voice channel.
+- Test in Chromium-based browser first, then desktop if the release includes desktop artifacts.
+- Use the same microphone device for local Docker and production.
+- Set Voice Settings:
+  - Noise suppression: `On`
+  - Input tuning preset: `Noisy room`
+  - Activation mode: `Voice Activity`
+
+## Runtime Diagnostic Gate
+
+After joining voice, open DevTools on the sender and run:
+
+```js
+window.__VOXPERY_VOICE_DIAGNOSTICS__
+```
+
+Required result:
+
+```js
+{
+  rnnoiseStatus: "ready",
+  noiseSuppressionEnabled: true,
+  voiceInputProfile: "isolation" /* or "custom" */,
+  suppressionTuning: "high",
+  aggressiveIsolation: true
+}
+```
+
+Fail the release candidate if:
+
+- `rnnoiseStatus` is `failed`, `loading` for more than a few seconds, or missing.
+- `noiseSuppressionEnabled` is not `true`.
+- `suppressionTuning` is not `high` after selecting `Noisy room`.
+- `aggressiveIsolation` is not `true` while suppression is on.
+
+## Audio Behavior Gate
+
+Run each sound while the receiver listens:
+
+| Input | Expected result |
+| --- | --- |
+| Normal speech | Clear and intelligible, without chopped syllables. |
+| Single clap near the mic | Not transmitted, or only a heavily attenuated transient. |
+| Keyboard typing | Not transmitted as continuous speech. |
+| Mouse clicks | Not transmitted as continuous speech. |
+| Fan or steady room noise | Does not open the voice activity gate by itself. |
+| Short breath near mic | Does not keep the gate open after the breath ends. |
+
+Fail the release candidate if normal speech is hard to understand, or if clap/keyboard/fan noise consistently reaches the receiver like normal voice.
+
+## Local vs Production Parity
+
+Run the same steps on:
+
+1. Local Docker build.
+2. Production candidate.
+
+The production candidate should not be meaningfully worse than local Docker with the same device and settings. If production differs, capture:
+
+- Browser + version.
+- Microphone device name.
+- `window.__VOXPERY_VOICE_DIAGNOSTICS__`.
+- Whether the request for `/assets/rnnoise-worklet.js` came from network or service worker cache.
+- Whether the test used browser, installed PWA, or desktop app.
+
+## Notes
+
+- RNNoise readiness is release-critical. If the worklet cannot become ready quickly, Voxpery records `rnnoiseStatus: "failed"` and falls back intentionally instead of silently pretending that suppression is active.
+- The mic test and real voice call must both pass, but the real call is authoritative for release sign-off.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -85,11 +85,13 @@ Room.localParticipant.publishTrack
   - Runs inside an `AudioWorkletNode` for low-latency realtime processing
   - Lazy-loaded on first enable (~4.8 MB WASM, 3.1 MB gzipped) -> separate chunk in Vite build
   - Removes keyboard clicks, fan noise, background hum while preserving voice clarity
+  - While RNNoise is loading, the worklet briefly outputs silence instead of raw mic audio so startup cannot leak background noise before the denoiser is ready
   - Toggle: Live on/off in Voice Settings (no voice channel re-join required)
 - **Simple user-facing model**
   - Voice Settings intentionally exposes only `Off` / `On`
   - When `On`, Voxpery automatically changes cleanup strength based on the current **Input sensitivity** threshold
   - This keeps `Custom` sensitivity values logically aligned with the actual environment instead of tying suppression strength to preset names only
+  - `Custom` keeps the same isolation style as the default profile; only `Studio` intentionally disables the aggressive cleanup path
 - **Threshold-based suppression tuning**
   - `-100 .. -53 dB` -> `balanced` cleanup
   - `-52 .. 0 dB` -> `high` cleanup
@@ -246,7 +248,8 @@ When debugging a production voice report, capture:
 
 1. The call bar ping color and visible ping.
 2. Whether the room was connected, connecting, or reconnecting.
-3. Whether the user recently changed microphone, camera, VPN, firewall, or network.
+3. `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active.
+4. Whether the user recently changed microphone, camera, VPN, firewall, or network.
 
 ### Voice cues
 


### PR DESCRIPTION
## Summary

- Fixed production/local noise suppression parity for voice calls.
- Kept aggressive voice isolation active for custom sensitivity and `Noisy room` settings.
- Added RNNoise runtime diagnostics for release smoke checks.
- Prevented stale/cached RNNoise worklets from being reused after deploy.
- Added a dedicated voice suppression smoke test document with GO/NO-GO criteria.

## Related

Closes/Addresses: Production noise cancellation parity investigation

## Changes

- Add RNNoise readiness/failure diagnostics via `window.__VOXPERY_VOICE_DIAGNOSTICS__`.
- Wait for RNNoise readiness before publishing the processed mic chain when suppression is enabled.
- Fall back intentionally if RNNoise cannot become ready instead of silently pretending suppression is active.
- Keep `custom` voice profile on the aggressive isolation path while suppression is enabled.
- Tighten transient/keyboard/clap suppression in the live audio pipeline.
- Exclude `/assets/rnnoise-worklet.js` from service worker cache-first handling.
- Add a production cache-buster to the RNNoise worklet URL.
- Document voice suppression smoke testing in `docs/VOICE_SUPPRESSION_SMOKE_TEST.md`.

## Validation

- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `graphify update .`
- [x] Local diagnostic checked:
  - `rnnoiseStatus: "ready"`
  - `noiseSuppressionEnabled: true`
  - `suppressionTuning: "high"`
  - `aggressiveIsolation: true`

## Security / Privacy Impact

- [x] No new secrets added
- [x] No auth/permission regression
- [x] No sensitive data added to logs

## Docs

- [x] Voice system docs updated
- [x] Release smoke checklist updated
- [x] Dedicated voice suppression smoke test added
