### PR TITLE
feat: update Content Security Policy to include 'wasm-unsafe-eval' fo…

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
         "default-src": "'self' tauri: asset: voxpery:",
         "connect-src": "ipc: http://ipc.localhost 'self' https://api.voxpery.com wss://api.voxpery.com https://livekit.voxpery.com wss://livekit.voxpery.com stun: turn: https://livekit.io https://*.livekit.io https://challenges.cloudflare.com",
         "img-src": "'self' asset: data: https: blob:",
-        "script-src": "'self' blob: https://challenges.cloudflare.com",
+        "script-src": "'self' blob: 'wasm-unsafe-eval' https://challenges.cloudflare.com",
         "frame-src": "https://challenges.cloudflare.com",
         "worker-src": "'self' blob:",
         "style-src": "'self' 'unsafe-inline'",

--- a/apps/desktop/src-tauri/tauri.dev.conf.json
+++ b/apps/desktop/src-tauri/tauri.dev.conf.json
@@ -5,7 +5,7 @@
         "default-src": "'self' tauri: asset: voxpery:",
         "connect-src": "ipc: http://ipc.localhost 'self' http://localhost:3001 ws://localhost:3001 http://127.0.0.1:3001 ws://127.0.0.1:3001 http://localhost:7880 ws://localhost:7880 http://127.0.0.1:7880 ws://127.0.0.1:7880 stun: turn: https://challenges.cloudflare.com",
         "img-src": "'self' asset: data: http: https: blob:",
-        "script-src": "'self' blob: https://challenges.cloudflare.com",
+        "script-src": "'self' blob: 'wasm-unsafe-eval' https://challenges.cloudflare.com",
         "frame-src": "https://challenges.cloudflare.com",
         "worker-src": "'self' blob:",
         "style-src": "'self' 'unsafe-inline'",

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -5,6 +5,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(self), microphone=(self), geolocation=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.voxpery.com wss://api.voxpery.com https://livekit.voxpery.com wss://livekit.voxpery.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';" always;
+
     location = /healthz {
         access_log off;
         add_header Content-Type text/plain;

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -73,6 +73,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Denying desktop camera permission shows OS-specific recovery guidance, opens OS privacy settings when supported, and succeeds after permission is restored and retried.
 - [ ] Voice settings mic test with noise suppression on and `Noisy room` selected does not pass normal keyboard, mouse, fan, or breath noise as speech.
 - [ ] Real production voice call with noise suppression on and `Noisy room` selected suppresses clap, keyboard, and room-noise bursts similarly to the local Docker build.
+- [ ] Production web CSP includes `script-src 'wasm-unsafe-eval'` so RNNoise WebAssembly can compile under strict headers.
 - [ ] During the real production voice call, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
 - [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -248,8 +248,10 @@ add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "DENY" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header Referrer-Policy "no-referrer" always;
-add_header Content-Security-Policy "default-src 'self'; connect-src 'self' wss://api.your-domain.com; img-src 'self' https:; style-src 'self' 'unsafe-inline';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; connect-src 'self' https://api.your-domain.com wss://api.your-domain.com https://livekit.your-domain.com wss://livekit.your-domain.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';" always;
 ```
+
+`'wasm-unsafe-eval'` is required for the RNNoise WebAssembly voice suppression runtime. It is narrower than broad JavaScript `'unsafe-eval'` and should stay in `script-src` for production voice releases.
 
 ## Secrets Management
 

--- a/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
+++ b/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
@@ -14,6 +14,18 @@ Use this smoke test before production releases that touch voice, WebRTC, LiveKit
 
 ## Runtime Diagnostic Gate
 
+Before joining voice on production, confirm the web response CSP allows WebAssembly:
+
+```bash
+curl -I https://voxpery.com/
+```
+
+Required header detail:
+
+```text
+content-security-policy: ... script-src 'self' 'wasm-unsafe-eval' ...
+```
+
 After joining voice, open DevTools on the sender and run:
 
 ```js
@@ -34,6 +46,7 @@ Required result:
 
 Fail the release candidate if:
 
+- The production CSP does not include `'wasm-unsafe-eval'` in `script-src`.
 - `rnnoiseStatus` is `failed`, `loading` for more than a few seconds, or missing.
 - `noiseSuppressionEnabled` is not `true`.
 - `suppressionTuning` is not `high` after selecting `Noisy room`.


### PR DESCRIPTION
## Summary

Fix production RNNoise initialization by allowing WebAssembly compilation under the production CSP.

## Changes

- Added `wasm-unsafe-eval` to web and desktop CSP.
- Updated voice suppression smoke/security docs.

## Validation

- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`
