### PR TITLE
feat: add remote media start cues for camera and screen sharing

### DIFF
--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -120,7 +120,15 @@ function isLikelySpeechFrame(
         && (!aggressiveIsolation || !noiseDominant)
 }
 
-export type VoiceCueKind = 'join' | 'leave' | 'mute' | 'unmute' | 'deafen' | 'undeafen'
+export type VoiceCueKind =
+    | 'join'
+    | 'leave'
+    | 'mute'
+    | 'unmute'
+    | 'deafen'
+    | 'undeafen'
+    | 'camera-start'
+    | 'screen-start'
 
 interface LiveSuppressionConfig {
     aggressiveIsolation: boolean
@@ -294,6 +302,18 @@ export function useAudioEngine() {
                 playCueStack(ctx, [
                     { from: 270, to: 340, durationSec: 0.08, peak: 0.018, type: 'sine', overtoneGain: 0.08, filterHz: 1400, q: 0.8 },
                     { from: 430, to: 640, offsetSec: 0.065, durationSec: 0.11, peak: 0.024, type: 'triangle', overtoneGain: 0.2, filterHz: 2400, q: 0.9 },
+                ])
+                break
+            case 'camera-start':
+                playCueStack(ctx, [
+                    { from: 1180, to: 1180, durationSec: 0.052, peak: 0.017, type: 'sine', overtoneGain: 0.04, filterHz: 3400, q: 0.65 },
+                    { from: 820, to: 1040, offsetSec: 0.055, durationSec: 0.075, peak: 0.016, type: 'triangle', overtoneGain: 0.07, filterHz: 2900, q: 0.75 },
+                ])
+                break
+            case 'screen-start':
+                playCueStack(ctx, [
+                    { from: 520, to: 520, durationSec: 0.075, peak: 0.023, type: 'square', overtoneGain: 0.04, filterHz: 1700, q: 0.8 },
+                    { from: 410, to: 680, offsetSec: 0.09, durationSec: 0.15, peak: 0.021, type: 'triangle', overtoneGain: 0.14, filterHz: 2300, q: 0.72 },
                 ])
                 break
         }

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { resyncVoiceStateAfterReconnect } from './useLiveKitVoice'
+import {
+  clearRemoteMediaStartCue,
+  remoteMediaStartCueKey,
+  resyncVoiceStateAfterReconnect,
+  shouldPlayRemoteMediaStartCue,
+} from './useLiveKitVoice'
 
 describe('resyncVoiceStateAfterReconnect', () => {
   it('re-sends voice join and control state after WebSocket reconnect', () => {
@@ -83,5 +88,44 @@ describe('resyncVoiceStateAfterReconnect', () => {
     })
 
     expect(send).not.toHaveBeenCalled()
+  })
+})
+
+describe('remote media start cues', () => {
+  it('creates stable remote media cue keys', () => {
+    expect(remoteMediaStartCueKey('user-1', 'camera')).toBe('user-1:camera')
+    expect(remoteMediaStartCueKey('user-1', 'screen')).toBe('user-1:screen')
+  })
+
+  it('does not play during initial remote media hydration', () => {
+    const seen = new Set<string>()
+
+    expect(shouldPlayRemoteMediaStartCue(seen, 'user-1', 'camera', false)).toBe(false)
+    expect(seen.has('user-1:camera')).toBe(true)
+  })
+
+  it('plays once when remote media starts after voice is ready', () => {
+    const seen = new Set<string>()
+
+    expect(shouldPlayRemoteMediaStartCue(seen, 'user-1', 'screen', true)).toBe(true)
+    expect(shouldPlayRemoteMediaStartCue(seen, 'user-1', 'screen', true)).toBe(false)
+  })
+
+  it('can play again after the remote media key is cleared', () => {
+    const seen = new Set<string>()
+
+    expect(shouldPlayRemoteMediaStartCue(seen, 'user-1', 'camera', true)).toBe(true)
+    clearRemoteMediaStartCue(seen, 'user-1', 'camera')
+    expect(shouldPlayRemoteMediaStartCue(seen, 'user-1', 'camera', true)).toBe(true)
+  })
+
+  it('clears all media cue keys for a peer', () => {
+    const seen = new Set<string>(['user-1:camera', 'user-1:screen', 'user-2:camera'])
+
+    clearRemoteMediaStartCue(seen, 'user-1')
+
+    expect(seen.has('user-1:camera')).toBe(false)
+    expect(seen.has('user-1:screen')).toBe(false)
+    expect(seen.has('user-2:camera')).toBe(true)
   })
 })

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -23,6 +23,7 @@ import {
 } from './voiceInputProfile'
 
 type PeerId = string
+type RemoteMediaStartCueKind = 'camera' | 'screen'
 
 type VoiceControlState = {
   muted?: boolean
@@ -53,6 +54,35 @@ export function resyncVoiceStateAfterReconnect({
     screen_sharing: !!control?.screenSharing,
     camera_on: !!control?.cameraOn,
   })
+}
+
+export function remoteMediaStartCueKey(peerId: string, kind: RemoteMediaStartCueKind): string {
+  return `${peerId}:${kind}`
+}
+
+export function shouldPlayRemoteMediaStartCue(
+  seenKeys: Set<string>,
+  peerId: string,
+  kind: RemoteMediaStartCueKind,
+  cueReady: boolean,
+): boolean {
+  const key = remoteMediaStartCueKey(peerId, kind)
+  if (seenKeys.has(key)) return false
+  seenKeys.add(key)
+  return cueReady
+}
+
+export function clearRemoteMediaStartCue(
+  seenKeys: Set<string>,
+  peerId: string,
+  kind?: RemoteMediaStartCueKind,
+): void {
+  if (kind) {
+    seenKeys.delete(remoteMediaStartCueKey(peerId, kind))
+    return
+  }
+  seenKeys.delete(remoteMediaStartCueKey(peerId, 'camera'))
+  seenKeys.delete(remoteMediaStartCueKey(peerId, 'screen'))
 }
 
 export interface UseLiveKitVoiceState {
@@ -100,6 +130,8 @@ export function useLiveKitVoice() {
 
   const remoteStreamsRef = useRef<Map<PeerId, MediaStream>>(new Map())
   const remoteMonitorCleanupsRef = useRef<Map<PeerId, () => void>>(new Map())
+  const remoteMediaStartCueKeysRef = useRef<Set<string>>(new Set())
+  const remoteMediaStartCueReadyRef = useRef(false)
   const joinedChannelIdRef = useRef<string | null>(null)
   const desiredMicMutedRef = useRef(false)
   const activeInputDeviceIdRef = useRef(getStoredVoiceInputDeviceId())
@@ -310,6 +342,7 @@ export function useLiveKitVoice() {
   }, [rebuildPublishedMicrophoneTrack])
 
   const closePeer = useCallback((peerId: PeerId) => {
+    clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId)
     remoteMonitorCleanupsRef.current.get(peerId)?.()
     remoteMonitorCleanupsRef.current.delete(peerId)
     const current = remoteStreamsRef.current.get(peerId)
@@ -347,6 +380,28 @@ export function useLiveKitVoice() {
     store.setVoiceCamera(participant.identity, hasCamera)
     store.setVoiceControl(participant.identity, !!current?.muted, !!current?.deafened, hasScreenShare)
   }, [])
+
+  const rememberExistingRemoteMedia = useCallback((participant: RemoteParticipant) => {
+    participant.trackPublications.forEach((publication) => {
+      if (publication.source === Track.Source.Camera) {
+        remoteMediaStartCueKeysRef.current.add(remoteMediaStartCueKey(participant.identity, 'camera'))
+      }
+      if (publication.source === Track.Source.ScreenShare) {
+        remoteMediaStartCueKeysRef.current.add(remoteMediaStartCueKey(participant.identity, 'screen'))
+      }
+    })
+  }, [])
+
+  const playRemoteMediaStartCue = useCallback((participant: RemoteParticipant, kind: RemoteMediaStartCueKind) => {
+    const shouldPlay = shouldPlayRemoteMediaStartCue(
+      remoteMediaStartCueKeysRef.current,
+      participant.identity,
+      kind,
+      remoteMediaStartCueReadyRef.current,
+    )
+    if (!shouldPlay) return
+    playVoiceCue(kind === 'camera' ? 'camera-start' : 'screen-start')
+  }, [playVoiceCue])
 
   const joinVoice = useCallback(async (channelId: string, options?: { preflightStream?: MediaStream }) => {
     if (!isConnected) throw new Error('WebSocket is not connected')
@@ -412,6 +467,8 @@ export function useLiveKitVoice() {
         },
       })
       roomRef.current = room
+      remoteMediaStartCueKeysRef.current.clear()
+      remoteMediaStartCueReadyRef.current = false
 
       const iceServers: RTCIceServer[] = [
         { urls: ['stun:stun.l.google.com:19302'] },
@@ -446,16 +503,23 @@ export function useLiveKitVoice() {
           if (pub.source === Track.Source.ScreenShare) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShare', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.add(mediaTrack.id)
+            playRemoteMediaStartCue(participant, 'screen')
           } else if (pub.source === Track.Source.ScreenShareAudio) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShareAudio', { value: true, writable: true, configurable: true })
           } else if (pub.source === Track.Source.Camera) {
             Object.defineProperty(mediaTrack, '__voxpery_isCamera', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.delete(mediaTrack.id)
+            playRemoteMediaStartCue(participant, 'camera')
           }
 
           mediaTrack.onmute = () => { syncParticipantMediaState(participant); bumpRemote() }
           mediaTrack.onunmute = () => { syncParticipantMediaState(participant); bumpRemote() }
-          mediaTrack.onended = () => { syncParticipantMediaState(participant); bumpRemote() }
+          mediaTrack.onended = () => {
+            if (pub.source === Track.Source.Camera) clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'camera')
+            if (pub.source === Track.Source.ScreenShare) clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'screen')
+            syncParticipantMediaState(participant)
+            bumpRemote()
+          }
 
           if (!combined.getTracks().some((t) => t.id === mediaTrack.id)) {
             combined.addTrack(mediaTrack)
@@ -486,6 +550,8 @@ export function useLiveKitVoice() {
             stream.removeTrack(existing)
             remoteScreenTrackIdsRef.current.delete(existing.id)
           }
+          if (_pub.source === Track.Source.Camera) clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'camera')
+          if (_pub.source === Track.Source.ScreenShare) clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'screen')
           if (stream.getTracks().length === 0) closePeer(peerId)
           else bumpRemote()
 
@@ -540,12 +606,14 @@ export function useLiveKitVoice() {
       await Promise.race([connectPromise, timeoutPromise])
 
       room.remoteParticipants.forEach((participant) => {
+        rememberExistingRemoteMedia(participant)
         participant.trackPublications.forEach((publication) => {
           if (!publication.isSubscribed) publication.setSubscribed(true)
         })
         syncParticipantMediaState(participant)
       })
       updateRoomStats()
+      remoteMediaStartCueReadyRef.current = true
 
       // Publish the track directly to LiveKit.
       const pub = await room.localParticipant.publishTrack(publishTrack, { source: Track.Source.Microphone })
@@ -573,13 +641,15 @@ export function useLiveKitVoice() {
     } catch (e: unknown) {
       const msg = (e as Error)?.message ?? 'Failed to join voice'
       setLastError(msg)
+      remoteMediaStartCueReadyRef.current = false
+      remoteMediaStartCueKeysRef.current.clear()
       if (!micPublished) cleanupLocalMedia()
       throw e
     } finally {
       isJoiningRef.current = false
       setIsJoining(false)
     }
-    }, [applyLocalMicSettings, buildMicSendTrack, cleanupLocalMedia, closePeer, getAudioContext, getMicrophoneStream, getScreenShareEncoding, getInputVolumeFactor, isConnected, playVoiceCue, refreshLocalStreams, send, setLocalMicMuted, startLocalSpeakingMonitor, syncParticipantMediaState, token, updateRoomStats, userId, voiceMode])
+    }, [applyLocalMicSettings, buildMicSendTrack, cleanupLocalMedia, closePeer, getAudioContext, getMicrophoneStream, getScreenShareEncoding, getInputVolumeFactor, isConnected, playRemoteMediaStartCue, playVoiceCue, refreshLocalStreams, rememberExistingRemoteMedia, send, setLocalMicMuted, startLocalSpeakingMonitor, syncParticipantMediaState, token, updateRoomStats, userId, voiceMode])
 
     const leaveVoice = useCallback((options?: { skipLeaveSound?: boolean }) => {
     isJoiningRef.current = false
@@ -587,6 +657,8 @@ export function useLiveKitVoice() {
     setLastError(null)
     send('LeaveVoice', null)
     joinedChannelIdRef.current = null
+    remoteMediaStartCueReadyRef.current = false
+    remoteMediaStartCueKeysRef.current.clear()
     setJoinedChannelId(null)
     useAppStore.getState().setJoinedVoiceChannelId(null)
     if (userId) useAppStore.getState().setVoiceCamera(userId, false)

--- a/apps/web/src/webrtc/useWebRTCVoice.ts
+++ b/apps/web/src/webrtc/useWebRTCVoice.ts
@@ -333,7 +333,15 @@ export function useWebRTCVoice() {
 
   const isSoundEnabled = useCallback(() => localStorage.getItem(SOUND_KEY) !== '0', [])
 
-  type VoiceCueKind = 'join' | 'leave' | 'mute' | 'unmute' | 'deafen' | 'undeafen'
+  type VoiceCueKind =
+    | 'join'
+    | 'leave'
+    | 'mute'
+    | 'unmute'
+    | 'deafen'
+    | 'undeafen'
+    | 'camera-start'
+    | 'screen-start'
 
   const playVoiceCue = useCallback((kind: VoiceCueKind) => {
     if (!isSoundEnabled()) return
@@ -407,6 +415,14 @@ export function useWebRTCVoice() {
       case 'undeafen':
         playTone({ from: 250, to: 320, offsetSec: 0, durationSec: 0.075, wave: 'triangle', peak: 0.02 })
         playTone({ from: 420, to: 590, offsetSec: 0.078, durationSec: 0.095, wave: 'triangle', peak: 0.024 })
+        break
+      case 'camera-start':
+        playTone({ from: 1180, to: 1180, offsetSec: 0, durationSec: 0.052, wave: 'sine', peak: 0.017 })
+        playTone({ from: 820, to: 1040, offsetSec: 0.055, durationSec: 0.075, wave: 'triangle', peak: 0.016 })
+        break
+      case 'screen-start':
+        playTone({ from: 520, to: 520, offsetSec: 0, durationSec: 0.075, wave: 'square', peak: 0.023 })
+        playTone({ from: 410, to: 680, offsetSec: 0.09, durationSec: 0.15, wave: 'triangle', peak: 0.021 })
         break
     }
   }, [isSoundEnabled])

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -70,6 +70,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Voice join succeeds after permission grant.
 - [ ] Active call bar quality indicator shows a colored Wi-Fi icon and current ping while connected, and the visible color matches the visible ping value.
 - [ ] Voice join and leave cues are distinct enough to tell whether a member entered or left the channel.
+- [ ] While already in a voice channel, remote camera and screen-share starts play distinct media cues; stopping camera or screen share stays silent, and joining a channel with existing remote media does not replay old media-start cues.
 - [ ] Reconnecting state shows a clear one-time warning without disconnecting the user from the channel.
 - [ ] Denying desktop microphone permission shows recovery guidance, opens OS privacy settings from Voice & Audio, and succeeds after permission is restored and retried.
 - [ ] Denying desktop camera permission shows OS-specific recovery guidance, opens OS privacy settings when supported, and succeeds after permission is restored and retried.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -264,6 +264,8 @@ When debugging a production voice report, capture:
 - Join and leave cues are intentionally different so members can identify someone entering or leaving without watching the channel list.
 - Join uses a short rising three-note motif.
 - Leave uses a lower descending two-note motif.
+- Remote camera and screen-share starts use their own short cues so members can tell when someone begins broadcasting media.
+- Existing remote media does not play a start cue when joining a channel; cues only play for media that starts while the user is already present.
 - Mute, unmute, deafen, and undeafen keep shorter local-only cues.
 
 ### Echo or feedback


### PR DESCRIPTION
## Summary

Add distinct voice media start cues for remote camera and screen share activity.

## Changes

- Added separate audio cues for remote camera start and screen share start.
- Kept media stop events silent to avoid unnecessary notification noise.
- Prevented cues from playing for your own camera/screen share actions.
- Prevented duplicate cues from existing media during voice join and screen-share audio tracks.
- Updated voice docs and release smoke checklist.
- Added unit coverage for remote media cue lifecycle behavior.

## Validation

- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test:run`
- `npm --prefix apps/web run build`
- `git diff --check`
- `graphify update .`

## Manual Test

- Remote camera start plays a light cue.
- Remote camera stop stays silent.
- Remote screen share start plays a distinct cue.
- Remote screen share stop stays silent.
- Existing media does not replay cues when joining later.