### PR TITLE
feat: implement remote media visibility controls and screen share aud…

### DIFF
--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -1,4 +1,4 @@
-import { PhoneOff, Mic, MicOff, Monitor, Volume2, VolumeX, Maximize2, Minimize2, Users, Video, VideoOff, Wifi } from 'lucide-react'
+import { Eye, EyeOff, PhoneOff, Mic, MicOff, Monitor, Volume2, VolumeX, Maximize2, Minimize2, Users, Video, VideoOff, Wifi } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
@@ -21,10 +21,12 @@ import {
 import { ROUTES } from '../routes'
 import { attachMediaStreamPreview } from '../mediaStreamPreview'
 import { resolveAvatarUrl } from '../api'
+import { createRemoteAudioPlaybackStream, remoteMediaVisibilityKey, type RemoteMediaKind } from '../webrtc/remoteMediaControls'
 
 interface VoxperyTrack extends MediaStreamTrack {
   __voxpery_isCamera?: boolean
   __voxpery_isScreenShare?: boolean
+  __voxpery_isScreenShareAudio?: boolean
 }
 
 interface VoxperyAudioElement extends HTMLAudioElement {
@@ -184,6 +186,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   })
   const [fullscreenTileKey, setFullscreenTileKey] = useState<string | null>(null)
+  const [hiddenRemoteMediaKeys, setHiddenRemoteMediaKeys] = useState<Set<string>>(() => new Set())
   const lastVoiceQualityWarningRef = useRef<string | null>(null)
   useEffect(() => {
     const onFullscreenChange = () => {
@@ -258,9 +261,10 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   }, [members, peerVolumeByUserId])
 
   const peerIdsWithScreenShareRef = useRef<Set<string>>(new Set())
+  const hiddenScreenSharePeerIdsRef = useRef<Set<string>>(new Set())
   const getPeerVolumeFactor = useCallback((peerId: string) => {
     const volumeKey = resolvePeerVolumeKey(peerId)
-    const useScreenKey = peerIdsWithScreenShareRef.current.has(peerId)
+    const useScreenKey = peerIdsWithScreenShareRef.current.has(peerId) && !hiddenScreenSharePeerIdsRef.current.has(peerId)
     const storageKey = useScreenKey ? `screen:${volumeKey}` : volumeKey
     const raw = peerVolumeByUserId[storageKey]
     const bounded = typeof raw === 'number' && Number.isFinite(raw) ? Math.min(200, Math.max(0, raw)) : 100
@@ -427,6 +431,32 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     const ids = Array.from(state.remoteStreams.keys()).sort()
     return ids.join(',')
   }, [state.remoteStreams])
+  const currentVoiceChannelId = state.joinedChannelId
+  useEffect(() => {
+    setHiddenRemoteMediaKeys(new Set())
+  }, [currentVoiceChannelId])
+
+  const getRemoteMediaKey = useCallback((peerId: string, kind: RemoteMediaKind) => {
+    if (!currentVoiceChannelId) return null
+    return remoteMediaVisibilityKey(currentVoiceChannelId, peerId, kind)
+  }, [currentVoiceChannelId])
+
+  const isRemoteMediaHidden = useCallback((peerId: string, kind: RemoteMediaKind) => {
+    const key = getRemoteMediaKey(peerId, kind)
+    return !!key && hiddenRemoteMediaKeys.has(key)
+  }, [getRemoteMediaKey, hiddenRemoteMediaKeys])
+
+  const setRemoteMediaHidden = useCallback((peerId: string, kind: RemoteMediaKind, hidden: boolean) => {
+    const key = getRemoteMediaKey(peerId, kind)
+    if (!key) return
+    setHiddenRemoteMediaKeys((current) => {
+      const next = new Set(current)
+      if (hidden) next.add(key)
+      else next.delete(key)
+      return next
+    })
+  }, [getRemoteMediaKey])
+
   // Track total audio track count so we re-trigger playback when screen share audio arrives
   const remoteAudioTrackCount = useMemo(() => {
     let count = 0
@@ -436,7 +466,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     return count
   }, [state.remoteStreams])
   const remoteVideoTrackEntries = useMemo(() => {
-    const entries: Array<{ peerId: string; track: MediaStreamTrack; label: string }> = []
+    const entries: Array<{ peerId: string; track: MediaStreamTrack; label: string; kind: RemoteMediaKind }> = []
     for (const [peerId, stream] of remoteEntries) {
       const tracks = stream
         .getVideoTracks()
@@ -444,7 +474,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       for (const track of tracks) {
         // Prefer camera: if track was published as Camera, always show "Camera" (not "Screen share")
         if ('__voxpery_isCamera' in track && (track as VoxperyTrack).__voxpery_isCamera) {
-          entries.push({ peerId, track, label: 'Camera' })
+          entries.push({ peerId, track, label: 'Camera', kind: 'camera' })
           continue
         }
         // Screen share: authoritative set from useLiveKitVoice or property set on subscribe
@@ -457,26 +487,41 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
             label.includes('window') ||
             label.includes('tab')
         }
-        entries.push({ peerId, track, label: isScreen ? 'Screen share' : 'Camera' })
+        entries.push({ peerId, track, label: isScreen ? 'Screen share' : 'Camera', kind: isScreen ? 'screen' : 'camera' })
       }
     }
     return entries
   }, [remoteEntries, state.remoteScreenTrackIds])
   useEffect(() => {
     peerIdsWithScreenShareRef.current = new Set(
-      remoteVideoTrackEntries.filter((e) => e.label === 'Screen share').map((e) => e.peerId)
+      remoteVideoTrackEntries.filter((e) => e.kind === 'screen').map((e) => e.peerId)
     )
   }, [remoteVideoTrackEntries])
+
+  const hiddenScreenSharePeerIds = useMemo(() => {
+    const hidden = new Set<string>()
+    for (const entry of remoteVideoTrackEntries) {
+      if (entry.kind === 'screen' && isRemoteMediaHidden(entry.peerId, 'screen')) {
+        hidden.add(entry.peerId)
+      }
+    }
+    return hidden
+  }, [isRemoteMediaHidden, remoteVideoTrackEntries])
+  useEffect(() => {
+    hiddenScreenSharePeerIdsRef.current = hiddenScreenSharePeerIds
+    applyOutputVolumeToElements(outputVolumeRef.current / 100)
+  }, [applyOutputVolumeToElements, hiddenScreenSharePeerIds])
 
   useEffect(() => {
     for (const [peerId, stream] of state.remoteStreams.entries()) {
       const el = remoteAudioRefsRef.current.get(peerId) as VoxperyAudioElement | undefined
       if (!el) continue
       // Force srcObject re-assignment when track count changes (e.g. screen share audio added)
-      const currentTrackIds = stream.getTracks().map(t => t.id).sort().join(',')
+      const playbackStream = createRemoteAudioPlaybackStream(stream, !hiddenScreenSharePeerIds.has(peerId))
+      const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
       const prevTrackIds = el.__voxpery_trackIds
-      if (el.srcObject !== stream || currentTrackIds !== prevTrackIds) {
-        el.srcObject = new MediaStream(stream.getTracks())
+      if (currentTrackIds !== prevTrackIds) {
+        el.srcObject = playbackStream
         el.__voxpery_trackIds = currentTrackIds
         void applyPreferredAudioOutputDevice(el)
       }
@@ -485,7 +530,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       }
       if (!deafenedRef.current) ensureRemoteAudioPlayback(peerId, el)
     }
-  }, [stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+  }, [hiddenScreenSharePeerIds, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -499,7 +544,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   }, [])
 
-  const currentVoiceChannelId = state.joinedChannelId
   const showActiveCallBar = !!(state.joinedChannelId || state.localStream || state.isJoining)
   const channelParticipants = useMemo(() => {
     if (!currentVoiceChannelId) return []
@@ -1015,18 +1059,35 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   </div>
                 </div>
               )}
-              {remoteVideoTrackEntries.map(({ peerId, track, label }) => {
+              {remoteVideoTrackEntries.map(({ peerId, track, label, kind }) => {
                 const volumeKey = resolvePeerVolumeKey(peerId)
                 const screenVolumeKey = `screen:${volumeKey}`
-                const currentVol = label === 'Screen share' ? (peerVolumeByUserId[screenVolumeKey] ?? 100) : (peerVolumeByUserId[volumeKey] ?? 100)
+                const currentVol = kind === 'screen' ? (peerVolumeByUserId[screenVolumeKey] ?? 100) : (peerVolumeByUserId[volumeKey] ?? 100)
                 const tileKey = `${peerId}-${track.id}`
+                const owner = remoteShareOwner(peerId)
+                const isHidden = isRemoteMediaHidden(peerId, kind)
+                if (isHidden) {
+                  return (
+                    <div key={tileKey} className="voice-stage-hidden-media-tile">
+                      <div className="voice-stage-hidden-media-icon">
+                        <EyeOff size={18} />
+                      </div>
+                      <div className="voice-stage-hidden-media-title">{label} hidden</div>
+                      <div className="voice-stage-hidden-media-sub">{owner}</div>
+                      <button type="button" className="voice-stage-hidden-media-show" onClick={() => setRemoteMediaHidden(peerId, kind, false)}>
+                        <Eye size={14} />
+                        Show
+                      </button>
+                    </div>
+                  )
+                }
                 return (
                   <div key={tileKey} className="screen-share-preview remote-screen-preview voice-stage-share-tile" data-fullscreen-key={tileKey} onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
                     <video autoPlay muted playsInline ref={(el) => { if (!el) return; let stream = remoteVideoStreamByTrackIdRef.current.get(track.id); if (!stream) { stream = new MediaStream([track]); remoteVideoStreamByTrackIdRef.current.set(track.id, stream) }; if (el.srcObject !== stream) el.srcObject = stream; void el.play().catch(() => { }) }} />
-                    <div className="screen-share-info-overlay"><span className="screen-share-info-text">{label} · {remoteShareOwner(peerId)}</span></div>
+                    <div className="screen-share-info-overlay"><span className="screen-share-info-text">{label} · {owner}</span></div>
                     <div className="screen-share-controls-bar">
                       <div className="screen-share-controls-left">
-                        {label === 'Screen share' && (
+                        {kind === 'screen' && (
                           <div className="screen-share-volume-container">
                             <button type="button" className="screen-share-volume-btn" title={currentVol === 0 ? 'Unmute' : 'Mute'} onClick={() => {
                               const isMuted = currentVol === 0
@@ -1061,6 +1122,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                         )}
                       </div>
                       <div className="screen-share-controls-right">
+                        <button type="button" className="screen-share-controls-btn" title={kind === 'screen' ? 'Stop watching screen' : 'Hide camera'} onClick={() => setRemoteMediaHidden(peerId, kind, true)}>
+                          <EyeOff size={16} />
+                        </button>
                         <button type="button" className="screen-share-controls-btn" title="Toggle fullscreen" onClick={(e) => {
                           const tile = (e.currentTarget as HTMLElement).closest('.screen-share-preview') as HTMLElement | null
                           if (!tile) return
@@ -1085,18 +1149,24 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   return (
                     <audio key={peerId} autoPlay playsInline ref={(el) => {
                       if (el) {
-                        remoteAudioRefsRef.current.set(peerId, el)
-                        if (el.srcObject !== stream) el.srcObject = stream
-                        void applyPreferredAudioOutputDevice(el)
+                        const audioEl = el as VoxperyAudioElement
+                        remoteAudioRefsRef.current.set(peerId, audioEl)
+                        const playbackStream = createRemoteAudioPlaybackStream(stream, !hiddenScreenSharePeerIds.has(peerId))
+                        const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
+                        if (audioEl.__voxpery_trackIds !== currentTrackIds) {
+                          audioEl.srcObject = playbackStream
+                          audioEl.__voxpery_trackIds = currentTrackIds
+                        }
+                        void applyPreferredAudioOutputDevice(audioEl)
                         const shouldMute = deafenedRef.current
                         const isCaptured = perPeerAudioCtxRef.current.has(peerId)
                         if (!isCaptured) {
                           const peerFactor = getPeerVolumeFactor(peerId)
                           const vol = Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
-                          try { el.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
-                          el.muted = shouldMute
+                          try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
+                          audioEl.muted = shouldMute
                         }
-                        if (!shouldMute) ensureRemoteAudioPlayback(peerId, el)
+                        if (!shouldMute) ensureRemoteAudioPlayback(peerId, audioEl)
                       } else {
                         remoteAudioRefsRef.current.delete(peerId)
                         const t = remoteAudioRetryTimerRef.current.get(peerId)

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8613,6 +8613,63 @@ a.community-open-btn:hover {
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.28);
 }
 
+.voice-stage-hidden-media-tile {
+  min-height: clamp(150px, 22vh, 260px);
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(24, 32, 58, 0.78), rgba(17, 24, 43, 0.88));
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 18px;
+  pointer-events: auto;
+}
+
+.voice-stage-hidden-media-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(96, 122, 177, 0.16);
+  color: rgba(203, 213, 245, 0.9);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.voice-stage-hidden-media-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.voice-stage-hidden-media-sub {
+  font-size: 12px;
+}
+
+.voice-stage-hidden-media-show {
+  min-height: 30px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(96, 165, 250, 0.36);
+  background: rgba(59, 130, 246, 0.14);
+  color: rgba(219, 234, 254, 0.95);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.voice-stage-hidden-media-show:hover {
+  background: rgba(59, 130, 246, 0.22);
+  border-color: rgba(147, 197, 253, 0.48);
+}
+
 .active-call-bar {
   min-height: 48px;
   display: flex;
@@ -13006,6 +13063,17 @@ textarea {
     min-height: 0;
     gap: 6px;
     padding: 10px 8px;
+  }
+
+  .voice-stage-hidden-media-tile {
+    min-height: 0;
+    gap: 6px;
+    padding: 12px 8px;
+  }
+
+  .voice-stage-hidden-media-icon {
+    width: 34px;
+    height: 34px;
   }
 
   .voice-stage-avatar {

--- a/apps/web/src/webrtc/remoteMediaControls.test.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.test.ts
@@ -1,0 +1,29 @@
+import { getRemoteAudioPlaybackTracks, isScreenShareAudioTrack, remoteMediaVisibilityKey } from './remoteMediaControls'
+
+function audioTrack(screenShareAudio = false) {
+  const track = {} as MediaStreamTrack
+  if (screenShareAudio) {
+    Object.defineProperty(track, '__voxpery_isScreenShareAudio', { value: true, configurable: true })
+  }
+  return track
+}
+
+describe('remote media controls', () => {
+  it('creates stable session-local visibility keys', () => {
+    expect(remoteMediaVisibilityKey('voice-1', 'user-2', 'screen')).toBe('voice-1:user-2:screen')
+  })
+
+  it('detects Voxpery screen share audio tracks', () => {
+    expect(isScreenShareAudioTrack(audioTrack())).toBe(false)
+    expect(isScreenShareAudioTrack(audioTrack(true))).toBe(true)
+  })
+
+  it('filters screen share audio while keeping microphone audio', () => {
+    const mic = audioTrack()
+    const screen = audioTrack(true)
+    const source = { getAudioTracks: () => [mic, screen] } as unknown as MediaStream
+
+    expect(getRemoteAudioPlaybackTracks(source, true)).toHaveLength(2)
+    expect(getRemoteAudioPlaybackTracks(source, false)).toEqual([mic])
+  })
+})

--- a/apps/web/src/webrtc/remoteMediaControls.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.ts
@@ -1,0 +1,24 @@
+export type RemoteMediaKind = 'camera' | 'screen'
+
+export interface VoxperyRemoteMediaTrack extends MediaStreamTrack {
+  __voxpery_isScreenShareAudio?: boolean
+}
+
+export function remoteMediaVisibilityKey(channelId: string, peerId: string, kind: RemoteMediaKind): string {
+  return `${channelId}:${peerId}:${kind}`
+}
+
+export function isScreenShareAudioTrack(track: MediaStreamTrack): boolean {
+  return !!(track as VoxperyRemoteMediaTrack).__voxpery_isScreenShareAudio
+}
+
+export function getRemoteAudioPlaybackTracks(stream: MediaStream, includeScreenShareAudio: boolean): MediaStreamTrack[] {
+  return stream
+    .getAudioTracks()
+    .filter((track) => includeScreenShareAudio || !isScreenShareAudioTrack(track))
+}
+
+export function createRemoteAudioPlaybackStream(stream: MediaStream, includeScreenShareAudio: boolean): MediaStream {
+  const tracks = getRemoteAudioPlaybackTracks(stream, includeScreenShareAudio)
+  return new MediaStream(tracks)
+}

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -446,6 +446,8 @@ export function useLiveKitVoice() {
           if (pub.source === Track.Source.ScreenShare) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShare', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.add(mediaTrack.id)
+          } else if (pub.source === Track.Source.ScreenShareAudio) {
+            Object.defineProperty(mediaTrack, '__voxpery_isScreenShareAudio', { value: true, writable: true, configurable: true })
           } else if (pub.source === Track.Source.Camera) {
             Object.defineProperty(mediaTrack, '__voxpery_isCamera', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.delete(mediaTrack.id)

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -34,6 +34,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Server/channel/category permission scenarios work.
 - [ ] Voice join/leave works.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
+- [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share also mutes only the screen-share audio while normal microphone audio continues.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.
 - [ ] Timed-out members cannot send/edit server-channel messages or add new reactions until cleared or expired.
 - [ ] Mobile server chat shows one visible message after send, including after the API response and WebSocket echo both arrive.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -164,6 +164,7 @@ Speaker
 - **Output volume**: Global 1-100% + per-peer 0-200%
 - **Amplification >100%**: Routed through WebAudio GainNode (gain > 1.0)
 - **Deafen**: Sets `audio.muted = true` on all remote elements
+- **Stop watching screen**: Hiding a remote screen share removes its screen-share audio track from playback while keeping the peer's normal microphone audio active.
 
 ## Screen Sharing
 
@@ -194,6 +195,13 @@ await room.localParticipant.publishTrack(videoTrack, {
 
 - **Screen share video**: `contentHint = 'detail'` (preserves text sharpness)
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
+
+### Remote Viewing Controls
+
+- Remote camera and screen-share tiles can be hidden per viewer without leaving the voice channel.
+- Hidden media stays as a compact placeholder with a `Show` action so the user can resume watching.
+- Hidden preferences are local to the current voice session and reset after leaving, refreshing, or switching voice channels.
+- Hiding a screen share also mutes that screen-share audio track; the participant's microphone audio continues normally.
 
 ## Camera
 


### PR DESCRIPTION
## Summary

Add viewer-side controls for remote camera and screen-share media in voice channels.

## Changes

- Added hide/show controls for remote camera and screen-share tiles.
- Added compact hidden media placeholders with a Show action.
- Muted only screen-share audio when a user stops watching a screen share.
- Kept normal microphone audio active while remote media is hidden.
- Reset hidden media state when leaving or switching voice channels.
- Updated voice docs and release smoke checklist.
- Added unit coverage for remote media playback filtering.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- Manual local voice test with camera/screen hide/show and screen-share audio stop watching
