### PR TITLE
fix(readme): adjust preview image heights for better alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 <table>
   <tr>
     <td width="78%" align="center" valign="bottom">
-      <img src="apps/web/src/assets/voxpery-desktop.png" alt="Voxpery desktop voice channel interface" height="360" />
+      <img src="apps/web/src/assets/voxpery-desktop.png" alt="Voxpery desktop voice channel interface" height="320" />
     </td>
     <td width="22%" align="center" valign="bottom">
-      <img src="apps/web/src/assets/voxpery-mobile.png" alt="Voxpery mobile voice channel interface" height="360" />
+      <img src="apps/web/src/assets/voxpery-mobile.png" alt="Voxpery mobile voice channel interface" height="320" />
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary

Align README desktop and mobile preview image heights.

## Changes

- Updated README preview image heights so desktop and mobile screenshots render with matching vertical size.
- Kept the existing side-by-side layout and image assets unchanged.

## Validation

- `git diff --check`
