### PR TITLE
feat: enhance security and logging measures; redact email in OAuth wa…

### DIFF
--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -366,6 +366,14 @@ fn constant_time_eq(left: &str, right: &str) -> bool {
     diff == 0
 }
 
+fn redact_email_for_log(email: &str) -> String {
+    let Some((local, domain)) = email.split_once('@') else {
+        return "[redacted-email]".to_string();
+    };
+    let first = local.chars().next().unwrap_or('*');
+    format!("{}***@{}", first, domain)
+}
+
 fn transliterate_special_latin_char(c: char) -> &'static str {
     match c {
         '\u{00DF}' => "ss",
@@ -1537,11 +1545,11 @@ async fn google_oauth_callback(
             let c = parts.next().unwrap_or("").trim().to_string();
             if n.is_empty() || o.is_empty() || !r.starts_with('/') {
                 tracing::warn!(
-                    "OAuth state parsing failed. Parts: n='{}', o='{}', r='{}', c='{}'",
-                    n,
-                    o,
-                    r,
-                    c
+                    "OAuth state parsing failed. nonce_present={}, origin_len={}, redirect_len={}, pkce_challenge_present={}",
+                    !n.is_empty(),
+                    o.len(),
+                    r.len(),
+                    !c.is_empty()
                 );
                 (
                     "".to_string(),
@@ -1665,7 +1673,10 @@ async fn google_oauth_callback(
     let email = email.trim().to_lowercase();
 
     if let Some(false) = userinfo.verified_email {
-        tracing::warn!("Google OAuth login rejected: unverified email ({})", email);
+        tracing::warn!(
+            "Google OAuth login rejected: unverified email ({})",
+            redact_email_for_log(&email)
+        );
         let redirect_error = format!("{}?error=oauth_unverified_email", redirect_path);
         return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
     }

--- a/apps/server/src/services/voice_revoke.rs
+++ b/apps/server/src/services/voice_revoke.rs
@@ -230,11 +230,11 @@ async fn remove_livekit_participant(
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             tracing::warn!(
-                "LiveKit participant revoke failed for user {} room {}: {} {}",
+                "LiveKit participant revoke failed for user {} room {}: status={} body_length={}",
                 user_id,
                 channel_id,
                 status,
-                body
+                body.len()
             );
         }
         Err(e) => {

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -14,12 +14,12 @@ RUN VITE_API_URL="${VITE_API_URL}" \
     VITE_TURNSTILE_SITE_KEY="${TURNSTILE_SITE_KEY_PUBLIC}" \
     npm run build
 
-FROM nginx:1.27-alpine AS runtime
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 
 ARG APP_ENV=development
 COPY nginx.${APP_ENV}.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/web/nginx.development.conf
+++ b/apps/web/nginx.development.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
 
     root /usr/share/nginx/html;

--- a/apps/web/nginx.production.conf
+++ b/apps/web/nginx.production.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
 
     root /usr/share/nginx/html;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
       server:
         condition: service_started
     ports:
-      - "127.0.0.1:${WEB_PORT:-5173}:80"
+      - "127.0.0.1:${WEB_PORT:-5173}:8080"
     logging: *default-logging
 
 volumes:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -74,6 +74,7 @@ Basic service checks:
 ```bash
 curl -f http://localhost:3001/health
 curl -I http://localhost:${WEB_PORT:-5173}
+curl -f http://localhost:${WEB_PORT:-5173}/healthz
 curl -s http://localhost:3001/api/system/features
 ```
 
@@ -122,6 +123,7 @@ Security defaults in compose:
 
 - `web`, `server`, `postgres`, `redis`, `livekit:7880` bind to `127.0.0.1` only
 - Local compose passes `APP_ENV=development` and builds the web image with `apps/web/nginx.development.conf` so localhost API and LiveKit smoke tests work. Public production images pass `APP_ENV=production` in CI and use `apps/web/nginx.production.conf`, which omits browser loopback `connect-src` allowances.
+- The web image uses unprivileged nginx and listens on container port `8080`; Compose maps it to `127.0.0.1:${WEB_PORT:-5173}`.
 - Public media ports stay open for LiveKit:
   - `7881/tcp` (fallback)
   - `7882/udp`
@@ -155,6 +157,7 @@ The backend is ready for multiple instances for REST traffic and cross-instance 
 
 ```bash
 curl -f http://localhost:3001/health
+curl -f http://localhost:${WEB_PORT:-5173}/healthz
 curl -I http://localhost:${WEB_PORT:-5173}
 ```
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -22,6 +22,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 
 - [ ] Relevant `CodeQL` analyzers are green or did not run because no matching files changed.
 - [ ] `Dependency Security Audit` is reviewed; unresolved upstream-blocked advisories have an explicit release decision recorded.
+- [ ] Web container health responds through the host mapping (`curl -f http://localhost:${WEB_PORT:-5173}/healthz`) while the container uses unprivileged nginx on internal port `8080`.
 - [ ] Remote avatar/server icon/inline media proxy rejects localhost/private targets and still loads normal public HTTPS images.
 - [ ] Manual `Release Smoke` workflow completed successfully against the release candidate API.
 - [ ] `Release Smoke` ran with strict security headers enabled for production candidates.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -268,7 +268,7 @@ add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-
 
 `'wasm-unsafe-eval'` is required for the RNNoise WebAssembly voice suppression runtime. It is narrower than broad JavaScript `'unsafe-eval'` and should stay in `script-src` for production voice releases.
 
-The production web image passes `APP_ENV=production` and uses `apps/web/nginx.production.conf`, which does not allow browser connections to visitor loopback targets. Local Docker compose passes `APP_ENV=development` by default and uses `apps/web/nginx.development.conf` so `localhost` API and LiveKit smoke tests keep working.
+The production web image passes `APP_ENV=production` and uses `apps/web/nginx.production.conf`, which does not allow browser connections to visitor loopback targets. Local Docker compose passes `APP_ENV=development` by default and uses `apps/web/nginx.development.conf` so `localhost` API and LiveKit smoke tests keep working. The web container runs with the unprivileged nginx image and listens on container port `8080`; Compose still exposes it on `127.0.0.1:${WEB_PORT:-5173}`.
 
 ## Secrets Management
 
@@ -288,7 +288,8 @@ The production web image passes `APP_ENV=production` and uses `apps/web/nginx.pr
 
 - Sensitive fields are not exposed in serialized user output (`password_hash` is skipped).
 - `User` debug output is redacted for sensitive fields (`password_hash`, email, OAuth linkage detail).
-- OAuth failure paths avoid logging raw state/cookie nonce values and third-party token bodies.
+- OAuth failure paths avoid logging raw state/cookie nonce values, PKCE challenges, full email addresses, and third-party token bodies.
+- Third-party service failures log status and safe metadata instead of raw response bodies.
 
 ## Vulnerability Disclosure
 


### PR DESCRIPTION
## Summary

Harden logging and web container runtime behavior.

## Changes

- Redact OAuth failure logs so raw state, PKCE challenge data, and full email addresses are not written to logs.
- Avoid logging raw LiveKit revoke response bodies; log only status and safe metadata.
- Switch the web runtime to unprivileged nginx on internal port `8080`.
- Keep the public Compose web mapping unchanged at `127.0.0.1:${WEB_PORT:-5173}`.
- Update security, deployment, and release smoke test docs.

## Validation

- `cargo check --manifest-path apps/server/Cargo.toml --locked`
- `cargo test --manifest-path apps/server/Cargo.toml oauth_pkce_tests --locked`
- `docker compose config`
- `docker compose build web`
- `git diff --check`
- `graphify update .`