### PR TITLE
docs: enhance trust and privacy information in README and SECURITY do…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@
 
 Voxpery is for communities that want real-time chat and voice without giving up code transparency or data ownership. Use the hosted app on **voxpery.com**, or deploy the same stack yourself.
 
+## Can I Trust Voxpery?
+
+Voxpery is open source, so the hosted app and self-hosted version are built from public, reviewable code. You can inspect how authentication, attachments, voice, moderation, and data export/delete work instead of relying on a closed client.
+
+- **Google sign-in does not give Voxpery your Google password.** Google OAuth only confirms your identity and returns the account information needed to sign you in.
+- **No ads or analytics by default.** Voxpery is not built around tracking users or selling attention.
+- **Self-hostable by design.** Communities that want full control can run the same stack on their own server.
+- **Data controls are built in.** Users can export their account data and permanently delete their account.
+- **Attachments are scoped.** Uploaded files use signed access and server/DM viewer authorization instead of public permanent links.
+
 ## Honest Comparison
 
 | Feature | Voxpery | Discord | Slack | Mattermost |

--- a/apps/web/src/pages/AboutPage.tsx
+++ b/apps/web/src/pages/AboutPage.tsx
@@ -79,7 +79,7 @@ export default function AboutPage() {
   const primaryDownloadUrl = detectedDownload ?? releaseUrl
   const primaryDownloadLabel = platform === 'unknown' ? 'Download desktop app' : `Download for ${PLATFORM_LABELS[platform]}`
   const appEntryRoute = isAuthenticated ? ROUTES.home : ROUTES.login
-  const appEntryLabel = isAuthenticated ? 'Open Voxpery app' : 'Open Voxpery in browser'
+  const appEntryLabel = 'Open in browser'
   const releaseMeta = [releaseTag, releaseDate].filter(Boolean).join(' • ')
 
   return (
@@ -107,7 +107,7 @@ export default function AboutPage() {
 
         <div className="about-topbar-actions">
           <Link to={appEntryRoute} className="about-btn about-btn--login">
-            {isAuthenticated ? 'Open app' : 'Login'}
+            {isAuthenticated ? 'Go to app' : 'Login'}
           </Link>
         </div>
       </header>
@@ -144,6 +144,10 @@ export default function AboutPage() {
               <img src={productPreviewUrl} alt="Voxpery voice channel interface" />
             </figure>
           </div>
+
+          <p className="about-trust-note">
+            Open source, self-hostable, and no ads or analytics.
+          </p>
 
         </section>
       </main>

--- a/apps/web/src/styles/about.css
+++ b/apps/web/src/styles/about.css
@@ -81,7 +81,7 @@
 .about-main {
   width: min(1180px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 42px 0 0;
+  padding: 38px 0 0;
   display: grid;
 }
 
@@ -173,10 +173,33 @@
 }
 
 .about-center-actions-row .about-cta {
-  width: min(100%, 260px);
+  box-sizing: border-box;
+  flex: 0 0 252px;
+  width: 252px;
 }
 .about-release-meta--center {
   justify-content: center;
+}
+
+.about-trust-note {
+  box-sizing: border-box;
+  width: fit-content;
+  max-width: min(800px, 100%);
+  margin: 18px auto 0;
+  padding: 10px 14px;
+  border: 1px solid rgba(181, 198, 230, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(225, 236, 255, 0.9);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.about-trust-note::before {
+  content: "Trust: ";
+  color: #fff;
+  font-weight: 800;
 }
 
 .about-product-previews {
@@ -186,10 +209,10 @@
 
 .about-product-preview {
   margin: 0;
-  border: 1px solid rgba(181, 198, 230, 0.2);
+  border: 1px solid rgba(181, 198, 230, 0.28);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
-  box-shadow: 0 28px 72px rgba(0, 0, 0, 0.34);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: 0 30px 76px rgba(0, 0, 0, 0.38), 0 0 0 1px rgba(89, 217, 177, 0.04);
   overflow: hidden;
   display: flex;
 }
@@ -263,6 +286,10 @@
     width: min(680px, 100%);
     margin-top: 24px;
   }
+
+  .about-trust-note {
+    margin-top: 14px;
+  }
 }
 
 @media (min-width: 701px) and (max-height: 740px) {
@@ -286,6 +313,10 @@
   .about-product-previews {
     width: min(560px, 100%);
     margin-top: 18px;
+  }
+
+  .about-trust-note {
+    display: none;
   }
 }
 
@@ -350,6 +381,7 @@
   }
 
   .about-center-actions-row .about-cta {
+    flex-basis: 100%;
     width: 100%;
   }
 
@@ -361,6 +393,14 @@
     margin-top: 18px;
     width: 100%;
     max-width: none;
+  }
+
+  .about-trust-note {
+    margin-top: 12px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    font-size: 12px;
+    line-height: 1.35;
   }
 }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,6 +2,16 @@
 
 Authentication, authorization, CORS policies, and security best practices.
 
+## User Trust Notes
+
+These notes are written for users who want a short answer before reading the full technical details:
+
+- Voxpery is open source and self-hostable; the hosted service and self-hosted deployments use the same public codebase.
+- Google OAuth is used only for sign-in. Voxpery never receives or stores a Google password.
+- Hosted Voxpery has no ads or analytics by default.
+- Users can export account data and permanently delete their account from settings.
+- Attachments are not exposed as public permanent files; access is scoped by signed URLs and viewer authorization.
+
 ## Authentication
 
 ### JWT (JSON Web Token)


### PR DESCRIPTION
## Summary

Improve Voxpery trust/privacy messaging and polish the public landing page.

## Changes

- Added concise trust/privacy notes to the landing page, README, and Security docs.
- Clarified the primary browser CTA as `Open in browser`.
- Balanced the landing page CTA button widths.
- Refined desktop/mobile landing spacing, preview styling, and trust pill responsiveness.
- Kept the landing page compact and product-focused.

## Validation

- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .