### PR TITLE
feat: add unread message count synchronization for direct messages

### DIFF
--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -33,6 +33,7 @@ pub struct DmChannelInfo {
     pub peer_avatar_url: Option<String>,
     pub peer_status: String,
     pub last_message_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub unread_count: i64,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -242,7 +243,16 @@ async fn list_dm_channels(
                     WHERE m.channel_id = c.id
                     ORDER BY m.created_at DESC
                     LIMIT 1
-                  ) as last_message_at
+                  ) as last_message_at,
+                  (
+                    SELECT COUNT(*)
+                    FROM dm_messages m
+                    LEFT JOIN dm_channel_reads r
+                      ON r.channel_id = c.id AND r.user_id = $1
+                    WHERE m.channel_id = c.id
+                      AND m.user_id <> $1
+                      AND (r.read_at IS NULL OR m.created_at > r.read_at)
+                  ) as unread_count
            FROM dm_channels c
            INNER JOIN dm_channel_members self_m
              ON self_m.channel_id = c.id AND self_m.user_id = $1
@@ -478,6 +488,7 @@ async fn get_dm_messages(
     hydrate_dm_attachments(&state, &mut result).await?;
     if let Some(last) = result.last() {
         mark_dm_read(&state, channel_id, claims.sub, Some(last.id)).await?;
+        publish_dm_read(&state, channel_id, claims.sub, Some(last.id)).await;
     }
     Ok(Json(result))
 }
@@ -551,6 +562,7 @@ async fn send_dm_message(
         .hydrate_attachments_for_output(&state.db, &state.jwt_secret, message.attachments.clone())
         .await?;
     mark_dm_read(&state, channel_id, claims.sub, Some(message.id)).await?;
+    publish_dm_read(&state, channel_id, claims.sub, Some(message.id)).await;
     let event = WsEvent::NewMessage {
         channel_id,
         channel_type: "dm".to_string(),
@@ -989,4 +1001,22 @@ async fn mark_dm_read(
     .execute(&state.db)
     .await?;
     Ok(())
+}
+
+async fn publish_dm_read(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    user_id: Uuid,
+    last_read_message_id: Option<Uuid>,
+) {
+    crate::ws::publish_user_event(
+        state,
+        user_id,
+        WsEvent::DmRead {
+            channel_id,
+            user_id,
+            last_read_message_id,
+        },
+    )
+    .await;
 }

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -465,6 +465,10 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                         WsEvent::FriendUpdate { user_id: target_user_id } => {
                             *target_user_id == user_id
                         }
+                        WsEvent::DmRead {
+                            user_id: target_user_id,
+                            ..
+                        } => *target_user_id == user_id,
                         WsEvent::PresenceUpdate { user_id: changed_user_id, .. } => {
                             users_share_server_or_are_friends(
                                 &send_state.db,

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -19,6 +19,12 @@ pub enum WsEvent {
         channel_type: String,
         message: MessageWithAuthor,
     },
+    /// A DM channel was read by one session for the current user.
+    DmRead {
+        channel_id: Uuid,
+        user_id: Uuid,
+        last_read_message_id: Option<Uuid>,
+    },
     /// A message was deleted in a server channel.
     MessageDeleted { channel_id: Uuid, message_id: Uuid },
     /// A message was updated (edited) in a server channel.

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -132,6 +132,7 @@ export interface DmChannel {
     peer_avatar_url: string | null
     peer_status: string
     last_message_at: string | null
+    unread_count: number
 }
 
 export interface DmReadState {

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -44,6 +44,7 @@ export default function AppShell() {
     dmChannels,
     setDmChannelIds,
     setDmChannels,
+    setDmUnreadFromChannels,
     setFriends,
     activeDmChannelId,
     setActiveServer,
@@ -62,6 +63,7 @@ export default function AppShell() {
       dmChannels: s.dmChannels,
       setDmChannelIds: s.setDmChannelIds,
       setDmChannels: s.setDmChannels,
+      setDmUnreadFromChannels: s.setDmUnreadFromChannels,
       setFriends: s.setFriends,
       activeDmChannelId: s.activeDmChannelId,
       setActiveServer: s.setActiveServer,
@@ -225,6 +227,7 @@ export default function AppShell() {
         ])
         setDmChannelIds(channels.map((c) => c.id))
         setDmChannels(channels)
+        setDmUnreadFromChannels(channels)
         setFriends(friendList)
       } catch {
         // ignore transient failures
@@ -233,7 +236,7 @@ export default function AppShell() {
     syncSocial()
     const id = window.setInterval(syncSocial, 2000)
     return () => window.clearInterval(id)
-  }, [setActiveDmChannelId, setDmChannelIds, setDmChannels, setFriends, token, userId])
+  }, [setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, token, userId])
 
   useEffect(() => {
     if (!isConnected || dmChannelIds.length === 0) return
@@ -356,6 +359,12 @@ export default function AppShell() {
             })
           )
         }
+        if (e?.type === 'DmRead') {
+          const payload = e.data as { channel_id?: string; user_id?: string }
+          if (payload?.user_id === userId && payload.channel_id) {
+            clearDmUnread(payload.channel_id)
+          }
+        }
         if (e?.type === 'NewMessage') {
           const payload = e?.data as { channel_id?: string; channel_type?: string; message?: { author?: { user_id?: string; username?: string } } }
           const channelId = payload?.channel_id
@@ -375,6 +384,7 @@ export default function AppShell() {
                 dmIds = latest.map((c) => c.id)
                 setDmChannels(latest)
                 setDmChannelIds(dmIds)
+                setDmUnreadFromChannels(latest)
                 channel = latest.find((c) => c.id === channelId)
               } catch {
                 // ignore refresh failure
@@ -440,7 +450,7 @@ export default function AppShell() {
       }
     })
     return () => unsub()
-  }, [activeDmChannelId, clearDmUnread, dmChannelIds, dmChannels, incrementDmUnread, location.pathname, myStatus, navigate, pushToast, setActiveDmChannelId, setDmChannelIds, setDmChannels, setFriends, setJoinedVoiceChannelId, setVoiceControl, setVoiceState, subscribe, token, userId])
+  }, [activeDmChannelId, clearDmUnread, dmChannelIds, dmChannels, incrementDmUnread, location.pathname, myStatus, navigate, pushToast, setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setJoinedVoiceChannelId, setVoiceControl, setVoiceState, subscribe, token, userId])
   const activeChannel = useMemo(() => channels.find((c) => c.id === activeChannelId), [channels, activeChannelId])
   // Prefer the voice channel the user is viewing so switching channels leaves current and joins the new one.
   const selectedVoiceChannelId =

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -116,6 +116,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     dmChannels: storeDmChannels,
     setFriends: setStoreFriends,
     setDmChannels: setStoreDmChannels,
+    setDmUnreadFromChannels,
     mobileSidebarPanel,
     setMobileSidebarPanel,
   } = useAppStore(
@@ -134,6 +135,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       dmChannels: s.dmChannels,
       setFriends: s.setFriends,
       setDmChannels: s.setDmChannels,
+      setDmUnreadFromChannels: s.setDmUnreadFromChannels,
       mobileSidebarPanel: s.mobileSidebarPanel,
       setMobileSidebarPanel: s.setMobileSidebarPanel,
     }))
@@ -244,12 +246,13 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setIncomingRequestCount(req.incoming.length)
       setOutgoingRequests(req.outgoing)
       setStoreDmChannels(dms)
+      setDmUnreadFromChannels(dms)
       setDmChannelIds(dms.map((d) => d.id))
     } finally {
       setServersLoading(false)
       setSocialBootstrapLoading(false)
     }
-  }, [setDmChannelIds, setIncomingRequestCount, setServers, setServersLoading, setStoreFriends, setStoreDmChannels, token, userId])
+  }, [setDmChannelIds, setDmUnreadFromChannels, setIncomingRequestCount, setServers, setServersLoading, setStoreFriends, setStoreDmChannels, token, userId])
 
   useEffect(() => {
     try {

--- a/apps/web/src/stores/app.test.ts
+++ b/apps/web/src/stores/app.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAppStore } from './app'
+import type { DmChannel } from '../api'
+
+function dmChannel(id: string, unread_count: number): DmChannel {
+    return {
+        id,
+        peer_id: `peer-${id}`,
+        peer_username: `peer-${id}`,
+        peer_avatar_url: null,
+        peer_status: 'online',
+        last_message_at: null,
+        unread_count,
+    }
+}
+
+describe('app store DM unread sync', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        useAppStore.setState({ dmUnread: {} })
+    })
+
+    it('hydrates unread counts from server DM channel metadata', () => {
+        useAppStore.getState().setDmUnreadFromChannels([
+            dmChannel('dm-a', 3),
+            dmChannel('dm-b', 0),
+        ])
+
+        expect(useAppStore.getState().dmUnread).toEqual({ 'dm-a': 3 })
+    })
+
+    it('clears stale local unread when the server says a DM is read', () => {
+        useAppStore.setState({ dmUnread: { 'dm-a': 2, 'dm-b': 1 } })
+
+        useAppStore.getState().setDmUnreadFromChannels([
+            dmChannel('dm-a', 0),
+        ])
+
+        expect(useAppStore.getState().dmUnread).toEqual({ 'dm-b': 1 })
+    })
+})

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -46,6 +46,7 @@ interface AppState {
     setFriends: (friends: Friend[]) => void
     setDmChannels: (channels: DmChannel[]) => void
     dmUnread: Record<string, number>
+    setDmUnreadFromChannels: (channels: DmChannel[]) => void
     incrementDmUnread: (channelId: string) => void
     clearDmUnread: (channelId: string) => void
     serverUnreadByChannel: Record<string, number>
@@ -218,6 +219,32 @@ export const useAppStore = create<AppState>()(
             setFriends: (friends) => set((s) => JSON.stringify(s.friends) === JSON.stringify(friends) ? s : { friends }),
             setDmChannels: (channels) => set((s) => JSON.stringify(s.dmChannels) === JSON.stringify(channels) ? s : { dmChannels: channels }),
             dmUnread: {},
+            setDmUnreadFromChannels: (channels) =>
+                set((s) => {
+                    const next = { ...s.dmUnread }
+                    let changed = false
+
+                    channels.forEach((channel) => {
+                        const unreadCount = Number.isFinite(channel.unread_count)
+                            ? Math.max(0, Math.trunc(channel.unread_count))
+                            : 0
+
+                        if (unreadCount > 0) {
+                            if (next[channel.id] !== unreadCount) {
+                                next[channel.id] = unreadCount
+                                changed = true
+                            }
+                            return
+                        }
+
+                        if (next[channel.id]) {
+                            delete next[channel.id]
+                            changed = true
+                        }
+                    })
+
+                    return changed ? { dmUnread: next } : s
+                }),
             incrementDmUnread: (channelId) =>
                 set((s) => ({ dmUnread: { ...s.dmUnread, [channelId]: (s.dmUnread[channelId] ?? 0) + 1 } })),
             clearDmUnread: (channelId) =>

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -83,6 +83,6 @@ export interface SignalingMessage {
 }
 
 export interface WsEvent {
-    type: 'NewMessage' | 'MessageDeleted' | 'MessageUpdated' | 'Typing' | 'PresenceUpdate' | 'FriendUpdate' | 'MemberJoined' | 'MemberLeft' | 'MemberRoleUpdated' | 'ServerRolesUpdated' | 'ServerChannelsUpdated' | 'VoiceStateUpdate' | 'VoiceControlUpdate' | 'Signal' | 'Pong';
+    type: 'NewMessage' | 'DmRead' | 'MessageDeleted' | 'MessageUpdated' | 'Typing' | 'PresenceUpdate' | 'FriendUpdate' | 'MemberJoined' | 'MemberLeft' | 'MemberRoleUpdated' | 'ServerRolesUpdated' | 'ServerChannelsUpdated' | 'VoiceStateUpdate' | 'VoiceControlUpdate' | 'Signal' | 'Pong';
     data: unknown;
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -215,6 +215,7 @@ Notes:
 ## Direct Message Endpoints
 
 - `GET /api/dm/channels`
+  - Returns DM channel metadata including `unread_count`, the server-derived unread count for the current user.
 - `POST /api/dm/channels/:peer_id`
 - `GET /api/dm/messages/:channel_id?before=<uuid>&limit=<n>`
 - `GET /api/dm/messages/:channel_id/search?q=<term>&from=<username>&has_attachment=<bool>&limit=<n>`

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -142,6 +142,7 @@ Uniqueness (case-insensitive):
 ### `dm_channel_reads`
 
 - `channel_id`, `user_id`, `last_read_message_id`, `read_at`
+- Used by `GET /api/dm/channels` to derive per-user `unread_count`, and by `DmRead` WebSocket events to synchronize unread badges across sessions.
 
 ### `dm_channel_pins`
 

--- a/docs/WEBSOCKET_EVENTS.md
+++ b/docs/WEBSOCKET_EVENTS.md
@@ -121,6 +121,9 @@ Legacy custom signaling event.
 ### Channel/Message
 
 - `NewMessage`
+- `DmRead`
+  - Targeted to the user who read the DM so other open sessions can clear the same unread badge.
+  - Payload includes `channel_id`, `user_id`, and `last_read_message_id`.
 - `MessageUpdated`
 - `MessageDeleted`
 - `Typing`


### PR DESCRIPTION
## Summary

Fix DM unread notification sync across multiple active sessions for the same user.

## Changes

- Added server-provided `unread_count` to DM channel responses.
- Published a `DmRead` WebSocket event when a DM channel is read.
- Synced DM unread state from both channel list responses and live read events.
- Added frontend store coverage for unread hydration and clearing behavior.
- Documented the DM unread count and `DmRead` WebSocket event.

## Validation

- `cargo check --manifest-path apps\server\Cargo.toml --locked`
- `npm --prefix apps\web run lint`
- `npm --prefix apps\web run test:run`
- `npm --prefix apps\web run build`
- `git diff --check`
- Manual: verified unread badge clears across two browser sessions logged into the same account.