### PR TITLE
fix(chat): improve message row stability and alignment in ChatArea co…

### DIFF
--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -1534,7 +1534,7 @@ export default function ChatArea({
                                         data-index={virtualRow.index}
                                         ref={rowVirtualizer.measureElement}
                                         className="virtual-list-item"
-                                        style={{ transform: `translateY(${virtualRow.start}px)` }}
+                                        style={{ transform: `translateY(${Math.round(virtualRow.start)}px)` }}
                                     >
                                         <div className="typing-indicator">{typingIndicatorLabel}</div>
                                     </div>
@@ -1586,7 +1586,7 @@ export default function ChatArea({
                                     data-index={virtualRow.index}
                                     ref={rowVirtualizer.measureElement}
                                     className={`virtual-list-item ${virtualRow.index === 0 ? 'virtual-list-item-first' : ''}`}
-                                    style={{ transform: `translateY(${virtualRow.start}px)` }}
+                                    style={{ transform: `translateY(${Math.round(virtualRow.start)}px)` }}
                                 >
                                     {showDayDivider && (
                                         <div className="message-day-divider" aria-label={`Messages from ${formatDayDivider(msg.created_at)}`}>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4457,6 +4457,7 @@ body {
 /* Message */
 .message {
   display: flex;
+  align-items: flex-start;
   gap: 16px;
   padding: 4px 16px;
   border-radius: var(--border-radius-sm);
@@ -4488,6 +4489,7 @@ body {
 }
 
 .message-avatar {
+  flex: 0 0 40px;
   width: 40px;
   height: 40px;
   border-radius: var(--border-radius-full);
@@ -4497,8 +4499,8 @@ body {
   justify-content: center;
   font-weight: 700;
   font-size: 15px;
+  line-height: 40px;
   color: white;
-  flex-shrink: 0;
   margin-top: 2px;
   overflow: hidden;
 }
@@ -4537,15 +4539,18 @@ body {
 
 .message-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
+  min-height: 20px;
   margin-bottom: 2px;
+  line-height: 20px;
 }
 
 .message-author {
   font-weight: 600;
   color: var(--text-primary);
   font-size: 14px;
+  line-height: 20px;
 }
 
 .message-author.owner {
@@ -4559,11 +4564,13 @@ body {
 
 .message-timestamp {
   font-size: 11px;
+  line-height: 20px;
   color: var(--text-muted);
 }
 
 .message-edited {
   font-size: 10px;
+  line-height: 20px;
   color: var(--text-muted);
   margin-left: 4px;
   font-style: italic;
@@ -4826,7 +4833,7 @@ body {
 .message-text {
   color: var(--text-secondary);
   font-size: 14px;
-  line-height: 1.4;
+  line-height: 20px;
   word-break: break-word;
   white-space: pre-wrap;
 }
@@ -13637,9 +13644,11 @@ textarea {
   }
 
   .message-avatar {
+    flex-basis: 36px;
     width: 36px;
     height: 36px;
     font-size: 13px;
+    line-height: 36px;
   }
 
   .message-content {
@@ -13651,12 +13660,15 @@ textarea {
     justify-content: flex-start;
     flex-wrap: wrap;
     gap: 2px 6px;
+    min-height: 18px;
+    line-height: 18px;
     margin-bottom: 1px;
     padding-right: 108px;
   }
 
   .message-author {
     font-size: 13px;
+    line-height: 18px;
     flex: 0 1 auto;
     min-width: 0;
     max-width: 100%;
@@ -13667,6 +13679,7 @@ textarea {
 
   .message-timestamp {
     font-size: 10px;
+    line-height: 18px;
     margin-left: 0;
     flex-shrink: 0;
     text-align: left;
@@ -13675,6 +13688,7 @@ textarea {
   }
 
   .message-edited {
+    line-height: 18px;
     margin-left: 0;
   }
 


### PR DESCRIPTION
## Summary

Improve chat message row visual stability by reducing small avatar/header/text alignment shifts after initial render.

## Changes

- Rounded virtualized message row positioning to whole pixels to avoid subpixel layout jitter.
- Stabilized message avatar sizing with fixed flex basis and line-height.
- Normalized message header, author, timestamp, edited label, and text line-height values.
- Kept media rendering/cache behavior unchanged in this branch.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`

## Manual Test

- Sent multiple short messages in the browser.
- Verified avatar, username, timestamp, and text alignment no longer shift after render.