### PR TITLE
feat: enhance voice diagnostics with opt-in flag and update related d…

### DIFF
--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -1318,9 +1318,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -39,7 +39,7 @@ base64 = "0.22"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 urlencoding = "2"
 bitflags = "2"
-lettre = { version = "0.11.21", features = ["tokio1", "tokio1-native-tls", "builder"] }
+lettre = { version = "0.11.22", features = ["tokio1", "tokio1-native-tls", "builder"] }
 sha2 = "0.10"
 unicode-normalization = "0.1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -1,14 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  VOICE_DIAGNOSTICS_STORAGE_KEY,
   classifyVoiceError,
   getVoiceNetworkQuality,
   getVoiceQualityAdvice,
   getVoicePingLevel,
+  isVoiceDiagnosticsEnabled,
   updateVoiceDiagnostics,
   voiceQualityLabel,
 } from './voiceDiagnostics'
 
 describe('voiceDiagnostics', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(VOICE_DIAGNOSTICS_STORAGE_KEY)
+    delete window.__VOXPERY_VOICE_DIAGNOSTICS__
+  })
+
   it('classifies healthy, fair, and poor network quality', () => {
     expect(getVoiceNetworkQuality({
       hasActiveVoiceSession: true,
@@ -69,7 +76,21 @@ describe('voiceDiagnostics', () => {
     expect(getVoiceQualityAdvice(summary, 'reconnecting')).toContain('reconnecting')
   })
 
-  it('exposes RNNoise runtime diagnostics for release smoke checks', () => {
+  it('keeps RNNoise runtime diagnostics hidden until explicitly enabled', () => {
+    expect(isVoiceDiagnosticsEnabled()).toBe(false)
+
+    updateVoiceDiagnostics({
+      rnnoiseStatus: 'ready',
+      noiseSuppressionEnabled: true,
+    })
+
+    expect(window.__VOXPERY_VOICE_DIAGNOSTICS__).toBeUndefined()
+  })
+
+  it('exposes RNNoise runtime diagnostics for opt-in release smoke checks', () => {
+    window.localStorage.setItem(VOICE_DIAGNOSTICS_STORAGE_KEY, '1')
+    expect(isVoiceDiagnosticsEnabled()).toBe(true)
+
     updateVoiceDiagnostics({
       rnnoiseStatus: 'ready',
       noiseSuppressionEnabled: true,

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -11,14 +11,30 @@ export interface VoiceRuntimeDiagnostics {
   updatedAt?: string
 }
 
+export const VOICE_DIAGNOSTICS_STORAGE_KEY = 'voxperyVoiceDiagnostics'
+
 declare global {
   interface Window {
     __VOXPERY_VOICE_DIAGNOSTICS__?: VoiceRuntimeDiagnostics
   }
 }
 
+export function isVoiceDiagnosticsEnabled(): boolean {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return window.localStorage.getItem(VOICE_DIAGNOSTICS_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
 export function updateVoiceDiagnostics(patch: VoiceRuntimeDiagnostics): void {
   if (typeof window === 'undefined') return
+  if (!isVoiceDiagnosticsEnabled()) {
+    delete window.__VOXPERY_VOICE_DIAGNOSTICS__
+    return
+  }
 
   window.__VOXPERY_VOICE_DIAGNOSTICS__ = {
     ...(window.__VOXPERY_VOICE_DIAGNOSTICS__ ?? {}),

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -74,7 +74,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Voice settings mic test with noise suppression on and `Noisy room` selected does not pass normal keyboard, mouse, fan, or breath noise as speech.
 - [ ] Real production voice call with noise suppression on and `Noisy room` selected suppresses clap, keyboard, and room-noise bursts similarly to the local Docker build.
 - [ ] Production web CSP includes `script-src 'wasm-unsafe-eval'` so RNNoise WebAssembly can compile under strict headers.
-- [ ] During the real production voice call, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
+- [ ] During the real production voice call, after enabling `localStorage.setItem("voxperyVoiceDiagnostics", "1")` and reloading, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
 - [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 

--- a/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
+++ b/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
@@ -26,6 +26,13 @@ Required header detail:
 content-security-policy: ... script-src 'self' 'wasm-unsafe-eval' ...
 ```
 
+Before joining voice, explicitly enable the temporary diagnostics surface in DevTools:
+
+```js
+localStorage.setItem("voxperyVoiceDiagnostics", "1")
+location.reload()
+```
+
 After joining voice, open DevTools on the sender and run:
 
 ```js
@@ -81,6 +88,13 @@ The production candidate should not be meaningfully worse than local Docker with
 - `window.__VOXPERY_VOICE_DIAGNOSTICS__`.
 - Whether the request for `/assets/rnnoise-worklet.js` came from network or service worker cache.
 - Whether the test used browser, installed PWA, or desktop app.
+
+After the smoke test, remove the opt-in flag:
+
+```js
+localStorage.removeItem("voxperyVoiceDiagnostics")
+location.reload()
+```
 
 ## Notes
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -248,7 +248,7 @@ When debugging a production voice report, capture:
 
 1. The call bar ping color and visible ping.
 2. Whether the room was connected, connecting, or reconnecting.
-3. `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active.
+3. Enable temporary diagnostics with `localStorage.setItem("voxperyVoiceDiagnostics", "1")`, reload, then inspect `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active.
 4. Whether the user recently changed microphone, camera, VPN, firewall, or network.
 
 ### Voice cues


### PR DESCRIPTION
## Summary

Gate production voice diagnostics behind an explicit localStorage debug flag.

## Changes

- Hide `window.__VOXPERY_VOICE_DIAGNOSTICS__` by default.
- Expose voice diagnostics only when `localStorage.setItem("voxperyVoiceDiagnostics", "1")` is enabled.
- Updated voice smoke/release docs with the opt-in and cleanup commands.
- Added tests for hidden-by-default and opt-in diagnostics behavior.

## Validation

- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `graphify update .`
