### PR TITLE
fix(readme): adjust mobile interface image height for better alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
       <img src="apps/web/src/assets/voxpery-desktop.png" alt="Voxpery desktop voice channel interface" height="320" />
     </td>
     <td width="22%" align="center" valign="bottom">
-      <img src="apps/web/src/assets/voxpery-mobile.png" alt="Voxpery mobile voice channel interface" height="320" />
+      <img src="apps/web/src/assets/voxpery-mobile.png" alt="Voxpery mobile voice channel interface" height="312" />
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary

Polish README preview image sizing.

## Changes

- Adjusted the mobile README preview height so it visually balances better next to the desktop screenshot.
- Kept the existing assets and side-by-side layout unchanged.

## Validation

- `git diff --check`