### PR TITLE
feat: enhance data export functionality with user-readable format and…

### DIFF
--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -1318,9 +1318,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -39,7 +39,7 @@ base64 = "0.22"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 urlencoding = "2"
 bitflags = "2"
-lettre = { version = "0.11.21", features = ["tokio1", "tokio1-native-tls", "builder"] }
+lettre = { version = "0.11.22", features = ["tokio1", "tokio1-native-tls", "builder"] }
 sha2 = "0.10"
 unicode-normalization = "0.1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -551,7 +551,6 @@ struct DeleteAccountRequest {
 
 #[derive(Debug, serde::Serialize, sqlx::FromRow)]
 struct ExportAccountRow {
-    id: Uuid,
     username: String,
     email: String,
     avatar_url: Option<String>,
@@ -571,8 +570,6 @@ struct ExportMembershipRow {
 #[derive(Debug, serde::Serialize, sqlx::FromRow)]
 struct ExportFriendRow {
     username: String,
-    avatar_url: Option<String>,
-    status: String,
     created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -601,6 +598,29 @@ struct ExportDmMessageRow {
     attachments: Option<serde_json::Value>,
     created_at: chrono::DateTime<chrono::Utc>,
     edited_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn summarize_export_attachments(attachments: &Option<serde_json::Value>) -> Vec<serde_json::Value> {
+    let Some(serde_json::Value::Array(items)) = attachments else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter_map(|item| item.as_object())
+        .map(|obj| {
+            let name = obj
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("Attachment");
+            serde_json::json!({
+                "name": name,
+                "content_type": obj.get("type").and_then(serde_json::Value::as_str),
+                "size_bytes": obj.get("size").and_then(serde_json::Value::as_i64),
+            })
+        })
+        .collect()
 }
 
 pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
@@ -2386,7 +2406,7 @@ async fn export_my_data(
     .await?;
 
     let account = sqlx::query_as::<_, ExportAccountRow>(
-        r#"SELECT id, username, email, avatar_url, status, dm_privacy, created_at,
+        r#"SELECT username, email, avatar_url, status, dm_privacy, created_at,
                   (google_id IS NOT NULL) AS google_connected
            FROM users
            WHERE id = $1"#,
@@ -2411,8 +2431,6 @@ async fn export_my_data(
 
     let friends = sqlx::query_as::<_, ExportFriendRow>(
         r#"SELECT u.username,
-                  u.avatar_url,
-                  u.status,
                   f.created_at
            FROM friendships f
            INNER JOIN users u
@@ -2479,14 +2497,86 @@ async fn export_my_data(
     .fetch_all(&state.db)
     .await?;
 
+    let server_messages: Vec<_> = server_messages
+        .iter()
+        .map(|message| {
+            serde_json::json!({
+                "server": message.server_name,
+                "channel": message.channel_name,
+                "content": message.content,
+                "attachments": summarize_export_attachments(&message.attachments),
+                "sent_at": message.created_at,
+                "edited_at": message.edited_at,
+            })
+        })
+        .collect();
+
+    let dm_messages: Vec<_> = dm_messages
+        .iter()
+        .map(|message| {
+            serde_json::json!({
+                "conversation_with": message.peer_username.as_deref().unwrap_or("Unknown user"),
+                "content": message.content,
+                "attachments": summarize_export_attachments(&message.attachments),
+                "sent_at": message.created_at,
+                "edited_at": message.edited_at,
+            })
+        })
+        .collect();
+
     let payload = serde_json::json!({
-        "exported_at": chrono::Utc::now().to_rfc3339(),
-        "account": account,
-        "memberships": memberships,
-        "friends": friends,
-        "friend_requests": friend_requests,
-        "server_messages": server_messages,
-        "dm_messages": dm_messages,
+        "export": {
+            "format": "voxpery-user-data-v2",
+            "generated_at": chrono::Utc::now().to_rfc3339(),
+            "description": "User-readable export of your Voxpery account, profile, relationships, servers, and authored messages.",
+            "privacy_notes": [
+                "Internal database identifiers, password hashes, sessions, tokens, and infrastructure values are not included.",
+                "Other users are represented with minimal display context needed to understand your relationships and conversations.",
+                "Message attachment entries are summarized without signed download URLs or storage identifiers."
+            ],
+            "limits": {
+                "server_messages": "Most recent 20000 authored server messages.",
+                "direct_messages": "Most recent 20000 authored direct messages."
+            }
+        },
+        "account": {
+            "username": account.username,
+            "email": account.email,
+            "status": account.status,
+            "dm_privacy": account.dm_privacy,
+            "created_at": account.created_at,
+            "google_connected": account.google_connected
+        },
+        "profile": {
+            "has_avatar": account.avatar_url.is_some()
+        },
+        "servers": memberships.iter().map(|membership| {
+            serde_json::json!({
+                "name": membership.server_name,
+                "role": membership.role,
+                "joined_at": membership.joined_at,
+            })
+        }).collect::<Vec<_>>(),
+        "relationships": {
+            "friends": friends.iter().map(|friend| {
+                serde_json::json!({
+                    "username": friend.username,
+                    "friends_since": friend.created_at,
+                })
+            }).collect::<Vec<_>>(),
+            "friend_requests": friend_requests.iter().map(|request| {
+                serde_json::json!({
+                    "direction": request.direction,
+                    "username": request.other_username,
+                    "status": request.status,
+                    "created_at": request.created_at,
+                })
+            }).collect::<Vec<_>>()
+        },
+        "messages": {
+            "server": server_messages,
+            "direct": dm_messages
+        }
     });
 
     let date = chrono::Utc::now().format("%Y-%m-%d");

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -2159,7 +2159,7 @@ async fn data_export_returns_user_profile_and_messages() {
         eprintln!("SKIP: DATABASE_URL not set");
         return;
     };
-    let (mut app, _) = setup_app().await;
+    let (mut app, state) = setup_app().await;
 
     let uid = Uuid::new_v4();
     let email = format!("export-{}@example.com", uid);
@@ -2217,6 +2217,26 @@ async fn data_export_returns_user_profile_and_messages() {
         "message send failed: {}",
         String::from_utf8_lossy(&body)
     );
+    let message: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let message_id = message["id"].as_str().unwrap();
+
+    sqlx::query(
+        r#"UPDATE messages
+           SET attachments = $1
+           WHERE id = $2"#,
+    )
+    .bind(serde_json::json!([{
+        "id": Uuid::new_v4().to_string(),
+        "url": "https://api.example.test/api/attachments/content/internal?exp=999&sig=secret",
+        "type": "image/png",
+        "name": "diagram.png",
+        "size": 1234,
+        "sha256": "internal-sha"
+    }]))
+    .bind(Uuid::parse_str(message_id).unwrap())
+    .execute(&state.db)
+    .await
+    .unwrap();
 
     let req = Request::builder()
         .method("GET")
@@ -2233,20 +2253,26 @@ async fn data_export_returns_user_profile_and_messages() {
     );
 
     let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload["account"]["id"], user_id.to_string());
+    assert_eq!(payload["export"]["format"], "voxpery-user-data-v2");
     assert_eq!(payload["account"]["email"], email);
-    assert!(payload["memberships"].is_array());
-    assert!(payload["server_messages"].is_array());
-    if let Some(first_membership) = payload["memberships"]
-        .as_array()
-        .and_then(|rows| rows.first())
-    {
+    assert_eq!(payload["account"]["username"], username);
+    assert!(payload["account"].get("id").is_none());
+    assert!(payload["account"].get("avatar_url").is_none());
+    assert!(payload["account"].get("password_hash").is_none());
+    assert!(payload["account"].get("token_version").is_none());
+    assert_eq!(payload["profile"]["has_avatar"], false);
+    assert!(payload["servers"].is_array());
+    assert!(payload["relationships"]["friends"].is_array());
+    assert!(payload["relationships"]["friend_requests"].is_array());
+    assert!(payload["messages"]["server"].is_array());
+    assert!(payload["messages"]["direct"].is_array());
+    if let Some(first_membership) = payload["servers"].as_array().and_then(|rows| rows.first()) {
         assert!(
             first_membership.get("server_id").is_none(),
             "server_id must not be included in export memberships",
         );
     }
-    if let Some(first_server_message) = payload["server_messages"]
+    if let Some(first_server_message) = payload["messages"]["server"]
         .as_array()
         .and_then(|rows| rows.first())
     {
@@ -2263,13 +2289,44 @@ async fn data_export_returns_user_profile_and_messages() {
             "message id must not be included in exported server messages",
         );
     }
-    let has_exported_message = payload["server_messages"]
+    let exported_message = payload["messages"]["server"]
         .as_array()
-        .map(|rows| rows.iter().any(|msg| msg["content"] == "export me"))
-        .unwrap_or(false);
+        .and_then(|rows| rows.iter().find(|msg| msg["content"] == "export me"))
+        .expect("export payload should include authored message");
+    assert_eq!(
+        exported_message["attachments"][0]["name"],
+        serde_json::json!("diagram.png")
+    );
+    assert_eq!(
+        exported_message["attachments"][0]["content_type"],
+        serde_json::json!("image/png")
+    );
+    assert_eq!(
+        exported_message["attachments"][0]["size_bytes"],
+        serde_json::json!(1234)
+    );
+    assert!(exported_message["attachments"][0].get("id").is_none());
+    assert!(exported_message["attachments"][0].get("url").is_none());
+    assert!(exported_message["attachments"][0].get("sha256").is_none());
+
+    let export_text = serde_json::to_string(&payload).unwrap();
+    for forbidden in [
+        "\"password_hash\"",
+        "\"access_token\"",
+        "\"refresh_token\"",
+        "\"session_id\"",
+        "\"avatar_url\"",
+        "internal-sha",
+        "sig=secret",
+    ] {
+        assert!(
+            !export_text.contains(forbidden),
+            "export payload must not contain sensitive/internal field: {forbidden}"
+        );
+    }
     assert!(
-        has_exported_message,
-        "export payload should include authored message"
+        !export_text.contains(&user_id.to_string()),
+        "export payload should not expose the account database id"
     );
 }
 

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -26,22 +26,36 @@ export interface AuthResponse {
 }
 
 export interface DataExportPayload {
-    exported_at: string
+    export: {
+        format: string
+        generated_at: string
+        description: string
+        privacy_notes: string[]
+        limits: {
+            server_messages: string
+            direct_messages: string
+        }
+    }
     account: {
-        id: string
         username: string
         email: string
-        avatar_url: string | null
         status: string
         dm_privacy: 'everyone' | 'friends'
         created_at: string
         google_connected: boolean
     }
-    memberships: unknown[]
-    friends: unknown[]
-    friend_requests: unknown[]
-    server_messages: unknown[]
-    dm_messages: unknown[]
+    profile: {
+        has_avatar: boolean
+    }
+    servers: unknown[]
+    relationships: {
+        friends: unknown[]
+        friend_requests: unknown[]
+    }
+    messages: {
+        server: unknown[]
+        direct: unknown[]
+    }
 }
 
 export interface DeleteAccountPayload {

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -959,7 +959,7 @@ export default function UserBar() {
       pushToast({
         level: 'info',
         title: 'Data export ready',
-        message: 'Your account data has been downloaded as JSON.',
+        message: 'Your readable account export has been downloaded as JSON.',
       })
     } catch (err: unknown) {
       const message = getAuthErrorMessage(err).message || 'Could not export account data.'
@@ -1941,7 +1941,9 @@ export default function UserBar() {
                 <div className="user-setting-row">
                   <div>
                     <div className="user-setting-title">Data export</div>
-                    <div className="user-setting-desc">Download your account data in JSON format.</div>
+                    <div className="user-setting-desc">
+                      Download a readable JSON export with your account, servers, relationships, and authored messages. Internal IDs, tokens, sessions, and raw attachment URLs are excluded.
+                    </div>
                   </div>
                   <button
                     type="button"

--- a/docs/API.md
+++ b/docs/API.md
@@ -55,7 +55,9 @@ Important behavior:
 - `GET /api/auth/google/callback`
 - `GET /api/auth/data-export`
   - GDPR/KVKK data export JSON payload for authenticated user.
-  - Export is intentionally user-readable: internal technical IDs (server/channel/message/friend IDs) are omitted.
+  - Export format: `voxpery-user-data-v2`.
+  - Export is intentionally user-readable and data-minimized: internal database IDs, tokens, sessions, password hashes, raw avatar URLs, signed attachment URLs, and storage identifiers are omitted.
+  - Payload sections include export metadata, account, profile summary, servers, relationships, and authored messages.
 - `DELETE /api/auth/account`
   - Body: `{ "confirm": "DELETE", "password"?: "..." }`
   - Permanently deletes account and authored content.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop release workflow now runs preflight metadata/icon validation and requires checklist confirmation on manual release runs.
 - Desktop preflight now enforces updater signing prerequisites when updater artifacts are enabled.
 - Security doc compliance section updated with GDPR/KVKK implementation status.
+- Data exports now use a more readable, data-minimized JSON format that omits internal identifiers, raw avatar URLs, signed attachment URLs, and storage metadata.
 
 ## [0.1.0] - 2026-03-14
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -340,7 +340,7 @@ npm audit fix
 
 ## Compliance
 
-- **GDPR/KVKK**: Implemented self-service account data export (`GET /api/auth/data-export`) and permanent account delete (`DELETE /api/auth/account`).
+- **GDPR/KVKK**: Implemented self-service account data export (`GET /api/auth/data-export`) and permanent account delete (`DELETE /api/auth/account`). Data exports use the `voxpery-user-data-v2` format and intentionally omit internal database IDs, tokens, sessions, password hashes, raw avatar URLs, signed attachment URLs, and storage identifiers.
 - **COPPA**: No age verification (assume 13+)
 - **Privacy**: No biometrics, no hidden telemetry
 


### PR DESCRIPTION
## Summary

Improve Data Export privacy and readability by switching to a user-readable, data-minimized export format.

## Changes

- Added `voxpery-user-data-v2` export metadata and clearer payload sections.
- Removed internal IDs, raw avatar URLs, signed attachment URLs, attachment hashes, tokens, sessions, and other internal fields from the export.
- Summarized attachments with only `name`, `content_type`, and `size_bytes`.
- Updated Data Export settings copy to explain what users receive.
- Updated API, Security, and Changelog docs.
- Strengthened backend integration coverage for sensitive/internal field exclusion.

## Validation

- [x] `cargo check --locked`
- [x] `cargo test --locked data_export_returns_user_profile_and_messages`
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`
- [x] `git diff --check`
