### PR TITLE
feat: enhance loading state handling in ChatArea and AppLayout compon…

### DIFF
--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -1162,24 +1162,32 @@ export default function ChatArea({
     if (!activeChannel) {
         return (
             <div className="chat-area">
-                <div className="core-landing">
-                    <h2>Welcome to Voxpery</h2>
-                    <p>Simple communication focused on what matters most.</p>
-                    <div className="core-pillars">
-                        <div className="core-pillar">
-                            <div className="core-pillar-title">Messaging</div>
-                            <div className="core-pillar-desc">Fast channel chat and direct conversation flow.</div>
-                        </div>
-                        <div className="core-pillar">
-                            <div className="core-pillar-title">Voice Chat</div>
-                            <div className="core-pillar-desc">Low-latency voice with clean controls.</div>
-                        </div>
-                        <div className="core-pillar">
-                            <div className="core-pillar-title">Screen Sharing</div>
-                            <div className="core-pillar-desc">Share your screen in voice rooms when needed.</div>
+                {loading ? (
+                    <div className="chat-loading-state chat-loading-state--centered" aria-hidden="true">
+                        <div className="chat-loading-bubble" />
+                        <div className="chat-loading-bubble short" />
+                        <div className="chat-loading-bubble" />
+                    </div>
+                ) : (
+                    <div className="core-landing">
+                        <h2>Welcome to Voxpery</h2>
+                        <p>Simple communication focused on what matters most.</p>
+                        <div className="core-pillars">
+                            <div className="core-pillar">
+                                <div className="core-pillar-title">Messaging</div>
+                                <div className="core-pillar-desc">Fast channel chat and direct conversation flow.</div>
+                            </div>
+                            <div className="core-pillar">
+                                <div className="core-pillar-title">Voice Chat</div>
+                                <div className="core-pillar-desc">Low-latency voice with clean controls.</div>
+                            </div>
+                            <div className="core-pillar">
+                                <div className="core-pillar-title">Screen Sharing</div>
+                                <div className="core-pillar-desc">Share your screen in voice rooms when needed.</div>
+                            </div>
                         </div>
                     </div>
-                </div>
+                )}
             </div>
         )
     }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6515,6 +6515,12 @@ body {
   padding: 20px 16px 4px;
 }
 
+.chat-loading-state--centered {
+  flex: 1;
+  justify-content: center;
+  padding: 24px;
+}
+
 .chat-loading-bubble {
   height: 56px;
 }

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -421,6 +421,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [channelPins, setChannelPins] = useState<MessageWithAuthor[]>([])
     const [showMobileMemberSheet, setShowMobileMemberSheet] = useState(false)
     const [serverBootstrapLoading, setServerBootstrapLoading] = useState(false)
+    const [serverListReady, setServerListReady] = useState(false)
     const messagesScrollRef = useRef<HTMLDivElement | null>(null)
     const currentServerMember = useMemo(
         () => (user?.id ? members.find((member) => member.user_id === user.id) ?? null : null),
@@ -526,12 +527,19 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const inviteBaseUrl = resolveInviteBaseUrl()
 
     useEffect(() => {
-        if (!isLoggedIn) return
+        if (!isLoggedIn) {
+            setServerListReady(false)
+            return
+        }
+        setServerListReady(false)
         setServersLoading(true)
         serverApi.list(token)
             .then(setServers)
             .catch(console.error)
-            .finally(() => setServersLoading(false))
+            .finally(() => {
+                setServerListReady(true)
+                setServersLoading(false)
+            })
     }, [isLoggedIn, token, setServers, setServersLoading])
 
     useEffect(() => {
@@ -1605,6 +1613,13 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     }
 
     const activeServer = servers.find((s) => s.id === activeServerId)
+    const hasResolvedActiveChannel = !!activeChannelId && channels.some((c) => c.id === activeChannelId)
+    const serverRouteLoading = isLoggedIn && (
+        !serverListReady
+        || serverBootstrapLoading
+        || (servers.length > 0 && !activeServerId)
+        || (!!activeServerId && channels.length > 0 && !hasResolvedActiveChannel)
+    )
     const activeServerInviteLink = activeServer ? `${inviteBaseUrl}/invite/${activeServer.invite_code}` : ''
     const isSoloServer = !!activeServer && members.length <= 1
     const [myServerPermissions, setMyServerPermissions] = useState<Record<string, number>>({})
@@ -2909,7 +2924,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 />
             )}
             <ChannelSidebar
-                loading={serverBootstrapLoading || (!activeServerId && serversLoading)}
+                loading={serverRouteLoading || (!activeServerId && serversLoading)}
                 onOpenServerSettings={openServerSettingsModal}
                 onOpenCreateChannel={openCreateChannelModal}
                 onOpenCreateCategory={openCreateCategoryModal}
@@ -2943,7 +2958,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             )}
             <ChatArea
                 activeChannel={activeChannel}
-                loading={serverBootstrapLoading || (!activeServerId && serversLoading)}
+                loading={serverRouteLoading || (!activeServerId && serversLoading)}
                 messages={channelSearch.trim() ? (channelSearchResults ?? []) : messages}
                 unreadDividerCount={channelSearch.trim() ? 0 : channelUnreadDividerCount}
                 draftAttachments={draftAttachments}


### PR DESCRIPTION
## Summary

Fix the brief server refresh placeholder flash during app bootstrap.

## Changes

- Keep the server route in a neutral loading state while servers and the active channel are resolving.
- Prevent `ChatArea` from showing the generic Voxpery landing placeholder when channel data is still loading.
- Add a centered chat skeleton for the no-channel-but-loading state.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- Manual: refreshed inside server channels and confirmed the old placeholder no longer flashes.
