### PR TITLE
docs: update release documentation for clarity and completeness

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5322,7 +5322,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.1.10"
+version = "0.1.12"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-05-19
+
+### Changed
+- Improved screen share quality defaults and release smoke coverage for production voice calls.
+- Refined release quality, desktop updater artifact verification, and smoke-test sign-off documentation.
+- Simplified chat attachment image previews so web and desktop use the same in-app modal behavior.
+- Updated desktop icon assets for better taskbar and installer scaling.
+
+### Fixed
+- Fixed desktop Google OAuth login return handling.
+- Fixed chat scroll position when loading older messages.
+- Fixed chat media rendering stability and message row alignment.
+- Fixed a test security fixture to avoid static credential-like sample data.
+
+### Chores
+- Updated non-breaking Rust and web dependencies.
+
+## [0.1.11] - 2026-05-18
+
+### Added
+- Distinct in-call audio cues when remote users start camera or screen share.
+- Unread message count synchronization for direct messages.
+
+### Changed
+- Improved deployment workflow behavior so manual deploys target updated `main`.
+
+### Fixed
+- Fixed remote media start cue behavior for camera and screen share starts.
+- Fixed LiveKit voice access revocation for channel and role permission changes.
+
+### Security
+- Hardened image proxy SSRF protections.
+- Hardened AutoMod normalization and report abuse/rate-limit handling.
+- Hardened desktop capabilities, JWT/token checks, OAuth warning logs, and web container least-privilege behavior.
+
 ## [0.1.10] - 2026-05-16
 
 ### Added

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -49,7 +49,20 @@ Mandatory conditions when updater artifacts are enabled:
 
 This policy is enforced in release preflight validation.
 
-## 4) Manual QA Gate (required)
+## 4) Updater Artifact Verification (required)
+
+Before publishing or announcing a desktop release:
+
+- `latest.json` must be uploaded to the same GitHub Release as the installer artifacts.
+- The `latest.json` version must match the Git tag and desktop app version.
+- Every updater asset referenced by `latest.json` must have a matching `.sig` file.
+- Artifact URLs in `latest.json` must point to release assets for the same version, not draft-only, private, temporary, or older release URLs.
+- The updater public key injected into `apps/desktop/src-tauri/tauri.conf.json` must match the private key used to sign the release artifacts.
+- Manual `Release desktop` workflow runs must target the exact release tag/ref and use `smoke_checklist_confirmed=yes`.
+- Production desktop releases should build all supported platforms. Single-platform manual runs are acceptable for test or explicit hotfix scopes only and must be noted in the release checklist.
+- If a GitHub Release exists but the desktop workflow did not run or did not attach updater metadata, keep the release as draft until the workflow is rerun against the correct tag/ref.
+
+## 5) Manual QA Gate (required)
 
 Before publishing a desktop release:
 
@@ -65,7 +78,7 @@ Before publishing a desktop release:
 7. Confirm Windows startup launch stays in the tray until the user opens Voxpery from the tray, and tray Show opens a maximized window.
 8. Confirm installer/update preparation closes tray/minimize state cleanly before install.
 
-## 5) Rollback Expectations
+## 6) Rollback Expectations
 
 Voxpery desktop rollback is manual and release-artifact based:
 
@@ -74,7 +87,7 @@ Voxpery desktop rollback is manual and release-artifact based:
 - Publish or re-promote the previous stable release metadata if updater clients must move back to a known-good version.
 - Document the rollback decision and affected version in release notes or the incident record.
 
-## 6) Recommended Repository Secrets
+## 7) Recommended Repository Secrets
 
 - `VITE_API_URL` (required for desktop release build)
 - `VITE_TURNSTILE_SITE_KEY` (required as a repository variable or secret for desktop release builds)

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -66,15 +66,25 @@ Voxpery follows Semantic Versioning:
 
 ### Release Checklist
 
-1. Ensure required PR gates are green on the release branch/tag.
-2. Run the manual `Release Smoke` workflow against the release candidate API.
-3. Complete and sign off [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md) (required).
-4. Validate [DESKTOP_RELEASE_HARDENING.md](DESKTOP_RELEASE_HARDENING.md) if desktop artifacts are part of release.
-5. Validate critical paths: auth, messaging+websocket, voice join/leave.
-6. Update docs for behavior changes.
-7. Update changelog entry.
-8. Create Git tag (for example `v0.1.5`).
-9. Publish GitHub Release notes.
+1. Prepare the candidate from updated `main` and keep the final release commit SHA recorded.
+2. Update docs for behavior changes and update the changelog entry before creating the tag.
+3. Ensure required PR gates are green on the release branch and no security monitoring gate is ignored without a recorded decision.
+4. Run the manual `Release Smoke` workflow against the release candidate API and record the workflow run URL in [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md).
+5. Complete and sign off [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md) (required).
+6. Validate [DESKTOP_RELEASE_HARDENING.md](DESKTOP_RELEASE_HARDENING.md) if desktop artifacts are part of the release.
+7. Validate critical paths: auth, messaging+websocket, voice join/leave.
+8. Create and push the Git tag (for example `v0.1.5`) from the exact signed-off commit.
+9. Confirm tag-triggered release jobs, Docker publish jobs, and desktop artifact jobs ran against that exact tag/ref.
+10. Verify release assets and updater metadata before publishing or announcing the release.
+11. Publish GitHub Release notes only after artifacts, signatures, and smoke sign-off are complete.
+
+### Release Workflow Rules
+
+- Prefer tag-driven releases: push the `v*` tag from the signed-off commit and let tag-triggered CI/release jobs build the immutable candidate.
+- If a GitHub Release is created manually and workflows do not run, do not announce it as ready. Run the appropriate manual workflow against the exact tag/ref or recreate the tag/release intentionally.
+- Manual desktop release workflow runs must use the exact release tag/ref, set `smoke_checklist_confirmed=yes`, and use `platform=all` for production releases unless the release is explicitly a single-platform hotfix/test.
+- Keep the release draft until `latest.json`, installer assets, signature files, and release notes all point to the same version and tag.
+- Record the workflow run URLs and GO/NO-GO decision in the release checklist so rollback and audit history are clear.
 
 ### Changelog Sections
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -8,9 +8,13 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 
 - Version:
 - Commit SHA:
+- Git ref / tag:
+- Release type: `web-only` / `desktop` / `voice` / `security` / `hotfix`
 - Tester:
 - Date (UTC):
 - Environment:
+- Release Smoke workflow run URL:
+- Desktop artifact workflow run URL, if applicable:
 
 ## 1) Required PR Gates (must be green)
 
@@ -25,7 +29,9 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Web container health responds through the host mapping (`curl -f http://localhost:${WEB_PORT:-5173}/healthz`) while the container uses unprivileged nginx on internal port `8080`.
 - [ ] Remote avatar/server icon/inline media proxy rejects localhost/private targets and still loads normal public HTTPS images.
 - [ ] Manual `Release Smoke` workflow completed successfully against the release candidate API.
+- [ ] Manual `Release Smoke` workflow run URL is recorded in Release Candidate Info.
 - [ ] `Release Smoke` ran with strict security headers enabled for production candidates.
+- [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 
 ## 3) Web Smoke Tests (mandatory)
 
@@ -67,6 +73,11 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Google OAuth opens browser and returns to desktop app via `voxpery://` deep link.
 - [ ] Session is restored after OAuth callback (user ends in authenticated app state).
 - [ ] If updater artifacts are enabled, signing keys and updater pubkey are configured (see `docs/DESKTOP_RELEASE_HARDENING.md`).
+- [ ] Desktop release workflow ran against the exact release tag/ref, with `smoke_checklist_confirmed=yes`.
+- [ ] Production desktop releases used `platform=all`; single-platform workflow runs are recorded as test/hotfix-only.
+- [ ] GitHub Release assets include `latest.json`, installer artifacts for the intended platforms, and matching `.sig` files for updater assets.
+- [ ] `latest.json` version matches the release tag and desktop app version.
+- [ ] `latest.json` URLs point to assets on the same GitHub Release, not a draft-only, private, or unrelated artifact URL.
 - [ ] Updater check shows a clear no-update state when no newer version is available.
 - [ ] Updater check shows the available version when a newer signed release is available.
 - [ ] Update availability appears as one calm toast plus a compact install pill; settings still provides manual check/install.
@@ -94,7 +105,9 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Changelog updated (`docs/CHANGELOG.md`).
 - [ ] Deployment notes updated if needed (`docs/DEPLOYMENT.md`).
 - [ ] Release notes draft prepared.
+- [ ] Release notes mention validation scope and any intentionally skipped checks.
 - [ ] Previous stable desktop installer artifacts remain available for manual rollback.
+- [ ] If the decision is `NO-GO`, rollback or draft-release handling is documented before announcement.
 - [ ] Approved to tag and publish.
 
 ## Sign-off


### PR DESCRIPTION
## Summary

Prepare the release quality flow and v0.1.12 release metadata.

## Changes

- Bumped desktop version metadata to `0.1.12`.
- Added changelog entries for `v0.1.11` and `v0.1.12`.
- Clarified release workflow expectations around exact tags/refs, smoke-test sign-off, and workflow run URLs.
- Added desktop updater verification checks for `latest.json`, installer assets, signatures, and release asset URLs.

## Validation

- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --locked`
- `tauri.conf.json` JSON parse check
- `git diff --check`