### PR TITLE
fix(voice): enhance screen share quality handling and add release smo…

### DIFF
--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeScreenShareQuality,
+  resolveScreenShareProfileForMode,
+  SCREEN_SHARE_PRESET_PROFILE,
+  toScreenShareConstraintsForProfile,
+} from './useLocalMedia'
+
+describe('screen share quality profiles', () => {
+  it('normalizes unknown and legacy values to auto', () => {
+    expect(normalizeScreenShareQuality('presentation')).toBe('presentation')
+    expect(normalizeScreenShareQuality('video')).toBe('video')
+    expect(normalizeScreenShareQuality('gaming')).toBe('gaming')
+    expect(normalizeScreenShareQuality('manual')).toBe('auto')
+    expect(normalizeScreenShareQuality('unknown')).toBe('auto')
+    expect(normalizeScreenShareQuality(null)).toBe('auto')
+  })
+
+  it('maps explicit presets to their release smoke expectations', () => {
+    expect(resolveScreenShareProfileForMode('presentation')).toEqual({
+      resolution: '1080p',
+      framerate: 30,
+      bitrate: 5_000_000,
+      contentHint: 'detail',
+    })
+    expect(resolveScreenShareProfileForMode('video')).toEqual({
+      resolution: '1080p',
+      framerate: 60,
+      bitrate: 7_000_000,
+      contentHint: 'motion',
+    })
+    expect(resolveScreenShareProfileForMode('gaming')).toEqual({
+      resolution: '1080p',
+      framerate: 60,
+      bitrate: 9_000_000,
+      contentHint: 'motion',
+    })
+  })
+
+  it('selects auto profile by shared surface', () => {
+    expect(resolveScreenShareProfileForMode('auto', 'monitor')).toEqual(SCREEN_SHARE_PRESET_PROFILE.gaming)
+    expect(resolveScreenShareProfileForMode('auto', 'browser')).toEqual(SCREEN_SHARE_PRESET_PROFILE.video)
+    expect(resolveScreenShareProfileForMode('auto', 'window')).toEqual(SCREEN_SHARE_PRESET_PROFILE.presentation)
+    expect(resolveScreenShareProfileForMode('auto')).toEqual(SCREEN_SHARE_PRESET_PROFILE.presentation)
+  })
+
+  it('keeps 1080p frame constraints aligned with the selected profile', () => {
+    expect(toScreenShareConstraintsForProfile(SCREEN_SHARE_PRESET_PROFILE.presentation)).toEqual({
+      width: { ideal: 1920, max: 1920 },
+      height: { ideal: 1080, max: 1080 },
+      frameRate: { ideal: 30, max: 30 },
+    })
+    expect(toScreenShareConstraintsForProfile(SCREEN_SHARE_PRESET_PROFILE.gaming)).toEqual({
+      width: { ideal: 1920, max: 1920 },
+      height: { ideal: 1080, max: 1080 },
+      frameRate: { ideal: 60, max: 60 },
+    })
+  })
+})

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -5,26 +5,55 @@ import {
     getStoredVoiceInputDeviceId,
 } from '../../voiceDevices'
 
-const SCREEN_SHARE_QUALITY_KEY = 'voxpery-settings-screen-share-quality'
+export const SCREEN_SHARE_QUALITY_KEY = 'voxpery-settings-screen-share-quality'
 const INPUT_VOL_KEY = 'voxpery-settings-input-volume'
 const NOISE_SUPPRESSION_KEY = 'voxpery-settings-noise-suppression'
 const DEFAULT_INPUT_VOLUME = 80
 
-type ScreenShareResolution = '720p' | '1080p'
-type ScreenShareFramerate = 30 | 60
-type ScreenShareQuality = 'auto' | 'presentation' | 'video' | 'gaming'
+export type ScreenShareResolution = '720p' | '1080p'
+export type ScreenShareFramerate = 30 | 60
+export type ScreenShareQuality = 'auto' | 'presentation' | 'video' | 'gaming'
 
-type ScreenShareProfile = {
+export type ScreenShareProfile = {
     resolution: ScreenShareResolution
     framerate: ScreenShareFramerate
     bitrate: number
     contentHint: 'detail' | 'motion'
 }
 
-const PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'auto'>, ScreenShareProfile> = {
+export const SCREEN_SHARE_PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'auto'>, ScreenShareProfile> = {
     presentation: { resolution: '1080p', framerate: 30, bitrate: 5_000_000, contentHint: 'detail' },
     video: { resolution: '1080p', framerate: 60, bitrate: 7_000_000, contentHint: 'motion' },
     gaming: { resolution: '1080p', framerate: 60, bitrate: 9_000_000, contentHint: 'motion' },
+}
+
+export function normalizeScreenShareQuality(value: string | null | undefined): ScreenShareQuality {
+    if (value === 'presentation' || value === 'video' || value === 'gaming') return value
+    return 'auto'
+}
+
+export function resolveScreenShareProfileForMode(
+    mode: ScreenShareQuality,
+    displaySurface?: string,
+): ScreenShareProfile {
+    if (mode === 'presentation' || mode === 'video' || mode === 'gaming') {
+        return SCREEN_SHARE_PRESET_PROFILE[mode]
+    }
+
+    if (displaySurface === 'monitor') return SCREEN_SHARE_PRESET_PROFILE.gaming
+    if (displaySurface === 'browser') return SCREEN_SHARE_PRESET_PROFILE.video
+    return SCREEN_SHARE_PRESET_PROFILE.presentation
+}
+
+export function toScreenShareConstraintsForProfile(profile: ScreenShareProfile): MediaTrackConstraints {
+    const base = { frameRate: { ideal: profile.framerate, max: profile.framerate } as MediaTrackConstraintSet['frameRate'] }
+    switch (profile.resolution) {
+        case '1080p':
+            return { ...base, width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 } }
+        case '720p':
+        default:
+            return { ...base, width: { ideal: 1280, max: 1280 }, height: { ideal: 720, max: 720 } }
+    }
 }
 
 export function useLocalMedia() {
@@ -38,35 +67,20 @@ export function useLocalMedia() {
             try { localStorage.setItem(SCREEN_SHARE_QUALITY_KEY, 'auto') } catch { /* ignore */ }
             return 'auto'
         }
-        if (raw === 'presentation' || raw === 'video' || raw === 'gaming') return raw
-        return 'auto'
+        return normalizeScreenShareQuality(raw)
     }, [])
 
     const resolveScreenShareProfile = useCallback((displaySurface?: string): ScreenShareProfile => {
-        const mode = resolveQualityMode()
-        if (mode === 'presentation' || mode === 'video' || mode === 'gaming') {
-            return PRESET_PROFILE[mode]
-        }
-
-        if (displaySurface === 'monitor') return PRESET_PROFILE.gaming
-        if (displaySurface === 'browser') return PRESET_PROFILE.video
-        return PRESET_PROFILE.presentation
+        return resolveScreenShareProfileForMode(resolveQualityMode(), displaySurface)
     }, [resolveQualityMode])
 
     const toScreenShareConstraints = useCallback((profile: ScreenShareProfile): MediaTrackConstraints => {
-        const base = { frameRate: { ideal: profile.framerate, max: profile.framerate } as MediaTrackConstraintSet['frameRate'] }
-        switch (profile.resolution) {
-            case '1080p':
-                return { ...base, width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 } }
-            case '720p':
-            default:
-                return { ...base, width: { ideal: 1280, max: 1280 }, height: { ideal: 720, max: 720 } }
-        }
+        return toScreenShareConstraintsForProfile(profile)
     }, [])
 
     const getScreenShareConstraints = useCallback((): DisplayMediaStreamOptions['video'] => {
         const mode = resolveQualityMode()
-        const profile = mode === 'auto' ? PRESET_PROFILE.video : resolveScreenShareProfile()
+        const profile = mode === 'auto' ? SCREEN_SHARE_PRESET_PROFILE.video : resolveScreenShareProfile()
         return toScreenShareConstraints(profile)
     }, [resolveQualityMode, resolveScreenShareProfile, toScreenShareConstraints])
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 Use this checklist for every production release candidate before tag/publish.
 
-For releases that touch voice, WebRTC, LiveKit, service workers, build output, or audio settings, also complete `docs/VOICE_SUPPRESSION_SMOKE_TEST.md`.
+For releases that touch voice, WebRTC, LiveKit, service workers, build output, or audio settings, also complete `docs/VOICE_RELEASE_SMOKE_TEST.md`. If the release touches noise suppression, CSP, service workers, build output, or production deployment config, also complete `docs/VOICE_SUPPRESSION_SMOKE_TEST.md`.
 
 ## Release Candidate Info
 
@@ -35,6 +35,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Google OAuth login works.
 - [ ] Server/channel/category permission scenarios work.
 - [ ] Voice join/leave works.
+- [ ] `docs/VOICE_RELEASE_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior when the release touches voice, LiveKit/WebRTC, camera, screen share, audio settings, service worker caching, desktop runtime, or build output.
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share also mutes only the screen-share audio while normal microphone audio continues.
@@ -85,7 +86,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Production web CSP includes `script-src 'wasm-unsafe-eval'` so RNNoise WebAssembly can compile under strict headers.
 - [ ] Production web CSP `connect-src` does not include `localhost` or `127.0.0.1` loopback targets.
 - [ ] During the real production voice call, after enabling `localStorage.setItem("voxperyVoiceDiagnostics", "1")` and reloading, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
-- [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior.
+- [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` when suppression, CSP, service workers, build output, or production deployment config changed.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 
 ## 5) Final Sign-off

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -1,0 +1,76 @@
+# Voice Release Smoke Test
+
+Use this checklist for every release candidate that touches voice, LiveKit/WebRTC, audio settings, camera, screen sharing, service worker caching, CSP, desktop runtime, or release build output.
+
+The goal is to verify the real user path, not every implementation detail. Run this after automated checks are green.
+
+## Setup
+
+- Use two accounts in the same server.
+- Test web first. Test desktop too when desktop artifacts or desktop config changed.
+- Use a real microphone and speaker/headset.
+- Keep one user as the sender and one as the receiver for media and noise checks.
+
+## 1. Join, Controls, and Cues
+
+- [ ] User A joins a voice channel and User B sees A in the channel list.
+- [ ] User B joins the same voice channel and both users hear the join cue.
+- [ ] Mute/unmute changes local mic state and does not disconnect the room.
+- [ ] Deafen stops remote audio playback and restores it when disabled.
+- [ ] User B leaves and User A hears a leave cue that is clearly different from the join cue.
+- [ ] Rejoining the same channel does not leave duplicate participants or stale voice controls.
+
+## 2. Reconnect and Revocation
+
+- [ ] Refresh the web app while joined to voice; the app either restores/resyncs cleanly or leaves with an understandable state.
+- [ ] Briefly interrupt WebSocket connectivity if possible; voice state resyncs after reconnect.
+- [ ] Kick, ban, moderator disconnect, or removing `Connect to Voice` removes the affected user from the active room promptly.
+- [ ] The removed user cannot keep listening through an existing LiveKit session.
+
+## 3. Camera
+
+- [ ] User A starts camera; User B sees the camera tile.
+- [ ] User B hears the camera-start cue only when A starts camera while B is already in the channel.
+- [ ] User B hides the remote camera tile and can show it again.
+- [ ] User A stops camera; User B does not hear a stop cue.
+- [ ] Starting camera again after stopping plays the camera-start cue once.
+- [ ] Switching from voice to a text channel and back keeps camera UI stable.
+
+## 4. Screen Share
+
+- [ ] `Presentation` profile publishes at the UI-described 1080p30 behavior.
+- [ ] `Video` profile publishes at the UI-described 1080p60 behavior.
+- [ ] `Gaming` profile publishes at the UI-described 1080p60 behavior with the higher bitrate profile.
+- [ ] `Auto` chooses by shared surface: monitor -> gaming, browser/tab -> video, window/unknown -> presentation.
+- [ ] User A starts screen share; User B sees the screen tile.
+- [ ] User B hears the screen-start cue only once for the screen video track.
+- [ ] Sharing screen audio does not play a duplicate start cue.
+- [ ] User B hides the screen share; the screen tile collapses and only screen-share audio is muted.
+- [ ] User A's normal microphone audio continues while the screen share is hidden.
+- [ ] User B shows the screen share again and audio behavior returns with the visible media.
+- [ ] User A stops screen share; User B does not hear a stop cue.
+
+## 5. Noise Suppression
+
+Complete `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` when this release touches audio processing, CSP, service workers, build output, or production deployment config.
+
+Minimum quick check for other voice releases:
+
+- [ ] Noise suppression is `On`.
+- [ ] Normal speech remains intelligible.
+- [ ] Keyboard, mouse, fan, breath, and clap transients do not consistently transmit as speech.
+- [ ] Production diagnostics, when enabled, report `rnnoiseStatus: "ready"` for releases that touch suppression or production CSP.
+
+## 6. Mobile Layout
+
+- [ ] Voice bar fits narrow mobile width without horizontal overflow.
+- [ ] Camera and screen tiles do not overlap the composer, bottom voice bar, or member sheet.
+- [ ] Remote media hide/show controls are reachable on mobile.
+- [ ] Member sheet can be opened and closed while in voice.
+
+## 7. Sign-off
+
+- [ ] Web voice path passed.
+- [ ] Desktop voice path passed when applicable.
+- [ ] Mobile voice layout passed when applicable.
+- [ ] Any skipped item has a reason recorded in the release notes or PR.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -288,3 +288,9 @@ When debugging a production voice report, capture:
 - **Bandwidth**: ~50 kbps per audio stream (Opus codec)
 - **CPU**: Minimal (SFU does forwarding, not transcoding)
 - **Scalability**: Tested up to 20 concurrent users per room on 2-core VPS
+
+## Release Validation
+
+Run `docs/VOICE_RELEASE_SMOKE_TEST.md` for every release candidate that changes voice, LiveKit/WebRTC, camera, screen sharing, audio settings, service worker caching, desktop runtime, or build output.
+
+Run `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` in addition when a release changes suppression, CSP, service workers, build output, or production deployment config. The suppression smoke test is intentionally stricter because RNNoise readiness and production CSP parity are release-critical for voice quality.


### PR DESCRIPTION
## Summary

Strengthen voice release reliability by adding a focused voice smoke test flow and unit coverage for screen share quality profiles.

## Changes

- Added `docs/VOICE_RELEASE_SMOKE_TEST.md` with practical release checks for join/leave, reconnect, revocation, camera, screen share, media cues, noise suppression, and mobile layout.
- Linked the new voice smoke checklist from the main release smoke checklist.
- Documented voice release validation expectations in `docs/VOICE_SYSTEM.md`.
- Extracted screen share quality profile helpers for testability.
- Added unit coverage for screen share preset and auto-profile behavior.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`