### PR TITLE
feat: enhance image proxy to validate public addresses and improve se…

### DIFF
--- a/apps/server/src/routes/images.rs
+++ b/apps/server/src/routes/images.rs
@@ -1,8 +1,4 @@
-use std::{
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
     extract::{ConnectInfo, Query, State},
@@ -46,25 +42,52 @@ fn client_ip(connect_info: Option<&Extension<ConnectInfo<SocketAddr>>>) -> Strin
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-async fn ensure_resolved_host_is_public(host: &str, port: u16) -> Result<(), AppError> {
-    let addrs = lookup_host((host, port))
-        .await
-        .map_err(|_| AppError::Validation("Image URL host could not be resolved".into()))?;
-
-    let resolved: Vec<IpAddr> = addrs.map(|addr| addr.ip()).collect();
+fn validate_public_resolved_addrs(
+    addrs: impl IntoIterator<Item = SocketAddr>,
+) -> Result<Vec<SocketAddr>, AppError> {
+    let mut seen = HashSet::new();
+    let resolved: Vec<SocketAddr> = addrs
+        .into_iter()
+        .filter(|addr| seen.insert(*addr))
+        .collect();
     if resolved.is_empty() {
         return Err(AppError::Validation(
             "Image URL host could not be resolved".into(),
         ));
     }
 
-    if resolved.iter().any(is_private_or_local_ip) {
+    if resolved
+        .iter()
+        .map(SocketAddr::ip)
+        .any(|ip| is_private_or_local_ip(&ip))
+    {
         return Err(AppError::Validation(
             "Image URL cannot resolve to local or private network addresses".into(),
         ));
     }
 
-    Ok(())
+    Ok(resolved)
+}
+
+async fn resolve_public_host_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, AppError> {
+    let addrs = lookup_host((host, port))
+        .await
+        .map_err(|_| AppError::Validation("Image URL host could not be resolved".into()))?;
+
+    validate_public_resolved_addrs(addrs)
+}
+
+fn build_pinned_image_proxy_client(
+    host: &str,
+    resolved_addrs: &[SocketAddr],
+) -> Result<reqwest::Client, AppError> {
+    reqwest::Client::builder()
+        .redirect(Policy::none())
+        .timeout(Duration::from_secs(6))
+        .no_proxy()
+        .resolve_to_addrs(host, resolved_addrs)
+        .build()
+        .map_err(|e| AppError::Internal(format!("Image proxy client build failed: {e}")))
 }
 
 async fn proxy_avatar(
@@ -107,13 +130,9 @@ async fn proxy_remote_image_with_label(
         .host_str()
         .ok_or_else(|| AppError::Validation(format!("{label} URL must include a host")))?;
     let port = url.port_or_known_default().unwrap_or(443);
-    ensure_resolved_host_is_public(host, port).await?;
+    let resolved_addrs = resolve_public_host_addrs(host, port).await?;
 
-    let client = reqwest::Client::builder()
-        .redirect(Policy::none())
-        .timeout(Duration::from_secs(6))
-        .build()
-        .map_err(|e| AppError::Internal(format!("Avatar proxy client build failed: {e}")))?;
+    let client = build_pinned_image_proxy_client(host, &resolved_addrs)?;
 
     let upstream = client
         .get(url)
@@ -179,9 +198,34 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_private_dns_resolution() {
-        let err = ensure_resolved_host_is_public("localhost", 443)
+        let err = resolve_public_host_addrs("localhost", 443)
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn rejects_mixed_private_and_public_resolved_addrs() {
+        let addrs = [
+            SocketAddr::from(([93, 184, 216, 34], 443)),
+            SocketAddr::from(([127, 0, 0, 1], 443)),
+        ];
+
+        let err = validate_public_resolved_addrs(addrs).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn keeps_unique_public_resolved_addrs() {
+        let addr = SocketAddr::from(([93, 184, 216, 34], 443));
+        let resolved = validate_public_resolved_addrs([addr, addr]).unwrap();
+        assert_eq!(resolved, vec![addr]);
+    }
+
+    #[test]
+    fn builds_proxy_client_with_pinned_public_addrs() {
+        let addrs = [SocketAddr::from(([93, 184, 216, 34], 443))];
+        let client = build_pinned_image_proxy_client("example.com", &addrs);
+        assert!(client.is_ok());
     }
 }

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -22,6 +22,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 
 - [ ] Relevant `CodeQL` analyzers are green or did not run because no matching files changed.
 - [ ] `Dependency Security Audit` is reviewed; unresolved upstream-blocked advisories have an explicit release decision recorded.
+- [ ] Remote avatar/server icon/inline media proxy rejects localhost/private targets and still loads normal public HTTPS images.
 - [ ] Manual `Release Smoke` workflow completed successfully against the release candidate API.
 - [ ] `Release Smoke` ran with strict security headers enabled for production candidates.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -199,7 +199,7 @@ let query = format!("SELECT * FROM users WHERE username = '{}'", username); // S
 
 - User-supplied external avatar URLs are rendered through `GET /api/images/avatar?url=...` so viewers do not request third-party avatar hosts directly.
 - User-controlled remote server icons and inline GIF/sticker previews are rendered through `GET /api/images/remote?url=...`.
-- The proxy accepts only `https://` image URLs, rejects localhost/private/reserved hosts, resolves DNS before fetch, disables redirects, and rate-limits proxy requests.
+- The proxy accepts only `https://` image URLs, rejects localhost/private/reserved hosts, resolves DNS before fetch, pins the outbound request to the validated public IP addresses to prevent DNS rebinding, disables redirects, and rate-limits proxy requests.
 - Responses must be `image/jpeg`, `image/png`, `image/gif`, or `image/webp`, are capped at 3 MB, and are returned with cache headers plus `X-Content-Type-Options: nosniff`.
 - `data:image/*` profile avatars and server icons are still accepted for uploaded profile photos/icons, but SVG data URLs are rejected and stored data URLs are capped at 1 MB.
 


### PR DESCRIPTION
## Summary

Harden the remote image proxy against DNS rebinding / SSRF by pinning outbound fetches to the already-validated public DNS results.

## Changes

- Resolve remote image hosts before proxy fetch.
- Reject localhost/private/reserved DNS results.
- Pin image proxy fetches to the validated public socket addresses.
- Disable proxy inheritance for the image proxy client.
- Add regression tests for private/mixed DNS resolution and pinned client creation.
- Update security docs and release smoke checklist.

## Validation

- `cargo check --locked`
- `cargo test --locked images`
- `cargo test --locked`
- `git diff --check`
- `graphify update .`