### PR TITLE
fix: update modal rendering to ensure proper layering and add documen…

### DIFF
--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -639,7 +639,6 @@ export default function ChannelSidebar({
                                     setContextMenu(null)
                                 }}
                             >
-                                <VolumeX size={14} />
                                 {isMuted ? 'Unmute Channel' : 'Mute Channel'}
                             </button>
                         )}

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -6,6 +6,7 @@ import type { Attachment } from '../types'
 import { resolveAttachmentUrl, resolveAvatarUrl, resolveInlineMediaUrl, type MessageWithAuthor, type Channel } from '../api'
 import type { DraftAttachmentItem } from '../draftAttachments'
 import { openExternalUrl } from '../openExternalUrl'
+import { cleanReplyQuotePreview } from '../replyPreview'
 import EmojiPicker from './EmojiPicker'
 import MessageInlineActions from './MessageInlineActions'
 import { useAuthStore } from '../stores/auth'
@@ -996,7 +997,7 @@ export default function ChatArea({
         const replyBody = content.slice(doubleNewline + 2).trim()
         const match = quotePart.match(/^>\s*@([^:]+):\s*(.*)$/s)
         if (!match) return null
-        return { replyUsername: match[1].trim(), replyQuote: match[2].trim(), replyBody }
+        return { replyUsername: match[1].trim(), replyQuote: cleanReplyQuotePreview(match[2]), replyBody }
     }
 
     const renderMessageContent = (content: string) => {

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -1993,7 +1993,7 @@ export default function UserBar() {
           </div>
         </div>
       ), document.body)}
-      {showDeleteModal && (
+      {showDeleteModal && typeof document !== 'undefined' && createPortal((
         <div className="modal-overlay" onClick={closeDeleteModal}>
           <div className="modal pw-modal delete-account-modal" onClick={(e) => e.stopPropagation()}>
             <header className="pw-modal-header">
@@ -2058,8 +2058,8 @@ export default function UserBar() {
             </footer>
           </div>
         </div>
-      )}
-      {showEmailModal && (
+      ), document.body)}
+      {showEmailModal && typeof document !== 'undefined' && createPortal((
         <div className="modal-overlay" onClick={() => closeEmailModal()}>
           <div className="modal pw-modal" onClick={(e) => e.stopPropagation()}>
             <header className="pw-modal-header">
@@ -2108,8 +2108,8 @@ export default function UserBar() {
             </footer>
           </div>
         </div>
-      )}
-      {showUsernameModal && (() => {
+      ), document.body)}
+      {showUsernameModal && typeof document !== 'undefined' && createPortal((() => {
         const changedAt = user?.username_changed_at ? new Date(user.username_changed_at).getTime() : null
         const nextAllowedMs = changedAt ? changedAt + 30 * 24 * 60 * 60 * 1000 : null
         const cannotChangeYet = nextAllowedMs != null && Date.now() < nextAllowedMs
@@ -2261,8 +2261,8 @@ export default function UserBar() {
             </footer>
           </div>
         </div>
-        ); })()}
-      {showPwModal && (
+        ); })(), document.body)}
+      {showPwModal && typeof document !== 'undefined' && createPortal((
         <div className="modal-overlay" onClick={() => closePasswordModal()}>
           <div className="modal pw-modal" onClick={(e) => e.stopPropagation()}>
             <header className="pw-modal-header">
@@ -2393,7 +2393,7 @@ export default function UserBar() {
             </footer>
           </div>
         </div>
-      )}
+      ), document.body)}
     </div>
   )
 }

--- a/apps/web/src/notificationSound.ts
+++ b/apps/web/src/notificationSound.ts
@@ -15,23 +15,23 @@ export function playMessageNotificationSound(): void {
 
   playCueStack(ctx, [
     {
-      from: 620,
-      to: 580,
-      durationSec: 0.14,
-      peak: 0.014,
+      from: 1046,
+      durationSec: 0.055,
+      peak: 0.012,
       type: 'sine',
-      overtoneGain: 0.08,
-      filterHz: 1800,
+      overtoneGain: 0.03,
+      filterHz: 2800,
+      q: 0.55,
     },
     {
-      from: 880,
-      to: 820,
-      offsetSec: 0.055,
-      durationSec: 0.12,
-      peak: 0.011,
+      from: 1568,
+      offsetSec: 0.045,
+      durationSec: 0.075,
+      peak: 0.009,
       type: 'sine',
-      overtoneGain: 0.05,
-      filterHz: 2200,
+      overtoneGain: 0.02,
+      filterHz: 3600,
+      q: 0.5,
     },
   ])
 }

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -38,6 +38,7 @@ import {
     shouldTrackServerUnread,
 } from '../notificationPreferences'
 import { shouldShowPushNotification, showPushNotification } from '../pushNotifications'
+import { createReplyContentSnippet } from '../replyPreview'
 import { createSavedMediaItem } from '../savedMedia'
 import { clearPendingSavedMediaJump, getPendingSavedMediaJump } from '../savedMediaJump'
 
@@ -1507,7 +1508,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
 
     const handleReplyToMessage = useCallback((msg: { id: string; author?: { username?: string }; content: string }) => {
         const username = msg.author?.username ?? 'User'
-        const snippet = msg.content.length > 80 ? msg.content.slice(0, 80) + '...' : msg.content
+        const snippet = createReplyContentSnippet(msg.content)
         setReplyingTo({ id: msg.id, username, contentSnippet: snippet })
     }, [])
 

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -35,6 +35,7 @@ import { createSavedMediaItem } from '../savedMedia'
 import { clearPendingSavedMediaJump, getPendingSavedMediaJump, setPendingSavedMediaJump } from '../savedMediaJump'
 import { type SocialView, getPersistedSocialView, setPersistedSocialView } from '../socialView'
 import { formatBadgeCount } from '../formatUnreadBadgeCount'
+import { createReplyContentSnippet } from '../replyPreview'
 import { ROUTES } from '../routes'
 
 type FriendsFilter = 'all' | 'online' | 'requests'
@@ -1470,7 +1471,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                 onCancelReply={() => setReplyingToDm(null)}
                 onReplyToMessage={(msg) => {
                   const username = msg.author?.username ?? 'User'
-                  const snippet = msg.content.length > 80 ? msg.content.slice(0, 80) + '...' : msg.content
+                  const snippet = createReplyContentSnippet(msg.content)
                   setReplyingToDm({ id: msg.id, username, contentSnippet: snippet })
                 }}
                 isViewActive={isMessagesView}

--- a/apps/web/src/replyPreview.test.ts
+++ b/apps/web/src/replyPreview.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { cleanReplyQuotePreview, createReplyContentSnippet } from './replyPreview'
+
+describe('reply preview helpers', () => {
+  it('uses the body when replying to an existing reply message', () => {
+    expect(createReplyContentSnippet('> @alice: hello there\n\nactual response')).toBe('actual response')
+  })
+
+  it('does not recursively include nested reply quote prefixes', () => {
+    expect(cleanReplyQuotePreview('> @alice: > @bob: hello there')).toBe('hello there')
+  })
+
+  it('normalizes whitespace and truncates long snippets', () => {
+    const snippet = createReplyContentSnippet('line one\nline two and some extra text', 12)
+    expect(snippet).toBe('line one lin...')
+  })
+})

--- a/apps/web/src/replyPreview.ts
+++ b/apps/web/src/replyPreview.ts
@@ -1,0 +1,34 @@
+const REPLY_PREFIX_RE = /^>\s*@[^:]+:\s*/s
+
+function parseReplyEnvelope(content: string): { quote: string; body: string } | null {
+  if (!content.startsWith('> @')) return null
+  const doubleNewline = content.indexOf('\n\n')
+  if (doubleNewline < 0) return null
+  const quotePart = content.slice(0, doubleNewline).trim()
+  const body = content.slice(doubleNewline + 2).trim()
+  const match = quotePart.match(/^>\s*@([^:]+):\s*(.*)$/s)
+  if (!match) return null
+  return { quote: match[2].trim(), body }
+}
+
+export function cleanReplyQuotePreview(content: string): string {
+  let text = content.replace(/\s+/g, ' ').trim()
+  for (let i = 0; i < 8; i += 1) {
+    const next = text.replace(REPLY_PREFIX_RE, '').trim()
+    if (next === text) break
+    text = next
+  }
+  return text
+}
+
+export function createReplyContentSnippet(content: string, maxLength = 80): string {
+  let text = content.trim()
+  for (let i = 0; i < 8; i += 1) {
+    const parsed = parseReplyEnvelope(text)
+    if (!parsed) break
+    text = parsed.body || parsed.quote
+  }
+
+  const normalized = cleanReplyQuotePreview(text)
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}...` : normalized
+}


### PR DESCRIPTION
## Summary

Polish chat/settings UI behavior and make reply previews cleaner.

## Changes

- Render Settings sub-modals through a body portal so username, email, password, and delete-account dialogs stay above chat and voice UI.
- Make message notification sounds more distinct from voice channel join/leave cues.
- Remove the lone icon from the channel context menu mute action for visual consistency.
- Clean reply previews so replying to a reply no longer recursively includes nested quote prefixes.
- Apply reply preview cleanup to both server chat and DMs.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
