### PR TITLE
fix(chat): enhance image attachment preview behavior in ChatArea comp…

### DIFF
--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -101,7 +101,6 @@ function AttachmentImagePreviewModal({
         >
             <div className="chat-image-preview-modal">
                 <div className="chat-image-preview-toolbar">
-                    <span className="chat-image-preview-title">{title}</span>
                     <button
                         type="button"
                         className="chat-image-preview-close"
@@ -228,6 +227,8 @@ function estimateMessageRowHeight(messages: UiMessage[], index: number, firstUnr
 function AttachmentLink({ attachment, index }: { attachment: Attachment; index: number }) {
     const token = useAuthStore((s) => s.token)
     const [previewOpen, setPreviewOpen] = useState(false)
+    const fallbackInFlightRef = useRef(false)
+    const fallbackObjectUrlRef = useRef<string | null>(null)
     const isImage = isImageAttachment(attachment)
     const [resolution, setResolution] = useState(() => ({
         sourceUrl: attachment.url,
@@ -249,7 +250,6 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
         let objectUrl: string | null = null
 
         resolveAttachmentUrl(attachment.url, token ?? null, {
-            forceAuthenticatedFetch: isImage,
             fallbackMimeType: attachment.type,
         })
             .then((nextUrl) => {
@@ -282,15 +282,87 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
         }
     }, [attachment.type, attachment.url, isImage, token])
 
+    useEffect(() => {
+        return () => {
+            if (fallbackObjectUrlRef.current) URL.revokeObjectURL(fallbackObjectUrlRef.current)
+        }
+    }, [])
+
+    useEffect(() => {
+        fallbackInFlightRef.current = false
+        if (fallbackObjectUrlRef.current) {
+            URL.revokeObjectURL(fallbackObjectUrlRef.current)
+            fallbackObjectUrlRef.current = null
+        }
+    }, [attachment.url])
+
     if (isImage) {
         const alt = attachment.name || `Attachment ${index + 1}`
         const handleImageLoadError = () => {
+            const shouldTryAuthenticatedFallback =
+                !currentResolution.triedDirectFallback &&
+                !currentResolution.resolvedUrl.startsWith('blob:') &&
+                !fallbackInFlightRef.current
+
+            if (shouldTryAuthenticatedFallback) {
+                fallbackInFlightRef.current = true
+                setResolution((current) => {
+                    if (current.sourceUrl !== attachment.url) return current
+                    return {
+                        ...current,
+                        triedDirectFallback: true,
+                    }
+                })
+                void resolveAttachmentUrl(attachment.url, token ?? null, {
+                    forceAuthenticatedFetch: true,
+                    fallbackMimeType: attachment.type,
+                })
+                    .then((nextUrl) => {
+                        if (nextUrl.startsWith('blob:')) {
+                            if (fallbackObjectUrlRef.current) URL.revokeObjectURL(fallbackObjectUrlRef.current)
+                            fallbackObjectUrlRef.current = nextUrl
+                        }
+                        setResolution((current) => {
+                            if (current.sourceUrl !== attachment.url) {
+                                if (nextUrl.startsWith('blob:')) URL.revokeObjectURL(nextUrl)
+                                if (fallbackObjectUrlRef.current === nextUrl) fallbackObjectUrlRef.current = null
+                                return current
+                            }
+                            if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
+                            return {
+                                sourceUrl: attachment.url,
+                                resolvedUrl: nextUrl,
+                                loadFailed: false,
+                                triedDirectFallback: true,
+                            }
+                        })
+                    })
+                    .catch(() => {
+                        setResolution((current) => {
+                            if (current.sourceUrl !== attachment.url) return current
+                            if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
+                            if (fallbackObjectUrlRef.current === current.resolvedUrl) fallbackObjectUrlRef.current = null
+                            return {
+                                ...current,
+                                loadFailed: true,
+                                triedDirectFallback: true,
+                            }
+                        })
+                    })
+                    .finally(() => {
+                        fallbackInFlightRef.current = false
+                    })
+                return
+            }
+
             setResolution((current) => {
                 if (current.sourceUrl !== attachment.url) return current
                 if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
+                if (fallbackObjectUrlRef.current === current.resolvedUrl) fallbackObjectUrlRef.current = null
                 return {
                     ...current,
                     loadFailed: true,
+                    triedDirectFallback: true,
                 }
             })
         }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8007,7 +8007,7 @@ a.community-open-btn:hover {
 .chat-image-preview-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
   min-height: 48px;
   padding: 8px 10px 8px 14px;

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -51,6 +51,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.
+- [ ] Uploaded chat image attachments render inline after channel/server navigation and open only in the in-app preview modal on web and desktop, with no external tab/browser navigation.
 
 ## 4) Desktop Smoke Tests (mandatory)
 


### PR DESCRIPTION
## Summary

Improve uploaded image attachment previews across web and desktop.

## Changes

- Use direct signed image URLs on web so browser image caching works naturally during channel/server navigation.
- Keep authenticated blob URL rendering for desktop/Tauri attachment previews.
- Add a one-time authenticated blob fallback if a web image fails to load directly.
- Remove the filename/title from the enlarged image preview modal.
- Add release smoke coverage for inline image previews and in-app modal behavior.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`