### PR TITLE
fix(screen-share): update quality presets and summaries for screen sh…

### DIFF
--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -52,10 +52,10 @@ function readScreenShareQuality(): ScreenShareQuality {
 }
 
 function screenShareQualitySummary(mode: ScreenShareQuality) {
-  if (mode === 'presentation') return '1080p30 · 6 Mbps · detail'
-  if (mode === 'video') return '1080p60 · 10 Mbps · motion'
-  if (mode === 'gaming') return '1080p60 · 12 Mbps · high motion'
-  return 'Auto picks profile by share source.'
+  if (mode === 'presentation') return '1080p30 · 5 Mbps · detail'
+  if (mode === 'video') return '1080p60 · 7 Mbps · motion'
+  if (mode === 'gaming') return '1080p60 · 9 Mbps · high motion'
+  return 'Auto picks 30/60fps by share source.'
 }
 
 export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId }: ActiveCallBarProps) {

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -22,9 +22,9 @@ type ScreenShareProfile = {
 }
 
 const PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'auto'>, ScreenShareProfile> = {
-    presentation: { resolution: '1080p', framerate: 30, bitrate: 6_000_000, contentHint: 'detail' },
-    video: { resolution: '1080p', framerate: 60, bitrate: 10_000_000, contentHint: 'motion' },
-    gaming: { resolution: '1080p', framerate: 60, bitrate: 12_000_000, contentHint: 'motion' },
+    presentation: { resolution: '1080p', framerate: 30, bitrate: 5_000_000, contentHint: 'detail' },
+    video: { resolution: '1080p', framerate: 60, bitrate: 7_000_000, contentHint: 'motion' },
+    gaming: { resolution: '1080p', framerate: 60, bitrate: 9_000_000, contentHint: 'motion' },
 }
 
 export function useLocalMedia() {
@@ -53,9 +53,8 @@ export function useLocalMedia() {
         return PRESET_PROFILE.presentation
     }, [resolveQualityMode])
 
-    const getScreenShareConstraints = useCallback((): DisplayMediaStreamOptions['video'] => {
-        const profile = resolveScreenShareProfile()
-        const base = { frameRate: { ideal: profile.framerate } as MediaTrackConstraintSet['frameRate'] }
+    const toScreenShareConstraints = useCallback((profile: ScreenShareProfile): MediaTrackConstraints => {
+        const base = { frameRate: { ideal: profile.framerate, max: profile.framerate } as MediaTrackConstraintSet['frameRate'] }
         switch (profile.resolution) {
             case '1080p':
                 return { ...base, width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 } }
@@ -63,7 +62,26 @@ export function useLocalMedia() {
             default:
                 return { ...base, width: { ideal: 1280, max: 1280 }, height: { ideal: 720, max: 720 } }
         }
-    }, [resolveScreenShareProfile])
+    }, [])
+
+    const getScreenShareConstraints = useCallback((): DisplayMediaStreamOptions['video'] => {
+        const mode = resolveQualityMode()
+        const profile = mode === 'auto' ? PRESET_PROFILE.video : resolveScreenShareProfile()
+        return toScreenShareConstraints(profile)
+    }, [resolveQualityMode, resolveScreenShareProfile, toScreenShareConstraints])
+
+    const applyScreenShareTrackProfile = useCallback(async (videoTrack: MediaStreamTrack | undefined) => {
+        if (!videoTrack) return
+        const profile = resolveScreenShareProfile(videoTrack.getSettings?.().displaySurface)
+        if ('contentHint' in videoTrack) {
+            try { videoTrack.contentHint = profile.contentHint } catch { /* ignore */ }
+        }
+        try {
+            await videoTrack.applyConstraints(toScreenShareConstraints(profile))
+        } catch {
+            // Browsers may refuse post-selection display constraints; publish encoding still caps bandwidth/FPS.
+        }
+    }, [resolveScreenShareProfile, toScreenShareConstraints])
 
     // Apply browser-level mic constraints.
     // Keep browser noise suppression in sync with user setting as a safe fallback
@@ -176,9 +194,10 @@ export function useLocalMedia() {
             video: videoConstraints,
             audio: true,
         })
+        await applyScreenShareTrackProfile(stream.getVideoTracks()[0])
         cachedScreenStreamRef.current = stream
         return stream
-    }, [getScreenShareConstraints])
+    }, [applyScreenShareTrackProfile, getScreenShareConstraints])
 
     /** Returns LiveKit-compatible videoEncoding and content hint based on quality mode. */
     const getScreenShareEncoding = useCallback((videoTrack?: MediaStreamTrack): {

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -38,6 +38,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share also mutes only the screen-share audio while normal microphone audio continues.
+- [ ] Screen share quality presets match the UI summary: Presentation uses 1080p30, Video/Gaming use 1080p60, and Auto selects the profile by shared surface without excessive bandwidth.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.
 - [ ] Timed-out members cannot send/edit server-channel messages or add new reactions until cleared or expired.
 - [ ] Mobile server chat shows one visible message after send, including after the API response and WebSocket echo both arrive.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -179,28 +179,30 @@ Speaker
 
 | Preset        | Resolution | FPS | Bitrate (Mbps) | Use Case         |
 |---------------|------------|-----|----------------|------------------|
-| 720p 30fps    | 1280x720   | 30  | 2.5            | Default          |
-| 720p 60fps    | 1280x720   | 60  | 4.0            | Gaming           |
-| 1080p 30fps   | 1920x1080  | 30  | 5.0            | Presentations    |
-| 1080p 60fps   | 1920x1080  | 60  | 8.0            | High-motion video|
+| Auto          | 1080p      | 30/60 | 5-9          | Picks by shared surface |
+| Presentation  | 1080p      | 30  | 5.0            | Slides, docs, IDEs |
+| Video         | 1080p      | 60  | 7.0            | Browser tabs and video |
+| Gaming        | 1080p      | 60  | 9.0            | Full-screen motion |
 
 ### Implementation
 
 ```typescript
 const stream = await navigator.mediaDevices.getDisplayMedia({
-  video: { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 60 } },
+  video: { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 60, max: 60 } },
   audio: true  // Screen share audio (e.g., YouTube video)
 })
 await room.localParticipant.publishTrack(videoTrack, {
   source: Track.Source.ScreenShare,
-  videoEncoding: { maxBitrate: 8_000_000, maxFramerate: 60 },
+  screenShareEncoding: { maxBitrate: 7_000_000, maxFramerate: 60 },
   simulcast: false  // Full quality, no layering
 })
 ```
 
 ### Content Hints
 
-- **Screen share video**: `contentHint = 'detail'` (preserves text sharpness)
+- **Auto screen share**: Starts with a 1080p60 capture envelope, then reapplies the selected surface profile after `displaySurface` is known.
+- **Presentation/window share**: `contentHint = 'detail'` at 1080p30 to preserve text sharpness while limiting traffic.
+- **Browser tab/video and monitor/gaming share**: `contentHint = 'motion'` at 1080p60 for smoother motion.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
 
 ### Remote Viewing Controls


### PR DESCRIPTION
## Summary

Improve screen share quality profiles so Auto mode better matches the selected share source while keeping production bandwidth reasonable.

## Changes

- Align screen-share capture constraints with the actual shared surface after `displaySurface` is known.
- Keep Presentation optimized for sharp 1080p30 text sharing.
- Use smoother 1080p60 profiles for Video and Gaming with more conservative production bitrates.
- Update the screen-share quality UI summary.
- Refresh voice docs and release smoke checklist for the current screen-share profiles.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`