### PR TITLE
feat: set default DM privacy to 'everyone' for new accounts and updat…

### DIFF
--- a/apps/server/migrations/039_default_dm_privacy_everyone.sql
+++ b/apps/server/migrations/039_default_dm_privacy_everyone.sql
@@ -1,0 +1,4 @@
+-- New accounts should be open to DMs by default for small communities.
+-- Existing user preferences are preserved.
+ALTER TABLE users
+ALTER COLUMN dm_privacy SET DEFAULT 'everyone';

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -824,8 +824,8 @@ async fn register(
 
     // Insert user (use validated trimmed values)
     let user = sqlx::query_as::<_, User>(
-        r#"INSERT INTO users (id, username, email, password_hash, status, email_verified, created_at)
-           VALUES ($1, $2, $3, $4, 'online', FALSE, NOW())
+        r#"INSERT INTO users (id, username, email, password_hash, status, dm_privacy, email_verified, created_at)
+           VALUES ($1, $2, $3, $4, 'online', 'everyone', FALSE, NOW())
            RETURNING *"#,
     )
     .bind(Uuid::new_v4())
@@ -1705,7 +1705,7 @@ async fn google_oauth_callback(
             let id = Uuid::new_v4();
             if let Err(e) = sqlx::query(
                 r#"INSERT INTO users (id, username, email, password_hash, status, dm_privacy, google_id, email_verified, created_at)
-               VALUES ($1, $2, $3, $4, 'online', 'friends', $5, TRUE, NOW())"#,
+               VALUES ($1, $2, $3, $4, 'online', 'everyone', $5, TRUE, NOW())"#,
             )
             .bind(id)
             .bind(&username)

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -349,6 +349,7 @@ async fn register_login_me_flow() {
     assert_eq!(status, StatusCode::OK);
     let me: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(me["username"], username);
+    assert_eq!(me["dm_privacy"], "everyone");
     assert!(me["id"].as_str().is_some());
 
     // Login

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -211,7 +211,7 @@ export default function UserBar() {
   const [noiseSuppressionEnabled, setNoiseSuppressionEnabled] = useState(true)
   const [voiceInputProfile, setVoiceInputProfile] = useState<VoiceInputProfile>(() => getStoredVoiceInputProfile())
   const [dmPrivacy, setDmPrivacy] = useState<'everyone' | 'friends'>(
-    (user?.dm_privacy === 'everyone' || user?.dm_privacy === 'friends' ? user.dm_privacy : 'friends') ?? 'friends'
+    user?.dm_privacy === 'everyone' || user?.dm_privacy === 'friends' ? user.dm_privacy : 'everyone'
   )
   const [speakingThreshold, setSpeakingThreshold] = useState(() => thresholdByPreset(DEFAULT_SPEAKING_PRESET))
   const [speakingPreset, setSpeakingPreset] = useState<SpeakingPreset>(DEFAULT_SPEAKING_PRESET)
@@ -671,7 +671,7 @@ export default function UserBar() {
   }, [capturingPtt, markVoiceProfileCustom])
 
   useEffect(() => {
-    setDmPrivacy(user?.dm_privacy === 'everyone' || user?.dm_privacy === 'friends' ? user.dm_privacy : 'friends')
+    setDmPrivacy(user?.dm_privacy === 'everyone' || user?.dm_privacy === 'friends' ? user.dm_privacy : 'everyone')
   }, [user?.dm_privacy])
 
   useEffect(() => {

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,7 @@ Important behavior:
 - `GET /api/auth/me`
 - `PATCH /api/auth/status` (`status` values: `online`, `dnd`, `invisible`)
 - `PATCH /api/auth/profile`
-  - `dm_privacy` values: `everyone`, `friends`
+  - `dm_privacy` values: `everyone`, `friends`; new accounts default to `everyone`
 - `GET /api/auth/check-username?username=...`
 - `POST /api/auth/change-password`
 - `POST /api/auth/forgot-password`

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -41,7 +41,7 @@ Key columns:
 - `token_version` (session invalidation counter)
 - `avatar_url`
 - `status` (string; runtime uses `online`/`dnd`/`offline`)
-- `dm_privacy` (`everyone` or `friends` in current backend behavior)
+- `dm_privacy` (`everyone` or `friends`; new accounts default to `everyone`)
 - `google_id` (nullable unique)
 - `username_changed_at`
 - `created_at`
@@ -243,6 +243,7 @@ All migrations currently present:
 - `036_server_rules.sql`
 - `037_member_timeouts_and_raid_events.sql`
 - `038_server_onboarding_guides.sql`
+- `039_default_dm_privacy_everyone.sql`
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Set new account DM privacy to `everyone` by default.

## Changes

- Updated new user registration and Google OAuth account creation to default `dm_privacy` to `everyone`.
- Added a migration to update the database column default without changing existing user preferences.
- Updated the settings fallback and API/database docs.
- Added integration coverage for the new registration default.

## Validation

- `cargo check --locked`
- `cargo test --locked`
- `cargo test --locked register_login_me_flow`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
