### PR TITLE
feat: implement voice access revocation for channel and role updates

### DIFF
--- a/apps/server/src/routes/channels.rs
+++ b/apps/server/src/routes/channels.rs
@@ -13,6 +13,7 @@ use crate::{
     models::Channel,
     services::audit,
     services::permissions::{self, Permissions},
+    services::voice_revoke,
     ws::WsEvent,
     AppState,
 };
@@ -468,6 +469,12 @@ async fn update_channel_override(
         },
     )
     .await;
+    voice_revoke::revoke_invalid_voice_sessions_for_server(
+        &state,
+        channel.server_id,
+        "channel permissions updated",
+    )
+    .await?;
 
     Ok(Json(ov))
 }
@@ -497,6 +504,12 @@ async fn delete_channel_override(
         .fetch_one(&state.db)
         .await?;
     crate::ws::publish_event(&state, WsEvent::ServerChannelsUpdated { server_id }).await;
+    voice_revoke::revoke_invalid_voice_sessions_for_server(
+        &state,
+        server_id,
+        "channel permissions deleted",
+    )
+    .await?;
 
     Ok(Json(serde_json::json!({ "message": "Override deleted" })))
 }
@@ -922,6 +935,12 @@ async fn update_category_override(
     .await?;
 
     crate::ws::publish_event(&state, WsEvent::ServerChannelsUpdated { server_id }).await;
+    voice_revoke::revoke_invalid_voice_sessions_for_server(
+        &state,
+        server_id,
+        "category permissions updated",
+    )
+    .await?;
 
     Ok(Json(ov))
 }
@@ -954,6 +973,12 @@ async fn delete_category_override(
     .await?;
 
     crate::ws::publish_event(&state, WsEvent::ServerChannelsUpdated { server_id }).await;
+    voice_revoke::revoke_invalid_voice_sessions_for_server(
+        &state,
+        server_id,
+        "category permissions deleted",
+    )
+    .await?;
 
     Ok(Json(serde_json::json!({ "message": "Override deleted" })))
 }

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -29,6 +29,7 @@ use crate::{
         moderation::{self, RaidEventEntry, ServerTimeoutEntry},
         permissions::{self, Permissions},
         rate_limit::enforce_rate_limit,
+        voice_revoke,
     },
     ws::WsEvent,
     AppState,
@@ -1033,6 +1034,15 @@ async fn update_role(
         .tx
         .send(crate::ws::WsEvent::ServerRolesUpdated { server_id });
 
+    if permissions_opt.is_some() {
+        voice_revoke::revoke_invalid_voice_sessions_for_server(
+            &state,
+            server_id,
+            "role permissions updated",
+        )
+        .await?;
+    }
+
     Ok(Json(role))
 }
 
@@ -1086,6 +1096,9 @@ async fn delete_role(
     let _ = state
         .tx
         .send(crate::ws::WsEvent::ServerRolesUpdated { server_id });
+
+    voice_revoke::revoke_invalid_voice_sessions_for_server(&state, server_id, "role deleted")
+        .await?;
 
     Ok(Json(serde_json::json!({ "ok": true })))
 }
@@ -1775,6 +1788,13 @@ async fn update_member_roles(
     )
     .await;
 
+    voice_revoke::revoke_invalid_voice_sessions_for_server(
+        &state,
+        server_id,
+        "member roles updated",
+    )
+    .await?;
+
     Ok(Json(
         serde_json::json!({ "message": "Member roles updated" }),
     ))
@@ -1856,6 +1876,13 @@ async fn update_member_role(
         },
     )
     .await;
+
+    voice_revoke::revoke_invalid_voice_sessions_for_server(
+        &state,
+        server_id,
+        "member role updated",
+    )
+    .await?;
 
     Ok(Json(serde_json::json!({ "message": "Role updated" })))
 }
@@ -1973,6 +2000,13 @@ async fn ban_member(
 
     if removed_member {
         crate::ws::publish_event(&state, WsEvent::MemberLeft { server_id, user_id }).await;
+        voice_revoke::revoke_user_voice_access_for_server(
+            &state,
+            server_id,
+            user_id,
+            "member banned",
+        )
+        .await?;
     }
 
     Ok(Json(serde_json::json!({
@@ -2666,6 +2700,8 @@ async fn kick_member(
     .await?;
 
     crate::ws::publish_event(&state, WsEvent::MemberLeft { server_id, user_id }).await;
+    voice_revoke::revoke_user_voice_access_for_server(&state, server_id, user_id, "member kicked")
+        .await?;
 
     Ok(Json(serde_json::json!({ "message": "Member kicked" })))
 }

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -8,3 +8,4 @@ pub mod jwt_blacklist;
 pub mod moderation;
 pub mod permissions;
 pub mod rate_limit;
+pub mod voice_revoke;

--- a/apps/server/src/services/voice_revoke.rs
+++ b/apps/server/src/services/voice_revoke.rs
@@ -1,0 +1,349 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{encode, EncodingKey, Header};
+use reqwest::StatusCode;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    errors::AppError,
+    ws::{self, access::can_join_voice_channel, WsEvent},
+    AppState,
+};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LivekitAdminVideoGrant {
+    room: String,
+    room_admin: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct LivekitAdminClaims {
+    iss: String,
+    sub: String,
+    nbf: usize,
+    exp: usize,
+    video: LivekitAdminVideoGrant,
+}
+
+#[derive(Debug, Serialize)]
+struct RemoveParticipantRequest<'a> {
+    room: &'a str,
+    identity: &'a str,
+}
+
+fn server_id_for_channel_from_state(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+) -> impl std::future::Future<Output = Option<Uuid>> + '_ {
+    async move {
+        sqlx::query_scalar::<_, Uuid>("SELECT server_id FROM channels WHERE id = $1")
+            .bind(channel_id)
+            .fetch_optional(&state.db)
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
+fn cleanup_voice_channel_active_since_if_empty(state: &Arc<AppState>, channel_id: Uuid) {
+    let still_has_participants = state
+        .voice_sessions
+        .iter()
+        .any(|entry| *entry.value() == channel_id);
+    if !still_has_participants {
+        state.voice_channel_active_since_ms.remove(&channel_id);
+    }
+}
+
+fn voice_control_event_from_state(
+    user_id: Uuid,
+    server_id: Option<Uuid>,
+    state: (bool, bool, bool, bool, bool, bool),
+) -> WsEvent {
+    WsEvent::VoiceControlUpdate {
+        user_id,
+        server_id,
+        muted: state.0,
+        deafened: state.1,
+        server_muted: state.2,
+        server_deafened: state.3,
+        screen_sharing: state.4,
+        camera_on: state.5,
+    }
+}
+
+async fn clear_local_voice_session(
+    state: &Arc<AppState>,
+    user_id: Uuid,
+    channel_id: Uuid,
+    reason: &str,
+) {
+    let removed = state
+        .voice_sessions
+        .remove_if(&user_id, |_, active_channel_id| {
+            *active_channel_id == channel_id
+        })
+        .is_some();
+    if !removed {
+        return;
+    }
+
+    let server_id = server_id_for_channel_from_state(state, channel_id).await;
+    let _ = state.voice_controls.remove(&user_id);
+    cleanup_voice_channel_active_since_if_empty(state, channel_id);
+
+    tracing::info!(
+        "Revoked local voice session for user {} in channel {} ({})",
+        user_id,
+        channel_id,
+        reason
+    );
+
+    ws::publish_event(
+        state,
+        WsEvent::VoiceStateUpdate {
+            channel_id: None,
+            user_id,
+            server_id,
+            channel_active_since_ms: None,
+        },
+    )
+    .await;
+    ws::publish_event(
+        state,
+        voice_control_event_from_state(
+            user_id,
+            server_id,
+            (false, false, false, false, false, false),
+        ),
+    )
+    .await;
+}
+
+fn livekit_http_base_url(ws_url: &str) -> Option<String> {
+    let trimmed = ws_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(rest) = trimmed.strip_prefix("wss://") {
+        return Some(format!("https://{rest}"));
+    }
+    if let Some(rest) = trimmed.strip_prefix("ws://") {
+        return Some(format!("http://{rest}"));
+    }
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        return Some(trimmed.to_string());
+    }
+    None
+}
+
+fn sign_livekit_admin_token(
+    api_key: &str,
+    api_secret: &str,
+    room: &str,
+) -> Result<String, AppError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_secs() as usize;
+    let token = encode(
+        &Header::default(),
+        &LivekitAdminClaims {
+            iss: api_key.to_string(),
+            sub: "voxpery-server".to_string(),
+            nbf: now,
+            exp: now + 60,
+            video: LivekitAdminVideoGrant {
+                room: room.to_string(),
+                room_admin: true,
+            },
+        },
+        &EncodingKey::from_secret(api_secret.as_bytes()),
+    )
+    .map_err(|e| AppError::Internal(format!("Failed to sign LiveKit admin token: {e}")))?;
+    Ok(token)
+}
+
+async fn remove_livekit_participant(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    user_id: Uuid,
+    reason: &str,
+) {
+    let Some(ws_url) = state.livekit_ws_url.as_deref() else {
+        return;
+    };
+    let Some(api_key) = state.livekit_api_key.as_deref() else {
+        return;
+    };
+    let Some(api_secret) = state.livekit_api_secret.as_deref() else {
+        return;
+    };
+    let Some(base_url) = livekit_http_base_url(ws_url) else {
+        tracing::warn!("Cannot revoke LiveKit participant because LIVEKIT_WS_URL is invalid");
+        return;
+    };
+
+    let room = channel_id.to_string();
+    let identity = user_id.to_string();
+    let token = match sign_livekit_admin_token(api_key, api_secret, &room) {
+        Ok(token) => token,
+        Err(e) => {
+            tracing::warn!("Cannot revoke LiveKit participant: {}", e);
+            return;
+        }
+    };
+
+    let url = format!("{base_url}/twirp/livekit.RoomService/RemoveParticipant");
+    let response = state
+        .release_http_client
+        .post(url)
+        .bearer_auth(token)
+        .json(&RemoveParticipantRequest {
+            room: &room,
+            identity: &identity,
+        })
+        .send()
+        .await;
+
+    match response {
+        Ok(response) if response.status().is_success() => {
+            tracing::info!(
+                "Removed LiveKit participant {} from room {} ({})",
+                user_id,
+                channel_id,
+                reason
+            );
+        }
+        Ok(response) if response.status() == StatusCode::NOT_FOUND => {
+            tracing::debug!(
+                "LiveKit participant {} was not present in room {} during revoke ({})",
+                user_id,
+                channel_id,
+                reason
+            );
+        }
+        Ok(response) => {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            tracing::warn!(
+                "LiveKit participant revoke failed for user {} room {}: {} {}",
+                user_id,
+                channel_id,
+                status,
+                body
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "LiveKit participant revoke request failed for user {} room {}: {}",
+                user_id,
+                channel_id,
+                e
+            );
+        }
+    }
+}
+
+async fn voice_channel_ids_for_server(
+    state: &Arc<AppState>,
+    server_id: Uuid,
+) -> Result<Vec<Uuid>, AppError> {
+    let channel_ids = sqlx::query_scalar::<_, Uuid>(
+        "SELECT id FROM channels WHERE server_id = $1 AND channel_type = 'voice'",
+    )
+    .bind(server_id)
+    .fetch_all(&state.db)
+    .await?;
+    Ok(channel_ids)
+}
+
+/// Revoke a user's voice access after server membership was removed.
+///
+/// This clears Voxpery's runtime voice state and also asks LiveKit to remove the
+/// participant from every voice room in that server so a modified client cannot
+/// keep listening with a previously minted token.
+pub async fn revoke_user_voice_access_for_server(
+    state: &Arc<AppState>,
+    server_id: Uuid,
+    user_id: Uuid,
+    reason: &str,
+) -> Result<(), AppError> {
+    let voice_channel_ids = voice_channel_ids_for_server(state, server_id).await?;
+
+    if let Some(active_channel_id) = state.voice_sessions.get(&user_id).map(|entry| *entry) {
+        if voice_channel_ids.contains(&active_channel_id) {
+            clear_local_voice_session(state, user_id, active_channel_id, reason).await;
+        }
+    }
+
+    for channel_id in voice_channel_ids {
+        remove_livekit_participant(state, channel_id, user_id, reason).await;
+    }
+
+    Ok(())
+}
+
+/// Re-check active voice sessions after permission or channel visibility changes.
+pub async fn revoke_invalid_voice_sessions_for_server(
+    state: &Arc<AppState>,
+    server_id: Uuid,
+    reason: &str,
+) -> Result<(), AppError> {
+    let voice_channel_ids = voice_channel_ids_for_server(state, server_id).await?;
+    let active_sessions: Vec<(Uuid, Uuid)> = state
+        .voice_sessions
+        .iter()
+        .map(|entry| (*entry.key(), *entry.value()))
+        .filter(|(_, channel_id)| voice_channel_ids.contains(channel_id))
+        .collect();
+
+    for (user_id, channel_id) in active_sessions {
+        if !can_join_voice_channel(&state.db, user_id, channel_id).await? {
+            clear_local_voice_session(state, user_id, channel_id, reason).await;
+            remove_livekit_participant(state, channel_id, user_id, reason).await;
+        }
+    }
+
+    Ok(())
+}
+
+/// Revoke a single active voice session, used by moderation controls that
+/// disconnect one participant from the current channel.
+pub async fn revoke_active_voice_session(
+    state: &Arc<AppState>,
+    user_id: Uuid,
+    reason: &str,
+) -> Result<(), AppError> {
+    let Some(channel_id) = state.voice_sessions.get(&user_id).map(|entry| *entry) else {
+        return Ok(());
+    };
+    clear_local_voice_session(state, user_id, channel_id, reason).await;
+    remove_livekit_participant(state, channel_id, user_id, reason).await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::livekit_http_base_url;
+
+    #[test]
+    fn derives_livekit_http_base_url_from_websocket_url() {
+        assert_eq!(
+            livekit_http_base_url("wss://livekit.voxpery.com/"),
+            Some("https://livekit.voxpery.com".to_string())
+        );
+        assert_eq!(
+            livekit_http_base_url("ws://localhost:7880"),
+            Some("http://localhost:7880".to_string())
+        );
+        assert_eq!(
+            livekit_http_base_url("https://livekit.voxpery.com"),
+            Some("https://livekit.voxpery.com".to_string())
+        );
+        assert_eq!(livekit_http_base_url(""), None);
+    }
+}

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -19,6 +19,7 @@ use super::{WsClientMessage, WsEvent};
 use crate::middleware::auth::token_from_request;
 use crate::middleware::auth::{claims_match_current_token_version, Claims};
 use crate::services::permissions::{get_user_server_permissions, Permissions};
+use crate::services::voice_revoke;
 use crate::ws::access::{can_join_voice_channel, can_subscribe_to_channel};
 use crate::AppState;
 
@@ -884,36 +885,17 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                     continue;
                                 }
 
-                                if let Some((_, previous_channel_id)) =
-                                    recv_state.voice_sessions.remove(&target_user_id)
+                                if let Err(e) = voice_revoke::revoke_active_voice_session(
+                                    &recv_state,
+                                    target_user_id,
+                                    "voice moderator disconnect",
+                                )
+                                .await
                                 {
-                                    let previous_server_id =
-                                        server_id_for_channel(&recv_state.db, previous_channel_id)
-                                            .await;
-                                    let _ = recv_state.voice_controls.remove(&target_user_id);
-                                    cleanup_voice_channel_active_since_if_empty(
-                                        &recv_state,
-                                        previous_channel_id,
+                                    tracing::warn!(
+                                        "DisconnectVoiceMember voice revoke failed: {}",
+                                        e
                                     );
-                                    super::publish_event(
-                                        &recv_state,
-                                        WsEvent::VoiceStateUpdate {
-                                            channel_id: None,
-                                            user_id: target_user_id,
-                                            server_id: previous_server_id,
-                                            channel_active_since_ms: None,
-                                        },
-                                    )
-                                    .await;
-                                    super::publish_event(
-                                        &recv_state,
-                                        voice_control_event_from_state(
-                                            target_user_id,
-                                            previous_server_id,
-                                            (false, false, false, false, false, false),
-                                        ),
-                                    )
-                                    .await;
                                 }
                             }
                             WsClientMessage::SetVoiceControl {

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -34,6 +34,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Google OAuth login works.
 - [ ] Server/channel/category permission scenarios work.
 - [ ] Voice join/leave works.
+- [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share also mutes only the screen-share audio while normal microphone audio continues.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -35,6 +35,13 @@ Microphone -> getUserMedia -> AudioContext pipeline -> LiveKit Room -> SFU -> Re
 5. Frontend publishes mic track -> LiveKit forwards to all room participants
 6. Frontend subscribes to all remote tracks automatically
 
+### Server-side Voice Revocation
+
+- LiveKit tokens are only minted after the backend verifies `VIEW_SERVER` and `CONNECT_VOICE`.
+- If a member is kicked, banned, disconnected by a moderator, or loses active voice permissions through role/channel overrides, the backend clears the runtime voice session and asks LiveKit to remove that participant from the room.
+- This server-side removal is required because a modified client could ignore WebSocket leave events while keeping an already-established LiveKit media connection alive.
+- If LiveKit is unavailable during revocation, Voxpery still clears local voice state and logs the LiveKit removal failure for operators.
+
 ### Room Events
 
 - `TrackSubscribed`: Remote peer published audio/video -> add to `remoteStreams`


### PR DESCRIPTION
## Summary

Fix voice access revocation so users cannot keep an existing LiveKit media session after losing voice access.

## Changes

- Added server-side voice revoke handling for active LiveKit participants.
- Kick/ban now clears Voxpery voice state and requests LiveKit participant removal.
- Role, member-role, channel override, and category override changes now re-check active voice sessions and revoke invalid ones.
- Moderator voice disconnect now uses the same revoke path.
- Updated voice docs and release smoke checklist for voice access revocation testing.

## Validation

- `cargo check --manifest-path apps/server/Cargo.toml --locked`
- `cargo test --manifest-path apps/server/Cargo.toml --locked`
- `git diff --check`
- `graphify update .`