### PR TITLE
feat: implement inline media image component and update emoji picker …

### DIFF
--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -3,11 +3,12 @@ import { createPortal } from 'react-dom'
 import { Hash, Volume2, Send, Paperclip, X, Save, Search, ChevronRight, Smile, Pin, PinOff, Users, ArrowDown } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { Attachment } from '../types'
-import { resolveAttachmentUrl, resolveAvatarUrl, resolveInlineMediaUrl, type MessageWithAuthor, type Channel } from '../api'
+import { resolveAttachmentUrl, resolveAvatarUrl, type MessageWithAuthor, type Channel } from '../api'
 import type { DraftAttachmentItem } from '../draftAttachments'
 import { openExternalUrl } from '../openExternalUrl'
 import { cleanReplyQuotePreview } from '../replyPreview'
 import EmojiPicker from './EmojiPicker'
+import InlineMediaImage from './InlineMediaImage'
 import MessageInlineActions from './MessageInlineActions'
 import { useAuthStore } from '../stores/auth'
 
@@ -988,10 +989,9 @@ export default function ChatArea({
                 {stickerUrls.length > 0 && (
                     <div className="chat-inline-gif-list">
                         {stickerUrls.map((url, index) => {
-                            const previewUrl = resolveInlineMediaUrl(url) ?? url
                             return (
                                 <a key={`${url}-${index}`} href={url} target="_blank" rel="noreferrer" className="chat-inline-gif-link chat-inline-sticker-link">
-                                    <img src={previewUrl} alt="Sticker preview" className="chat-inline-sticker" loading="lazy" />
+                                    <InlineMediaImage src={url} alt="Sticker preview" className="chat-inline-sticker" />
                                 </a>
                             )
                         })}
@@ -1000,10 +1000,9 @@ export default function ChatArea({
                 {gifUrls.length > 0 && (
                     <div className="chat-inline-gif-list">
                         {gifUrls.map((url, index) => {
-                            const previewUrl = resolveInlineMediaUrl(url) ?? url
                             return (
                                 <a key={`${url}-${index}`} href={url} target="_blank" rel="noreferrer" className="chat-inline-gif-link">
-                                    <img src={previewUrl} alt="GIF preview" className="chat-inline-gif" loading="lazy" />
+                                    <InlineMediaImage src={url} alt="GIF preview" className="chat-inline-gif" />
                                 </a>
                             )
                         })}

--- a/apps/web/src/components/EmojiPicker.tsx
+++ b/apps/web/src/components/EmojiPicker.tsx
@@ -8,7 +8,7 @@ import {
   getReactionModeEmojiOptions,
   type EmojiOption,
 } from '../emoji'
-import { resolveInlineMediaUrl } from '../api'
+import InlineMediaImage from './InlineMediaImage'
 
 type EmojiPickerProps = {
   onSelect: (emoji: string) => void
@@ -144,7 +144,7 @@ export default function EmojiPicker({
                   title={entry.label}
                   aria-label={entry.label}
                 >
-                  <img src={resolveInlineMediaUrl(entry.url) ?? entry.url} alt={entry.label} loading="lazy" />
+                  <InlineMediaImage src={entry.url} alt={entry.label} />
                   <span>{entry.label}</span>
                 </button>
               ))}
@@ -164,7 +164,7 @@ export default function EmojiPicker({
                   title={entry.label}
                   aria-label={entry.label}
                 >
-                  <img src={resolveInlineMediaUrl(entry.imageUrl) ?? entry.imageUrl} alt={entry.label} className="chat-sticker-image" loading="lazy" />
+                  <InlineMediaImage src={entry.imageUrl} alt={entry.label} className="chat-sticker-image" />
                   <span className="chat-sticker-label">{entry.label}</span>
                 </button>
               ))}

--- a/apps/web/src/components/InlineMediaImage.tsx
+++ b/apps/web/src/components/InlineMediaImage.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useMemo, useState } from 'react'
+import { resolveInlineMediaUrl } from '../api'
+import { trustedInlineMediaFallbackUrl } from '../inlineMediaSources'
+
+type InlineMediaImageProps = {
+  src: string
+  alt: string
+  className?: string
+}
+
+export default function InlineMediaImage({ src, alt, className }: InlineMediaImageProps) {
+  const [useFallback, setUseFallback] = useState(false)
+  const fallbackUrl = useMemo(() => trustedInlineMediaFallbackUrl(src), [src])
+  const primaryUrl = resolveInlineMediaUrl(src) ?? src
+  const activeUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl
+
+  useEffect(() => {
+    setUseFallback(false)
+  }, [src])
+
+  return (
+    <img
+      src={activeUrl}
+      alt={alt}
+      className={className}
+      loading="lazy"
+      onError={() => {
+        if (!useFallback && fallbackUrl && activeUrl !== fallbackUrl) {
+          setUseFallback(true)
+        }
+      }}
+    />
+  )
+}

--- a/apps/web/src/emoji.ts
+++ b/apps/web/src/emoji.ts
@@ -585,6 +585,90 @@ export const GIF_OPTIONS: GifOption[] = [
     url: 'https://media.giphy.com/media/xUPGcjQ6dJEjH5uwMw/giphy.gif',
     keywords: ['bye', 'peace', 'later'],
   },
+  {
+    id: 'ship-it',
+    label: 'Ship it',
+    url: 'https://media.giphy.com/media/13HgwGsXF0aiGY/giphy.gif',
+    keywords: ['ship', 'done', 'approve'],
+  },
+  {
+    id: 'lets-go',
+    label: "Let's go",
+    url: 'https://media.giphy.com/media/11ISwbgCxEzMyY/giphy.gif',
+    keywords: ['go', 'hype', 'party'],
+  },
+  {
+    id: 'loading',
+    label: 'Loading',
+    url: 'https://media.giphy.com/media/3oEjI6SIIHBdRxXI40/giphy.gif',
+    keywords: ['loading', 'wait', 'thinking'],
+  },
+  {
+    id: 'nailed-it',
+    label: 'Nailed it',
+    url: 'https://media.giphy.com/media/5VKbvrjxpVJCM/giphy.gif',
+    keywords: ['win', 'done', 'nice'],
+  },
+  {
+    id: 'focus',
+    label: 'Focus',
+    url: 'https://media.giphy.com/media/l0HlPystfePnAI3G8/giphy.gif',
+    keywords: ['focus', 'math', 'confused'],
+  },
+  {
+    id: 'well-played',
+    label: 'Well played',
+    url: 'https://media.giphy.com/media/3o7aD2saalBwwftBIY/giphy.gif',
+    keywords: ['well played', 'nice', 'win'],
+  },
+  {
+    id: 'thinking-loop',
+    label: 'Thinking loop',
+    url: 'https://media.giphy.com/media/l0HlNaQ6gWfllcjDO/giphy.gif',
+    keywords: ['thinking', 'hmm', 'wait'],
+  },
+  {
+    id: 'party-ready',
+    label: 'Party ready',
+    url: 'https://media.giphy.com/media/26xBwdIuRJiAIqHwA/giphy.gif',
+    keywords: ['party', 'ready', 'hype'],
+  },
+  {
+    id: 'cheers',
+    label: 'Cheers',
+    url: 'https://media.giphy.com/media/3o6Zt6ML6BklcajjsA/giphy.gif',
+    keywords: ['cheers', 'celebrate', 'toast'],
+  },
+  {
+    id: 'good-vibes',
+    label: 'Good vibes',
+    url: 'https://media.giphy.com/media/l0Exk8EUzSLsrErEQ/giphy.gif',
+    keywords: ['vibes', 'happy', 'nice'],
+  },
+  {
+    id: 'confetti',
+    label: 'Confetti',
+    url: 'https://media.giphy.com/media/26gsspfbt1HfVQ9va/giphy.gif',
+    keywords: ['confetti', 'celebrate', 'party'],
+  },
+  {
+    id: 'dramatic-nod',
+    label: 'Dramatic nod',
+    url: 'https://media.giphy.com/media/l4FGuhL4U2WyjdkaY/giphy.gif',
+    keywords: ['nod', 'agree', 'yes'],
+  },
+  {
+    id: 'sparkle-win',
+    label: 'Sparkle win',
+    url: 'https://media.giphy.com/media/3o7qE1YN7aBOFPRw8E/giphy.gif',
+    keywords: ['sparkle', 'win', 'celebrate'],
+  },
+  {
+    id: 'mind-blown-loop',
+    label: 'Mind blown loop',
+    url: 'https://media.giphy.com/media/26BRBKqUiq586bRVm/giphy.gif',
+    keywords: ['mind blown', 'wow', 'surprised'],
+  },
 ]
 
 export const STICKER_OPTIONS: StickerOption[] = [
@@ -923,6 +1007,30 @@ export const STICKER_OPTIONS: StickerOption[] = [
     label: 'Peace',
     imageUrl: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/270c.png',
     keywords: ['peace', 'bye', 'later'],
+  },
+  {
+    id: 'bug',
+    label: 'Bug',
+    imageUrl: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f41b.png',
+    keywords: ['bug', 'issue', 'fix'],
+  },
+  {
+    id: 'tools',
+    label: 'Tools',
+    imageUrl: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f6e0.png',
+    keywords: ['tools', 'fix', 'work'],
+  },
+  {
+    id: 'gem',
+    label: 'Gem',
+    imageUrl: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f48e.png',
+    keywords: ['gem', 'nice', 'polish'],
+  },
+  {
+    id: 'shield',
+    label: 'Shield',
+    imageUrl: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f6e1.png',
+    keywords: ['shield', 'security', 'safe'],
   },
 ]
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5385,7 +5385,9 @@ body {
   display: inline-flex;
   border-radius: 10px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.09);
+  border: none;
+  background: transparent;
+  box-shadow: none;
   max-width: min(320px, 100%);
 }
 

--- a/apps/web/src/inlineMediaSources.test.ts
+++ b/apps/web/src/inlineMediaSources.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { trustedInlineMediaFallbackUrl } from './inlineMediaSources'
+
+describe('trustedInlineMediaFallbackUrl', () => {
+  it('allows built-in Giphy media as a direct preview fallback', () => {
+    const url = 'https://media.giphy.com/media/26u4cqiYI30juCOGY/giphy.gif'
+
+    expect(trustedInlineMediaFallbackUrl(url)).toBe(url)
+  })
+
+  it('allows built-in Twemoji stickers as a direct preview fallback', () => {
+    const url = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f389.png'
+
+    expect(trustedInlineMediaFallbackUrl(url)).toBe(url)
+  })
+
+  it('rejects untrusted or non-https media fallbacks', () => {
+    expect(trustedInlineMediaFallbackUrl('http://media.giphy.com/media/example/giphy.gif')).toBeNull()
+    expect(trustedInlineMediaFallbackUrl('https://example.giphy.com/media/example/giphy.gif')).toBeNull()
+    expect(trustedInlineMediaFallbackUrl('https://example.com/media.gif')).toBeNull()
+  })
+})

--- a/apps/web/src/inlineMediaSources.ts
+++ b/apps/web/src/inlineMediaSources.ts
@@ -1,0 +1,20 @@
+const TRUSTED_GIPHY_HOST_RE = /^media\d*\.giphy\.com$/i
+const TRUSTED_TWEMOJI_HOST = 'cdn.jsdelivr.net'
+const TRUSTED_TWEMOJI_PATH_PREFIX = '/gh/twitter/twemoji@'
+
+export function trustedInlineMediaFallbackUrl(rawUrl: string): string | null {
+  try {
+    const url = new URL(rawUrl)
+    if (url.protocol !== 'https:') return null
+    if (TRUSTED_GIPHY_HOST_RE.test(url.hostname)) return rawUrl
+    if (
+      url.hostname === TRUSTED_TWEMOJI_HOST &&
+      url.pathname.startsWith(TRUSTED_TWEMOJI_PATH_PREFIX)
+    ) {
+      return rawUrl
+    }
+    return null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Improve GIF and sticker media reliability in chat.

## Changes

- Added trusted inline media fallback handling for built-in GIF and sticker sources.
- Fixed broken GIF/sticker preview behavior in the picker.
- Removed the unwanted square border/background around inline GIF messages.
- Expanded the built-in GIF catalog with reliable working entries.
- Kept GIF and sticker catalogs balanced at 60 items each.

## Validation

- `npm run test:run -- inlineMediaSources`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `graphify update .`
