### PR TITLE
feat: implement rate limiting and deduplication for user and message …

### DIFF
--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -53,6 +53,9 @@ const MAX_ONBOARDING_TASKS: usize = 6;
 const MAX_ONBOARDING_TITLE_CHARS: usize = 80;
 const MAX_ONBOARDING_BODY_CHARS: usize = 1000;
 const MAX_ONBOARDING_TASK_CHARS: usize = 120;
+const REPORT_SUBMIT_RATE_LIMIT_MAX: usize = 5;
+const REPORT_SUBMIT_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+const REPORT_LIST_LIMIT: i64 = 200;
 
 #[derive(Debug, serde::Serialize, sqlx::FromRow)]
 struct AuditLogEntry {
@@ -492,6 +495,21 @@ fn normalize_report_details(details: Option<&str>) -> Result<Option<String>, App
         return Ok(Some(value.to_string()));
     }
     Ok(None)
+}
+
+async fn enforce_report_submit_rate_limit(
+    state: &Arc<AppState>,
+    server_id: Uuid,
+    reporter_user_id: Uuid,
+) -> Result<(), AppError> {
+    enforce_rate_limit(
+        &state.redis,
+        format!("reports:submit:{server_id}:{reporter_user_id}"),
+        REPORT_SUBMIT_RATE_LIMIT_MAX,
+        REPORT_SUBMIT_RATE_LIMIT_WINDOW,
+        "Too many report submissions. Please wait a moment and try again.",
+    )
+    .await
 }
 
 /// GET /api/servers/invite/:invite_code — public preview for invite pages.
@@ -2355,6 +2373,8 @@ async fn report_user(
         return Err(AppError::Validation("Cannot report yourself".into()));
     }
 
+    enforce_report_submit_rate_limit(&state, server_id, claims.sub).await?;
+
     let reason = normalize_report_reason(&body.reason)?;
     let details = normalize_report_details(body.details.as_deref())?;
 
@@ -2367,6 +2387,27 @@ async fn report_user(
     .await?;
     if member_exists == 0 {
         return Err(AppError::NotFound("Member not found".into()));
+    }
+
+    let existing_report_id = sqlx::query_scalar::<_, Uuid>(
+        r#"SELECT id
+           FROM server_reports
+           WHERE server_id = $1
+             AND reporter_user_id = $2
+             AND reported_user_id = $3
+             AND message_id IS NULL
+             AND status = 'open'
+           LIMIT 1"#,
+    )
+    .bind(server_id)
+    .bind(claims.sub)
+    .bind(body.reported_user_id)
+    .fetch_optional(&state.db)
+    .await?;
+    if existing_report_id.is_some() {
+        return Ok(Json(
+            serde_json::json!({ "message": "Report already submitted" }),
+        ));
     }
 
     sqlx::query(
@@ -2400,6 +2441,8 @@ async fn report_message(
     )
     .await?;
 
+    enforce_report_submit_rate_limit(&state, server_id, claims.sub).await?;
+
     let reason = normalize_report_reason(&body.reason)?;
     let details = normalize_report_details(body.details.as_deref())?;
 
@@ -2421,6 +2464,26 @@ async fn report_message(
     if reported_user_id == claims.sub {
         return Err(AppError::Validation(
             "Cannot report your own message".into(),
+        ));
+    }
+
+    let existing_report_id = sqlx::query_scalar::<_, Uuid>(
+        r#"SELECT id
+           FROM server_reports
+           WHERE server_id = $1
+             AND reporter_user_id = $2
+             AND message_id = $3
+             AND status = 'open'
+           LIMIT 1"#,
+    )
+    .bind(server_id)
+    .bind(claims.sub)
+    .bind(body.message_id)
+    .fetch_optional(&state.db)
+    .await?;
+    if existing_report_id.is_some() {
+        return Ok(Json(
+            serde_json::json!({ "message": "Report already submitted" }),
         ));
     }
 
@@ -2497,9 +2560,11 @@ async fn list_reports(
            WHERE sr.server_id = $1
            ORDER BY
              CASE WHEN sr.status = 'open' THEN 0 ELSE 1 END,
-             sr.created_at DESC"#,
+             sr.created_at DESC
+           LIMIT $2"#,
     )
     .bind(server_id)
+    .bind(REPORT_LIST_LIMIT)
     .fetch_all(&state.db)
     .await?;
 

--- a/apps/server/src/services/automod.rs
+++ b/apps/server/src/services/automod.rs
@@ -41,21 +41,42 @@ pub fn content_preview(content: &str) -> (String, bool) {
 }
 
 fn has_link(content: &str) -> bool {
-    let lower = content.to_ascii_lowercase();
-    lower.contains("http://")
-        || lower.contains("https://")
-        || lower.contains("www.")
-        || lower.contains(".com")
-        || lower.contains(".net")
-        || lower.contains(".org")
+    content.contains("http://")
+        || content.contains("https://")
+        || content.contains("www.")
+        || content.contains(".com")
+        || content.contains(".net")
+        || content.contains(".org")
 }
 
 fn has_invite_link(content: &str) -> bool {
-    let lower = content.to_ascii_lowercase();
-    lower.contains("discord.gg/")
-        || lower.contains("discord.com/invite/")
-        || lower.contains("discordapp.com/invite/")
-        || lower.contains("/invite/")
+    content.contains("discord.gg/")
+        || content.contains("discord.com/invite/")
+        || content.contains("discordapp.com/invite/")
+        || content.contains("/invite/")
+}
+
+fn is_automod_ignored_char(ch: char) -> bool {
+    ch.is_control()
+        || matches!(
+            ch,
+            '\u{00AD}'
+                | '\u{034F}'
+                | '\u{061C}'
+                | '\u{180E}'
+                | '\u{200B}'..='\u{200F}'
+                | '\u{202A}'..='\u{202E}'
+                | '\u{2060}'..='\u{206F}'
+                | '\u{FEFF}'
+        )
+}
+
+fn normalize_automod_text(input: &str) -> String {
+    input
+        .chars()
+        .filter(|ch| !is_automod_ignored_char(*ch))
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn is_mention_boundary_char(ch: Option<char>) -> bool {
@@ -93,16 +114,15 @@ pub fn mention_count(content: &str) -> usize {
 }
 
 fn evaluate_rule(rule: &AutoModRule, content: &str) -> Option<AutoModMatch> {
+    let normalized_content = normalize_automod_text(content);
     match rule.trigger_type.as_str() {
         "blocked_keyword" => {
             let pattern = rule.pattern.as_deref()?.trim();
             if pattern.is_empty() {
                 return None;
             }
-            if content
-                .to_ascii_lowercase()
-                .contains(&pattern.to_ascii_lowercase())
-            {
+            let normalized_pattern = normalize_automod_text(pattern);
+            if !normalized_pattern.is_empty() && normalized_content.contains(&normalized_pattern) {
                 Some(AutoModMatch {
                     rule_id: rule.id,
                     rule_name: rule.name.clone(),
@@ -113,13 +133,13 @@ fn evaluate_rule(rule: &AutoModRule, content: &str) -> Option<AutoModMatch> {
                 None
             }
         }
-        "invite_filter" if has_invite_link(content) => Some(AutoModMatch {
+        "invite_filter" if has_invite_link(&normalized_content) => Some(AutoModMatch {
             rule_id: rule.id,
             rule_name: rule.name.clone(),
             trigger_type: rule.trigger_type.clone(),
             matched_value: Some("invite_link".into()),
         }),
-        "link_filter" if has_link(content) => Some(AutoModMatch {
+        "link_filter" if has_link(&normalized_content) => Some(AutoModMatch {
             rule_id: rule.id,
             rule_name: rule.name.clone(),
             trigger_type: rule.trigger_type.clone(),
@@ -127,7 +147,7 @@ fn evaluate_rule(rule: &AutoModRule, content: &str) -> Option<AutoModMatch> {
         }),
         "mention_spam" => {
             let limit = rule.mention_limit.unwrap_or(5).max(1) as usize;
-            let mentions = mention_count(content);
+            let mentions = mention_count(&normalized_content);
             if mentions >= limit {
                 Some(AutoModMatch {
                     rule_id: rule.id,
@@ -213,9 +233,53 @@ pub async fn log_blocked_message(
 mod tests {
     use super::*;
 
+    fn blocked_keyword_rule(pattern: &str) -> AutoModRule {
+        AutoModRule {
+            id: Uuid::new_v4(),
+            server_id: Uuid::new_v4(),
+            name: "Blocked keyword".into(),
+            trigger_type: "blocked_keyword".into(),
+            pattern: Some(pattern.into()),
+            mention_limit: None,
+            enabled: true,
+            exempt_role_ids: vec![],
+            exempt_channel_ids: vec![],
+            created_by: None,
+            updated_by: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
     #[test]
     fn mention_count_ignores_email_like_text() {
         assert_eq!(mention_count("hello @one @two test@example.com"), 2);
+    }
+
+    #[test]
+    fn blocked_keyword_matches_zero_width_bypass() {
+        let rule = blocked_keyword_rule("badword");
+        assert!(evaluate_rule(&rule, "ba\u{200B}dword").is_some());
+    }
+
+    #[test]
+    fn blocked_keyword_matches_rtl_override_bypass() {
+        let rule = blocked_keyword_rule("badword");
+        assert!(evaluate_rule(&rule, "bad\u{202E}word").is_some());
+    }
+
+    #[test]
+    fn invite_filter_matches_zero_width_bypass() {
+        let mut rule = blocked_keyword_rule("");
+        rule.trigger_type = "invite_filter".into();
+        assert!(evaluate_rule(&rule, "discord.\u{200B}gg/example").is_some());
+    }
+
+    #[test]
+    fn link_filter_matches_zero_width_bypass() {
+        let mut rule = blocked_keyword_rule("");
+        rule.trigger_type = "link_filter".into();
+        assert!(evaluate_rule(&rule, "https://exa\u{200B}mple.com").is_some());
     }
 
     #[test]
@@ -226,4 +290,3 @@ mod tests {
         assert!(truncated);
     }
 }
-

--- a/docs/API.md
+++ b/docs/API.md
@@ -187,9 +187,10 @@ Notes:
 - `POST /api/messages/:channel_id` (requires `SEND_MESSAGES`)
 - `PATCH /api/messages/item/:message_id` (author only)
 - `DELETE /api/messages/item/:message_id` (author or `MANAGE_MESSAGES`)
-- Enabled AutoMod rules are evaluated before server-channel sends/edits are stored or broadcast.
+- Enabled AutoMod rules are evaluated before server-channel sends/edits are stored or broadcast. Keyword, link, invite, and mention-spam checks normalize invisible Unicode format/control characters before matching.
 - Active member timeouts block server-channel sends/edits and new reactions before persistence or broadcast.
 - Server-level raid protection records join bursts, new-account join bursts, message bursts, and invite spikes in moderation activity/audit logs; message and invite bursts can return `429`.
+- User and message reports are rate limited per reporter/server, deduplicated while an open report for the same target exists, and moderation report listing returns the most recent 200 entries.
 
 ### Pins
 
@@ -261,6 +262,7 @@ Current key limits (Redis-backed):
 - Friend request: 5/min per user
 - DM channel create: 5/min per user
 - Message send: `MESSAGE_RATE_LIMIT_MAX` / `MESSAGE_RATE_LIMIT_WINDOW_SECS`
+- Report submit: 5/min per reporter/server
 - WS connect: 3/10s per user
 
 ## Error Shape

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -42,8 +42,9 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Mobile server chat shows one visible message after send, including after the API response and WebSocket echo both arrive.
 - [ ] Mobile Social/Friends list scrolls when the visible friend or request list exceeds the viewport.
 - [ ] Safety moderation view shows open reports, active timeouts, and recent raid events.
+- [ ] Repeated user/message report submissions for the same target do not create duplicate open reports, and rapid report spam returns `429`.
 - [ ] Server Settings opens and remains scrollable on desktop; mobile still shows the desktop-only guidance instead of a broken settings modal.
-- [ ] AutoMod rule create/edit/enable/disable/delete works and blocked messages do not persist or broadcast.
+- [ ] AutoMod rule create/edit/enable/disable/delete works and blocked messages do not persist or broadcast, including blocked keywords split with invisible zero-width/bidi characters.
 - [ ] Raid protection records message bursts, invite spikes, and join burst signals in audit/moderation activity without exposing private secrets.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
 - [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -320,7 +320,9 @@ The production web image passes `APP_ENV=production` and uses `apps/web/nginx.pr
 
 Audit logging is implemented for core moderation/server actions (for example role updates, kick, ban, and server settings updates) and exposed via server audit endpoints.
 
-AutoMod rules are server-scoped and require `MANAGE_MESSAGES` to manage. Enabled rules can block server-channel sends/edits for blocked keywords, invite links, links, or mention spam before persistence/broadcast. AutoMod blocks write audit entries with rule metadata and a truncated content preview.
+AutoMod rules are server-scoped and require `MANAGE_MESSAGES` to manage. Enabled rules can block server-channel sends/edits for blocked keywords, invite links, links, or mention spam before persistence/broadcast. AutoMod matching removes common invisible Unicode format/control characters before evaluation so zero-width and bidi override characters cannot be used to split blocked keywords or links. AutoMod blocks write audit entries with rule metadata and a truncated content preview.
+
+User and message reports require server membership, are rate limited per reporter/server, and repeated open reports for the same target are deduplicated before they reach the moderation queue. Report listing is capped to keep the safety panel responsive under abuse.
 
 Temporary member timeouts require `MANAGE_MESSAGES`, respect role hierarchy, cannot target the server owner, and block server-channel sends/edits plus new reactions until expiration or manual clearing. Timeout create/clear actions are audit logged.
 


### PR DESCRIPTION
## Summary

Hardens moderation abuse paths found in the AppSec review.

## Changes

- Normalize invisible Unicode format/control characters before AutoMod matching.
- Cover zero-width and bidi bypasses for blocked keywords, links, and invite filters.
- Rate-limit report submissions per reporter/server.
- Deduplicate repeated open user/message reports for the same target.
- Cap report listing to keep the moderation queue responsive under abuse.
- Update security/API docs and release smoke checklist.

## Validation

- `cargo check --locked`
- `cargo test automod --locked`
- `git diff --check`
- `graphify update .`