### PR TITLE
feat: improve desktop update UX with refined styles and toast notific…

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -532,49 +532,39 @@ body {
 }
 
 .shell-update-dock {
-  padding: 0 12px 10px;
+  display: flex;
+  justify-content: center;
+  padding: 0 12px 8px;
 }
 
 .shell-update-btn--dock {
-  width: 100%;
-  min-height: 46px;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 10px 12px;
-  border-radius: 16px;
-  background:
-    linear-gradient(180deg, rgba(71, 102, 191, 0.28), rgba(49, 74, 148, 0.22));
-  border-color: rgba(147, 197, 253, 0.28);
+  width: auto;
+  min-height: 34px;
+  justify-content: center;
+  gap: 8px;
+  padding: 7px 11px;
+  border-radius: 999px;
+  background: rgba(71, 102, 191, 0.22);
+  border-color: rgba(147, 197, 253, 0.26);
   color: #edf4ff;
   box-shadow:
-    0 16px 28px rgba(8, 13, 28, 0.24),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    0 10px 18px rgba(8, 13, 28, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .shell-update-btn--dock:hover:not(:disabled) {
-  background:
-    linear-gradient(180deg, rgba(79, 127, 216, 0.34), rgba(55, 83, 166, 0.28));
-  border-color: rgba(191, 219, 254, 0.42);
+  background: rgba(79, 127, 216, 0.3);
+  border-color: rgba(191, 219, 254, 0.38);
 }
 
 .shell-update-dock-copy {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  display: inline-flex;
+  align-items: center;
   min-width: 0;
-  gap: 2px;
-}
-
-.shell-update-dock-eyebrow {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(222, 236, 255, 0.72);
 }
 
 .shell-update-dock-title {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 700;
   color: #f3f7ff;
   white-space: nowrap;

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -28,6 +28,8 @@ import {
 import { ROUTES } from '../routes'
 import { setPersistedSocialView } from '../socialView'
 
+const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+
 export default function AppShell() {
   const { user } = useAuthStore()
   const userId = user?.id ?? null
@@ -120,8 +122,8 @@ export default function AppShell() {
         lastDesktopUpdateToastVersionRef.current = result.version
         pushToast({
           level: 'info',
-          title: 'Desktop update available',
-          message: `Voxpery ${result.version} is ready to install.`,
+          title: 'Update available',
+          message: `Voxpery ${result.version} can be installed when you are ready.`,
         })
       }
     }
@@ -138,7 +140,7 @@ export default function AppShell() {
     void run()
     const intervalId = window.setInterval(() => {
       void run()
-    }, 5 * 60 * 1000)
+    }, DESKTOP_UPDATE_CHECK_INTERVAL_MS)
     return () => {
       cancelled = true
       window.removeEventListener(DESKTOP_UPDATE_STATUS_EVENT, onUpdateStatus as EventListener)
@@ -602,12 +604,11 @@ export default function AppShell() {
               title={`Install Voxpery ${desktopUpdate.version}`}
             >
               <span className="shell-update-dock-copy">
-                <span className="shell-update-dock-eyebrow">Desktop update ready</span>
                 <span className="shell-update-dock-title">
                   {installingDesktopUpdate ? 'Installing update…' : `Install ${desktopUpdate.version}`}
                 </span>
               </span>
-              <ArrowDownToLine size={16} aria-hidden />
+              <ArrowDownToLine size={14} aria-hidden />
             </button>
           </div>
         )}

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -61,6 +61,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] If updater artifacts are enabled, signing keys and updater pubkey are configured (see `docs/DESKTOP_RELEASE_HARDENING.md`).
 - [ ] Updater check shows a clear no-update state when no newer version is available.
 - [ ] Updater check shows the available version when a newer signed release is available.
+- [ ] Update availability appears as one calm toast plus a compact install pill; settings still provides manual check/install.
 - [ ] Updater install path prepares the desktop runtime before install/relaunch.
 - [ ] Failed updater check/install shows recoverable UI and does not leave settings stuck.
 - [ ] Linux desktop test host has `xdg-desktop-portal` + (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` running.


### PR DESCRIPTION
## Summary

Refine the desktop update experience so update prompts feel calmer and less repetitive.

## Changes

- Reduced automatic desktop update polling from every 5 minutes to every 6 hours.
- Updated the automatic update toast copy to be less urgent.
- Replaced the larger left-bottom update card with a compact install pill.
- Kept manual update check/install available in Settings > Desktop.
- Added the expected update UX behavior to the release smoke checklist.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`

## Security / Privacy Impact

- [x] No new secrets added
- [x] No auth/permission regression
- [x] No sensitive data added to logs

## Docs

- [x] Release smoke checklist updated
