### PR TITLE
feat: enhance image attachment handling with preview modal and improv…

### DIFF
--- a/apps/web/src/api/attachments.ts
+++ b/apps/web/src/api/attachments.ts
@@ -1,23 +1,58 @@
-import { isTauri } from '../secureStorage'
+import { getSecureToken, isTauri } from '../secureStorage'
 import { apiMultipartFetch } from './client'
 import type { AuthToken, UploadedAttachment } from './contracts'
 
-export async function resolveAttachmentUrl(url: string, token: string | null): Promise<string> {
-    // Desktop attachments are protected by Bearer auth, so <img src="..."> cannot
-    // load them directly. Resolve them through the same Tauri HTTP path in both
-    // dev and packaged builds, then render the returned blob in-app.
-    if (!isTauri() || !token) return url
+function isLoopbackAttachmentUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url, typeof window === 'undefined' ? undefined : window.location.href)
+        return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1'
+    } catch {
+        return false
+    }
+}
+
+export async function resolveAttachmentUrl(
+    url: string,
+    token: string | null,
+    options?: { forceAuthenticatedFetch?: boolean; fallbackMimeType?: string }
+): Promise<string> {
+    // Desktop production attachments need Bearer auth, while local desktop dev can
+    // rely on the same localhost cookie path as the web app. In both cases we
+    // resolve to a blob URL so the chat preview stays in-app.
+    const isDesktop = isTauri()
+    const shouldUseBrowserFetch = !isDesktop || isLoopbackAttachmentUrl(url)
+    if (!isDesktop && !options?.forceAuthenticatedFetch) return url
+    if (shouldUseBrowserFetch) {
+        const headers: Record<string, string> = {}
+        if (token) headers.Authorization = `Bearer ${token}`
+        const res = await fetch(url, {
+            method: 'GET',
+            headers,
+            credentials: 'include',
+        })
+        if (!res.ok) {
+            throw new Error(`Attachment request failed with HTTP ${res.status}`)
+        }
+        const blob = new Blob([await res.arrayBuffer()], {
+            type: res.headers.get('content-type') || options?.fallbackMimeType || 'application/octet-stream',
+        })
+        return URL.createObjectURL(blob)
+    }
+    const desktopToken = token ?? await getSecureToken()
+    if (!desktopToken) return url
     const res = await (await import('@tauri-apps/plugin-http')).fetch(url, {
         method: 'GET',
         headers: {
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${desktopToken}`,
         },
         timeout: 60,
     } as RequestInit & { timeout?: number })
     if (!res.ok) {
         throw new Error(`Attachment request failed with HTTP ${res.status}`)
     }
-    const blob = await res.blob()
+    const blob = new Blob([await res.arrayBuffer()], {
+        type: res.headers.get('content-type') || options?.fallbackMimeType || 'application/octet-stream',
+    })
     return URL.createObjectURL(blob)
 }
 

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -60,12 +60,85 @@ function extractEmbeddedMediaMarkdown(content: string): { text: string; gifUrls:
     return { text, gifUrls, stickerUrls }
 }
 
+function AttachmentImagePreviewModal({
+    src,
+    title,
+    onClose,
+    onImageLoadError,
+}: {
+    src: string
+    title: string
+    onClose: () => void
+    onImageLoadError: () => void
+}) {
+    useEffect(() => {
+        const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+            if (event.key === 'Escape') onClose()
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [onClose])
+
+    if (typeof document === 'undefined') return null
+
+    return createPortal(
+        <div
+            className="chat-image-preview-backdrop"
+            role="dialog"
+            aria-modal="true"
+            aria-label={title}
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) onClose()
+            }}
+        >
+            <div className="chat-image-preview-modal">
+                <div className="chat-image-preview-toolbar">
+                    <span className="chat-image-preview-title">{title}</span>
+                    <button
+                        type="button"
+                        className="chat-image-preview-close"
+                        onClick={onClose}
+                        aria-label="Close image preview"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+                <div className="chat-image-preview-stage">
+                    <img
+                        src={src}
+                        alt={title}
+                        className="chat-image-preview-image"
+                        onError={onImageLoadError}
+                    />
+                </div>
+            </div>
+        </div>,
+        document.body
+    )
+}
+
+function isImageAttachment(attachment: Attachment): boolean {
+    if (typeof attachment?.type === 'string' && attachment.type.startsWith('image/')) return true
+    const name = attachment.name ?? ''
+    const path = (() => {
+        try {
+            return new URL(attachment.url).pathname
+        } catch {
+            return attachment.url
+        }
+    })()
+    return /\.(apng|avif|gif|jpe?g|png|webp)$/i.test(`${name} ${path}`)
+}
+
 function AttachmentLink({ attachment, index }: { attachment: Attachment; index: number }) {
     const token = useAuthStore((s) => s.token)
+    const [previewOpen, setPreviewOpen] = useState(false)
+    const isImage = isImageAttachment(attachment)
     const [resolution, setResolution] = useState(() => ({
         sourceUrl: attachment.url,
         resolvedUrl: attachment.url,
         loadFailed: false,
+        triedDirectFallback: false,
     }))
     const currentResolution = resolution.sourceUrl === attachment.url
         ? resolution
@@ -73,13 +146,17 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
             sourceUrl: attachment.url,
             resolvedUrl: attachment.url,
             loadFailed: false,
+            triedDirectFallback: false,
         }
 
     useEffect(() => {
         let cancelled = false
         let objectUrl: string | null = null
 
-        resolveAttachmentUrl(attachment.url, token ?? null)
+        resolveAttachmentUrl(attachment.url, token ?? null, {
+            forceAuthenticatedFetch: isImage,
+            fallbackMimeType: attachment.type,
+        })
             .then((nextUrl) => {
                 if (cancelled) {
                     if (nextUrl.startsWith('blob:')) URL.revokeObjectURL(nextUrl)
@@ -90,6 +167,7 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
                     sourceUrl: attachment.url,
                     resolvedUrl: nextUrl,
                     loadFailed: false,
+                    triedDirectFallback: false,
                 })
             })
             .catch(() => {
@@ -97,7 +175,8 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
                     setResolution({
                         sourceUrl: attachment.url,
                         resolvedUrl: attachment.url,
-                        loadFailed: true,
+                        loadFailed: isImage,
+                        triedDirectFallback: true,
                     })
                 }
             })
@@ -106,21 +185,51 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
             cancelled = true
             if (objectUrl) URL.revokeObjectURL(objectUrl)
         }
-    }, [attachment.url, token])
+    }, [attachment.type, attachment.url, isImage, token])
 
-    const isImage = typeof attachment?.type === 'string' && attachment.type.startsWith('image/')
     if (isImage) {
+        const alt = attachment.name || `Attachment ${index + 1}`
+        const handleImageLoadError = () => {
+            setResolution((current) => {
+                if (current.sourceUrl !== attachment.url) return current
+                if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
+                return {
+                    ...current,
+                    loadFailed: true,
+                }
+            })
+        }
         if (currentResolution.loadFailed) {
             return (
-                <a href={attachment.url} target="_blank" rel="noreferrer" className="dm-attachment-link">
+                <span className="dm-attachment-link chat-image-unavailable" title="Image preview could not be loaded">
                     {attachment.name || `Image attachment ${index + 1}`}
-                </a>
+                </span>
             )
         }
         return (
-            <a href={currentResolution.resolvedUrl} target="_blank" rel="noreferrer" className="chat-image-link">
-                <img src={currentResolution.resolvedUrl} alt={attachment.name || `Attachment ${index + 1}`} className="chat-image-attachment" />
-            </a>
+            <>
+                <button
+                    type="button"
+                    className="chat-image-link chat-image-preview-trigger"
+                    onClick={() => setPreviewOpen(true)}
+                    aria-label={`Preview ${alt}`}
+                >
+                    <img
+                        src={currentResolution.resolvedUrl}
+                        alt={alt}
+                        className="chat-image-attachment"
+                        onError={handleImageLoadError}
+                    />
+                </button>
+                {previewOpen && (
+                    <AttachmentImagePreviewModal
+                        src={currentResolution.resolvedUrl}
+                        title={alt}
+                        onClose={() => setPreviewOpen(false)}
+                        onImageLoadError={handleImageLoadError}
+                    />
+                )}
+            </>
         )
     }
 
@@ -990,9 +1099,16 @@ export default function ChatArea({
                     <div className="chat-inline-gif-list">
                         {stickerUrls.map((url, index) => {
                             return (
-                                <a key={`${url}-${index}`} href={url} target="_blank" rel="noreferrer" className="chat-inline-gif-link chat-inline-sticker-link">
+                                <div
+                                    key={`${url}-${index}`}
+                                    className="chat-inline-gif-link chat-inline-sticker-link"
+                                    onClickCapture={(event) => {
+                                        event.preventDefault()
+                                        event.stopPropagation()
+                                    }}
+                                >
                                     <InlineMediaImage src={url} alt="Sticker preview" className="chat-inline-sticker" />
-                                </a>
+                                </div>
                             )
                         })}
                     </div>
@@ -1001,9 +1117,16 @@ export default function ChatArea({
                     <div className="chat-inline-gif-list">
                         {gifUrls.map((url, index) => {
                             return (
-                                <a key={`${url}-${index}`} href={url} target="_blank" rel="noreferrer" className="chat-inline-gif-link">
+                                <div
+                                    key={`${url}-${index}`}
+                                    className="chat-inline-gif-link"
+                                    onClickCapture={(event) => {
+                                        event.preventDefault()
+                                        event.stopPropagation()
+                                    }}
+                                >
                                     <InlineMediaImage src={url} alt="GIF preview" className="chat-inline-gif" />
-                                </a>
+                                </div>
                             )
                         })}
                     </div>

--- a/apps/web/src/components/EmojiPicker.tsx
+++ b/apps/web/src/components/EmojiPicker.tsx
@@ -145,7 +145,6 @@ export default function EmojiPicker({
                   aria-label={entry.label}
                 >
                   <InlineMediaImage src={entry.url} alt={entry.label} />
-                  <span>{entry.label}</span>
                 </button>
               ))}
             </div>
@@ -165,7 +164,6 @@ export default function EmojiPicker({
                   aria-label={entry.label}
                 >
                   <InlineMediaImage src={entry.imageUrl} alt={entry.label} className="chat-sticker-image" />
-                  <span className="chat-sticker-label">{entry.label}</span>
                 </button>
               ))}
             </div>

--- a/apps/web/src/components/InlineMediaImage.tsx
+++ b/apps/web/src/components/InlineMediaImage.tsx
@@ -10,24 +10,41 @@ type InlineMediaImageProps = {
 
 export default function InlineMediaImage({ src, alt, className }: InlineMediaImageProps) {
   const [useFallback, setUseFallback] = useState(false)
-  const fallbackUrl = useMemo(() => trustedInlineMediaFallbackUrl(src), [src])
-  const primaryUrl = resolveInlineMediaUrl(src) ?? src
+  const [loadFailed, setLoadFailed] = useState(false)
+  const trustedDirectUrl = useMemo(() => trustedInlineMediaFallbackUrl(src), [src])
+  const proxiedUrl = resolveInlineMediaUrl(src) ?? src
+  const primaryUrl = trustedDirectUrl ?? proxiedUrl
+  const fallbackUrl = trustedDirectUrl && trustedDirectUrl !== primaryUrl ? trustedDirectUrl : null
   const activeUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl
 
   useEffect(() => {
     setUseFallback(false)
+    setLoadFailed(false)
   }, [src])
+
+  if (loadFailed) {
+    return (
+      <span
+        className={`${className ?? ''} inline-media-unavailable`.trim()}
+        role="img"
+        aria-label={`${alt} unavailable`}
+      />
+    )
+  }
 
   return (
     <img
       src={activeUrl}
       alt={alt}
       className={className}
+      draggable={false}
       loading="lazy"
       onError={() => {
         if (!useFallback && fallbackUrl && activeUrl !== fallbackUrl) {
           setUseFallback(true)
+          return
         }
+        setLoadFailed(true)
       }}
     />
   )

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4523,9 +4523,9 @@ body {
 
 .message.message-compact .message-inline-actions {
   position: absolute;
-  top: 50%;
+  top: 2px;
   right: 0;
-  transform: translateY(-50%);
+  transform: none;
   z-index: 1;
 }
 
@@ -5298,12 +5298,12 @@ body {
 
 .chat-gif-item {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  align-items: center;
+  justify-content: center;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.03);
-  padding: 6px;
+  padding: 5px;
   color: var(--text-secondary);
   cursor: pointer;
   align-self: start;
@@ -5322,12 +5322,6 @@ body {
   border-radius: 8px;
 }
 
-.chat-gif-item span {
-  font-size: 11px;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
 .chat-sticker-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -5343,9 +5337,8 @@ body {
 
 .chat-sticker-item {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.03);
@@ -5362,16 +5355,10 @@ body {
 }
 
 .chat-sticker-image {
-  width: 56px;
-  height: 56px;
+  width: 64px;
+  height: 64px;
   object-fit: contain;
   image-rendering: -webkit-optimize-contrast;
-}
-
-.chat-sticker-label {
-  font-size: 11px;
-  font-weight: 700;
-  line-height: 1.1;
 }
 
 .chat-inline-gif-list {
@@ -5389,6 +5376,7 @@ body {
   background: transparent;
   box-shadow: none;
   max-width: min(320px, 100%);
+  cursor: default;
 }
 
 .chat-inline-gif {
@@ -5413,6 +5401,23 @@ body {
   object-fit: contain;
   display: block;
   filter: drop-shadow(0 8px 18px rgba(7, 11, 24, 0.18));
+}
+
+.inline-media-unavailable {
+  min-width: 96px;
+  min-height: 72px;
+  border: var(--border-subtle);
+  border-radius: 10px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02)),
+    rgba(10, 14, 26, 0.5);
+}
+
+.chat-inline-sticker.inline-media-unavailable {
+  width: 88px;
+  height: 88px;
+  min-width: 88px;
+  min-height: 88px;
 }
 
 /* ============================================
@@ -8273,6 +8278,94 @@ a.community-open-btn:hover {
   border-radius: 8px;
   overflow: hidden;
   border: var(--border-subtle);
+}
+
+.chat-image-preview-trigger {
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.chat-image-preview-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 11000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  background: rgba(4, 6, 12, 0.76);
+  backdrop-filter: blur(8px);
+}
+
+.chat-image-preview-modal {
+  width: min(1120px, 100%);
+  max-height: min(860px, calc(100vh - 56px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: var(--border-subtle);
+  border-radius: 12px;
+  background: rgba(16, 20, 34, 0.98);
+  box-shadow: var(--shadow-lg);
+}
+
+.chat-image-preview-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  padding: 8px 10px 8px 14px;
+  border-bottom: var(--border-subtle);
+}
+
+.chat-image-preview-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-image-preview-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  border: var(--border-subtle);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.chat-image-preview-close {
+  width: 32px;
+}
+
+.chat-image-preview-close:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.chat-image-preview-stage {
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.chat-image-preview-image {
+  display: block;
+  max-width: 100%;
+  max-height: calc(100vh - 148px);
+  object-fit: contain;
+  border-radius: 8px;
+  background: #0b0d14;
 }
 
 .chat-image-attachment {
@@ -12801,13 +12894,17 @@ textarea {
 
   .chat-header-search-expanded {
     width: auto;
-    max-width: min(100%, 176px);
+    max-width: min(100%, 132px);
   }
 
   .chat-header-search-input {
     min-width: 0;
-    width: 88px;
-    padding: 6px 8px;
+    width: 72px;
+    padding: 6px 7px;
+  }
+
+  .chat-header-search-help {
+    display: none;
   }
 
   .home-chip-row {
@@ -13801,14 +13898,14 @@ textarea {
     flex-wrap: wrap;
     gap: 2px 6px;
     margin-bottom: 1px;
-    padding-right: 96px;
+    padding-right: 108px;
   }
 
   .message-author {
     font-size: 13px;
     flex: 0 1 auto;
     min-width: 0;
-    max-width: calc(100% - 96px);
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -13833,10 +13930,41 @@ textarea {
     right: 0;
     margin-left: 0;
     gap: 2px;
+    width: max-content;
+    padding: 1px 3px;
+    border-radius: 8px;
+    background: rgba(14, 20, 36, 0.72);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+    transform: none;
+  }
+
+  .message.message-compact .message-inline-actions {
+    position: absolute;
+    top: 2px;
+    right: 0;
+    transform: none;
+    margin-bottom: 0;
   }
 
   .message-inline-action-btn {
     padding: 4px;
+  }
+
+  .chat-inline-gif-link {
+    max-width: min(280px, 100%);
+  }
+
+  .chat-inline-gif {
+    max-height: 176px;
+  }
+
+  .chat-inline-sticker-link {
+    max-width: 92px;
+  }
+
+  .chat-inline-sticker {
+    max-height: 92px;
   }
 
   .message-inline-actions .message-inline-action-btn--pin,


### PR DESCRIPTION
## Summary
- Add click-to-expand image preview modal with backdrop blur and keyboard (Esc) dismissal
- Improve desktop attachment resolution with loopback detection and authenticated fetch fallback
- Add graceful unavailable placeholder for failed image/GIF/sticker loads
- Refactor inline media (GIFs, stickers) to prevent accidental navigation and improve mobile sizing

## Changes
### Frontend
- **ChatArea.tsx**: New `AttachmentImagePreviewModal` (portal-based, backdrop click + Esc to close), `isImageAttachment` helper, preview trigger button replacing direct `<a>` links, sticker/GIF click handling fixes
- **attachments.ts**: `resolveAttachmentUrl` enhanced with loopback hostname detection, `forceAuthenticatedFetch` option, MIME type fallback, proper blob URL lifecycle
- **InlineMediaImage.tsx**: Trusted direct URL fallback, `loadFailed` state, unavailable placeholder rendering
- **index.css**: Preview modal styles (backdrop, toolbar, stage, close button), `.inline-media-unavailable` placeholder, compact message action bar polish, mobile-responsive GIF/sticker sizing

## Validation
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`

## Notes
- Image previews now use `button` elements instead of `<a>` tags to prevent new-tab navigation
- Blob URLs are properly revoked on unmount to avoid memory leaks
- Mobile: GIF max-width reduced to 280px, sticker max-width to 92px for better fit