### PR TITLE
chore: update version to 0.1.10 in Cargo files and changelog

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5322,7 +5322,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,8 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-05-16
+
+### Added
+- Voice channel active duration indicators so users can see how long a voice channel has been active.
+- Remote media watching controls for voice calls, including hide/show camera and stop-watching screen share behavior.
+
+### Changed
+- New accounts now default to allowing DMs from everyone, with the existing setting still available for users who prefer friends-only DMs.
+- Settings/Profile now owns the logout action across desktop and mobile for a more predictable account flow.
+- Chat media previews now use a more consistent in-app preview model across web and desktop.
+- GIF and sticker picker results were cleaned up and deduplicated.
+
 ### Removed
 - Removed the unfinished Saved/bookmark media surface from Social and message actions to keep the core chat experience simpler.
+
+### Fixed
+- Fixed refresh-time placeholder flashes when reopening a server.
+- Fixed settings modal layering issues from voice/chat surfaces.
+- Fixed mention suggestion positioning, message grouping polish, and chat layout shift cases.
+- Fixed GIF/sticker preview and navigation polish so media stays inside the app experience.
+- Fixed desktop image preview behavior so chat images can be viewed consistently with web.
 
 ## [0.1.9] - 2026-05-15
 


### PR DESCRIPTION
## Summary

Prepare Voxpery v0.1.10 release metadata.

## Changes

- Bumped desktop release metadata from `0.1.9` to `0.1.10`.
- Updated desktop Cargo lock metadata for the release package.
- Added the v0.1.10 changelog entry covering recent voice, chat, settings, media preview, and picker polish.

## Validation

- `cargo check --manifest-path apps\desktop\src-tauri\Cargo.toml --locked`
- `git diff --check`
- `graphify update .`
