### PR TITLE
feat: add logout functionality to user settings and update styles

### DIFF
--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -1,4 +1,4 @@
-import { Settings, Eye, EyeOff, Lock, Download, Trash2, MessageSquare, Mic, Monitor, Shield, User, ChevronsUpDown } from 'lucide-react'
+import { Settings, Eye, EyeOff, Lock, Download, Trash2, MessageSquare, Mic, Monitor, Shield, User, ChevronsUpDown, LogOut } from 'lucide-react'
 import type { StatusValue } from './StatusIcon'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal, flushSync } from 'react-dom'
@@ -469,6 +469,14 @@ export default function UserBar() {
   const closeSettingsPanel = useCallback(() => {
     setShowSettingsPanel(false)
   }, [])
+
+  const handleLogout = useCallback(() => {
+    closeSettingsPanel()
+    closeStatusMenu()
+    disconnect()
+    logout()
+    navigate(ROUTES.login, { replace: true })
+  }, [closeSettingsPanel, closeStatusMenu, disconnect, logout, navigate])
 
   const openSettingsPanel = useCallback(() => {
     closeStatusMenu()
@@ -1244,19 +1252,6 @@ export default function UserBar() {
       {statusSaving && (
         <div className="user-status-popover-saving">Updating…</div>
       )}
-      <div className="user-status-popover-footer">
-        <button
-          type="button"
-          className="user-status-popover-logout"
-          onClick={() => {
-            disconnect()
-            logout()
-            navigate(ROUTES.login, { replace: true })
-          }}
-        >
-          Log out
-        </button>
-      </div>
     </div>
   )
 
@@ -1935,6 +1930,20 @@ export default function UserBar() {
                     {isGoogleOnlyAccount ? 'Set password' : 'Change'}
                   </button>
                 </div>
+                <div className="user-setting-row user-setting-row--account-action">
+                  <div>
+                    <div className="user-setting-title">Log out</div>
+                    <div className="user-setting-desc">End this session and return to the login screen.</div>
+                  </div>
+                  <button
+                    type="button"
+                    className="user-toggle account-action-btn account-action-btn--danger"
+                    onClick={handleLogout}
+                  >
+                    <LogOut size={14} style={{ marginRight: 6 }} />
+                    Log out
+                  </button>
+                </div>
               </section>
               )}
               {activeSettingsSection === 'privacy' && (
@@ -2374,9 +2383,7 @@ export default function UserBar() {
                       setPwSuccess(true)
                       setPwOld(''); setPwNew(''); setPwConfirm('')
                       setTimeout(() => {
-                        disconnect()
-                        logout()
-                        navigate(ROUTES.login, { replace: true })
+                        handleLogout()
                       }, 1500)
                     }
                   } catch (err: unknown) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2621,27 +2621,6 @@ body {
   border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-.user-status-popover-footer {
-  padding: 8px 10px 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.user-status-popover-logout {
-  width: 100%;
-  height: 30px;
-  border: 1px solid rgba(240, 71, 71, 0.35);
-  background: rgba(240, 71, 71, 0.12);
-  color: #ffd5d5;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.user-status-popover-logout:hover {
-  background: rgba(240, 71, 71, 0.22);
-}
-
 .user-status-popover-avatar {
   width: 32px;
   height: 32px;
@@ -3111,6 +3090,18 @@ body {
   background: rgba(255, 255, 255, 0.09);
   border-color: rgba(255, 255, 255, 0.24);
   color: var(--text-primary);
+}
+
+.user-settings-modal .account-action-btn--danger {
+  border-color: var(--btn-danger-soft-border);
+  background: var(--btn-danger-soft-bg);
+  color: var(--btn-danger-soft-text);
+}
+
+.user-settings-modal .account-action-btn--danger:hover:not(:disabled) {
+  border-color: var(--btn-danger-soft-border-hover);
+  background: var(--btn-danger-soft-bg-hover);
+  color: #ffd5d5;
 }
 
 .quick-switcher-overlay {
@@ -13890,14 +13881,6 @@ textarea {
     font-size: 12px;
   }
 
-  .user-status-popover-footer {
-    padding: 5px 7px 7px;
-  }
-
-  .user-status-popover-logout {
-    height: 26px;
-    font-size: 11px;
-  }
 }
 
 @media (min-width: 701px) and (max-width: 1180px) {


### PR DESCRIPTION
## Summary

Move logout into the shared Settings > Profile flow so desktop and mobile use the same account management path.

## Changes

- Added a Log out action to the Profile settings section.
- Removed Log out from the status popover so that surface only manages presence.
- Reused the shared logout handler for password-change logout behavior.
- Kept status updates and profile settings behavior unchanged.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`
