### PR TITLE
feat(audio): separate microphone and screen-share audio handling for …

### DIFF
--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -21,7 +21,7 @@ import {
 import { ROUTES } from '../routes'
 import { attachMediaStreamPreview } from '../mediaStreamPreview'
 import { resolveAvatarUrl } from '../api'
-import { createRemoteAudioPlaybackStream, remoteMediaVisibilityKey, type RemoteMediaKind } from '../webrtc/remoteMediaControls'
+import { createRemoteAudioKindPlaybackStream, remoteMediaVisibilityKey, type RemoteMediaKind } from '../webrtc/remoteMediaControls'
 
 interface VoxperyTrack extends MediaStreamTrack {
   __voxpery_isCamera?: boolean
@@ -36,6 +36,8 @@ interface VoxperyAudioElement extends HTMLAudioElement {
 interface VoxperyHTMLDivElement extends HTMLDivElement {
   _idleTimeout?: ReturnType<typeof setTimeout>
 }
+
+type RemoteAudioKind = 'mic' | 'screen'
 
 interface ActiveCallBarProps {
   selectedVoiceChannelId: string | null
@@ -204,7 +206,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
   const remoteVideoStreamByTrackIdRef = useRef<Map<string, MediaStream>>(new Map())
-  // Per-peer WebAudio nodes for amplification above 100% (GainNode allows gain > 1.0)
+  // Per-playback WebAudio nodes for amplification above 100% (GainNode allows gain > 1.0).
+  // Microphone and screen-share audio are separate playback paths so their volumes cannot affect each other.
   const perPeerAudioCtxRef = useRef<Map<string, { ctx: AudioContext; source: MediaElementAudioSourceNode; gain: GainNode }>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
@@ -260,12 +263,20 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     return member?.user_id ?? peerId
   }, [members, peerVolumeByUserId])
 
-  const peerIdsWithScreenShareRef = useRef<Set<string>>(new Set())
   const hiddenScreenSharePeerIdsRef = useRef<Set<string>>(new Set())
-  const getPeerVolumeFactor = useCallback((peerId: string) => {
+  const remoteAudioPlaybackKey = useCallback((peerId: string, kind: RemoteAudioKind) => `${kind}:${peerId}`, [])
+  const parseRemoteAudioPlaybackKey = useCallback((playbackKey: string): { peerId: string; kind: RemoteAudioKind } => {
+    if (playbackKey.startsWith('screen:')) {
+      return { kind: 'screen', peerId: playbackKey.slice('screen:'.length) }
+    }
+    if (playbackKey.startsWith('mic:')) {
+      return { kind: 'mic', peerId: playbackKey.slice('mic:'.length) }
+    }
+    return { kind: 'mic', peerId: playbackKey }
+  }, [])
+  const getPlaybackVolumeFactor = useCallback((peerId: string, kind: RemoteAudioKind) => {
     const volumeKey = resolvePeerVolumeKey(peerId)
-    const useScreenKey = peerIdsWithScreenShareRef.current.has(peerId) && !hiddenScreenSharePeerIdsRef.current.has(peerId)
-    const storageKey = useScreenKey ? `screen:${volumeKey}` : volumeKey
+    const storageKey = kind === 'screen' ? `screen:${volumeKey}` : volumeKey
     const raw = peerVolumeByUserId[storageKey]
     const bounded = typeof raw === 'number' && Number.isFinite(raw) ? Math.min(200, Math.max(0, raw)) : 100
     return bounded / 100  // returns 0.0–2.0
@@ -327,24 +338,25 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const applyOutputVolumeToElements = useCallback((vol: number) => {
     const global = Math.min(1, Math.max(0, vol))
     const isDeafened = deafenedRef.current
-    for (const [peerId, el] of remoteAudioRefsRef.current.entries()) {
+    for (const [playbackKey, el] of remoteAudioRefsRef.current.entries()) {
       try {
-        const peerFactor = getPeerVolumeFactor(peerId)  // 0.0–2.0
+        const { peerId, kind } = parseRemoteAudioPlaybackKey(playbackKey)
+        const peerFactor = getPlaybackVolumeFactor(peerId, kind)  // 0.0–2.0
         const combined = isDeafened ? 0 : global * peerFactor
         if (peerFactor <= 1.0) {
           // Normal range: use plain audio.volume (0–1)
           el.volume = Math.min(1, Math.max(0, combined))
           // Tear down any existing GainNode for this peer (they lowered it back)
-          const existing = perPeerAudioCtxRef.current.get(peerId)
+          const existing = perPeerAudioCtxRef.current.get(playbackKey)
           if (existing) {
             try { existing.source.disconnect(); existing.gain.disconnect() } catch { /* ignore */ }
             void existing.ctx.close().catch(() => { })
-            perPeerAudioCtxRef.current.delete(peerId)
+            perPeerAudioCtxRef.current.delete(playbackKey)
           }
         } else {
           // Amplified range (>100%): route through a GainNode. When captured, el.muted is ignored
           // by the browser, so we mute by setting gain.gain.value = 0 when deafened.
-          let nodes = perPeerAudioCtxRef.current.get(peerId)
+          let nodes = perPeerAudioCtxRef.current.get(playbackKey)
           if (!nodes) {
             // When deafened (combined === 0), avoid createMediaElementSource so Firefox doesn't warn
             // about captured MediaElement (volume/mute not supported after capture)
@@ -362,7 +374,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                 source.connect(gain)
                 gain.connect(ctx.destination)
                 nodes = { ctx, source, gain }
-                perPeerAudioCtxRef.current.set(peerId, nodes)
+                perPeerAudioCtxRef.current.set(playbackKey, nodes)
               }
             } catch {
               // WebAudio unavailable: clamp to 1.0
@@ -376,14 +388,14 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
           }
         }
         // Only set el.muted when not using GainNode (captured element ignores it; mute is via gain.gain.value)
-        if (!perPeerAudioCtxRef.current.has(peerId)) {
+        if (!perPeerAudioCtxRef.current.has(playbackKey)) {
           el.muted = isDeafened
         }
       } catch {
         // ignore
       }
     }
-  }, [getPeerVolumeFactor])
+  }, [getPlaybackVolumeFactor, parseRemoteAudioPlaybackKey])
 
   useEffect(() => {
     const onSettingsChanged = () => {
@@ -492,12 +504,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
     return entries
   }, [remoteEntries, state.remoteScreenTrackIds])
-  useEffect(() => {
-    peerIdsWithScreenShareRef.current = new Set(
-      remoteVideoTrackEntries.filter((e) => e.kind === 'screen').map((e) => e.peerId)
-    )
-  }, [remoteVideoTrackEntries])
-
   const hiddenScreenSharePeerIds = useMemo(() => {
     const hidden = new Set<string>()
     for (const entry of remoteVideoTrackEntries) {
@@ -514,23 +520,31 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
   useEffect(() => {
     for (const [peerId, stream] of state.remoteStreams.entries()) {
-      const el = remoteAudioRefsRef.current.get(peerId) as VoxperyAudioElement | undefined
-      if (!el) continue
-      // Force srcObject re-assignment when track count changes (e.g. screen share audio added)
-      const playbackStream = createRemoteAudioPlaybackStream(stream, !hiddenScreenSharePeerIds.has(peerId))
-      const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
-      const prevTrackIds = el.__voxpery_trackIds
-      if (currentTrackIds !== prevTrackIds) {
-        el.srcObject = playbackStream
-        el.__voxpery_trackIds = currentTrackIds
-        void applyPreferredAudioOutputDevice(el)
+      const entries: Array<{ kind: RemoteAudioKind; include: boolean }> = [
+        { kind: 'mic', include: true },
+        { kind: 'screen', include: !hiddenScreenSharePeerIds.has(peerId) },
+      ]
+      for (const { kind, include } of entries) {
+        const playbackKey = remoteAudioPlaybackKey(peerId, kind)
+        const el = remoteAudioRefsRef.current.get(playbackKey) as VoxperyAudioElement | undefined
+        if (!el) continue
+        const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
+        const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
+        const prevTrackIds = el.__voxpery_trackIds
+        if (currentTrackIds !== prevTrackIds) {
+          el.srcObject = playbackStream
+          el.__voxpery_trackIds = currentTrackIds
+          void applyPreferredAudioOutputDevice(el)
+        }
+        if (!perPeerAudioCtxRef.current.has(playbackKey)) {
+          el.muted = deafenedRef.current
+        }
+        if (!deafenedRef.current && currentTrackIds) {
+          ensureRemoteAudioPlayback(playbackKey, el)
+        }
       }
-      if (!perPeerAudioCtxRef.current.has(peerId)) {
-        el.muted = deafenedRef.current
-      }
-      if (!deafenedRef.current) ensureRemoteAudioPlayback(peerId, el)
     }
-  }, [hiddenScreenSharePeerIds, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+  }, [hiddenScreenSharePeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -1146,34 +1160,44 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                 {Array.from(state.remoteStreams.keys()).map((peerId) => {
                   const stream = state.remoteStreams.get(peerId)
                   if (!stream) return null
-                  return (
-                    <audio key={peerId} autoPlay playsInline ref={(el) => {
-                      if (el) {
-                        const audioEl = el as VoxperyAudioElement
-                        remoteAudioRefsRef.current.set(peerId, audioEl)
-                        const playbackStream = createRemoteAudioPlaybackStream(stream, !hiddenScreenSharePeerIds.has(peerId))
-                        const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
-                        if (audioEl.__voxpery_trackIds !== currentTrackIds) {
-                          audioEl.srcObject = playbackStream
-                          audioEl.__voxpery_trackIds = currentTrackIds
+                  return (['mic', 'screen'] as RemoteAudioKind[]).map((kind) => {
+                    const playbackKey = remoteAudioPlaybackKey(peerId, kind)
+                    return (
+                      <audio key={playbackKey} autoPlay playsInline ref={(el) => {
+                        if (el) {
+                          const audioEl = el as VoxperyAudioElement
+                          remoteAudioRefsRef.current.set(playbackKey, audioEl)
+                          const include = kind === 'mic' || !hiddenScreenSharePeerIds.has(peerId)
+                          const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
+                          const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
+                          if (audioEl.__voxpery_trackIds !== currentTrackIds) {
+                            audioEl.srcObject = playbackStream
+                            audioEl.__voxpery_trackIds = currentTrackIds
+                          }
+                          void applyPreferredAudioOutputDevice(audioEl)
+                          const shouldMute = deafenedRef.current
+                          const isCaptured = perPeerAudioCtxRef.current.has(playbackKey)
+                          if (!isCaptured) {
+                            const peerFactor = getPlaybackVolumeFactor(peerId, kind)
+                            const vol = Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
+                            try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
+                            audioEl.muted = shouldMute
+                          }
+                          if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
+                        } else {
+                          remoteAudioRefsRef.current.delete(playbackKey)
+                          const t = remoteAudioRetryTimerRef.current.get(playbackKey)
+                          if (t != null) { window.clearTimeout(t); remoteAudioRetryTimerRef.current.delete(playbackKey) }
+                          const existing = perPeerAudioCtxRef.current.get(playbackKey)
+                          if (existing) {
+                            try { existing.source.disconnect(); existing.gain.disconnect() } catch { /* ignore */ }
+                            void existing.ctx.close().catch(() => { })
+                            perPeerAudioCtxRef.current.delete(playbackKey)
+                          }
                         }
-                        void applyPreferredAudioOutputDevice(audioEl)
-                        const shouldMute = deafenedRef.current
-                        const isCaptured = perPeerAudioCtxRef.current.has(peerId)
-                        if (!isCaptured) {
-                          const peerFactor = getPeerVolumeFactor(peerId)
-                          const vol = Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
-                          try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
-                          audioEl.muted = shouldMute
-                        }
-                        if (!shouldMute) ensureRemoteAudioPlayback(peerId, audioEl)
-                      } else {
-                        remoteAudioRefsRef.current.delete(peerId)
-                        const t = remoteAudioRetryTimerRef.current.get(peerId)
-                        if (t != null) { window.clearTimeout(t); remoteAudioRetryTimerRef.current.delete(peerId) }
-                      }
-                    }} />
-                  )
+                      }} />
+                    )
+                  })
                 })}
               </div>
               <div className="callbar-status">

--- a/apps/web/src/webrtc/remoteMediaControls.test.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.test.ts
@@ -1,4 +1,10 @@
-import { getRemoteAudioPlaybackTracks, isScreenShareAudioTrack, remoteMediaVisibilityKey } from './remoteMediaControls'
+import {
+  getRemoteAudioPlaybackTracks,
+  getRemoteMicrophoneAudioTracks,
+  getRemoteScreenShareAudioTracks,
+  isScreenShareAudioTrack,
+  remoteMediaVisibilityKey,
+} from './remoteMediaControls'
 
 function audioTrack(screenShareAudio = false) {
   const track = {} as MediaStreamTrack
@@ -25,5 +31,14 @@ describe('remote media controls', () => {
 
     expect(getRemoteAudioPlaybackTracks(source, true)).toHaveLength(2)
     expect(getRemoteAudioPlaybackTracks(source, false)).toEqual([mic])
+  })
+
+  it('splits microphone and screen share audio for independent playback controls', () => {
+    const mic = audioTrack()
+    const screen = audioTrack(true)
+    const source = { getAudioTracks: () => [mic, screen] } as unknown as MediaStream
+
+    expect(getRemoteMicrophoneAudioTracks(source)).toEqual([mic])
+    expect(getRemoteScreenShareAudioTracks(source)).toEqual([screen])
   })
 })

--- a/apps/web/src/webrtc/remoteMediaControls.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.ts
@@ -22,3 +22,22 @@ export function createRemoteAudioPlaybackStream(stream: MediaStream, includeScre
   const tracks = getRemoteAudioPlaybackTracks(stream, includeScreenShareAudio)
   return new MediaStream(tracks)
 }
+
+export function getRemoteMicrophoneAudioTracks(stream: MediaStream): MediaStreamTrack[] {
+  return stream
+    .getAudioTracks()
+    .filter((track) => !isScreenShareAudioTrack(track))
+}
+
+export function getRemoteScreenShareAudioTracks(stream: MediaStream): MediaStreamTrack[] {
+  return stream
+    .getAudioTracks()
+    .filter((track) => isScreenShareAudioTrack(track))
+}
+
+export function createRemoteAudioKindPlaybackStream(stream: MediaStream, kind: 'mic' | 'screen'): MediaStream {
+  const tracks = kind === 'screen'
+    ? getRemoteScreenShareAudioTracks(stream)
+    : getRemoteMicrophoneAudioTracks(stream)
+  return new MediaStream(tracks)
+}

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -44,7 +44,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] `docs/VOICE_RELEASE_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior when the release touches voice, LiveKit/WebRTC, camera, screen share, audio settings, service worker caching, desktop runtime, or build output.
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
-- [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share also mutes only the screen-share audio while normal microphone audio continues.
+- [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share or changing screen-share volume affects only screen-share audio while normal microphone audio continues.
 - [ ] Screen share quality presets match the UI summary: Presentation uses 1080p30, Video/Gaming use 1080p60, and Auto selects the profile by shared surface without excessive bandwidth.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.
 - [ ] Timed-out members cannot send/edit server-channel messages or add new reactions until cleared or expired.

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -47,6 +47,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] Sharing screen audio does not play a duplicate start cue.
 - [ ] User B hides the screen share; the screen tile collapses and only screen-share audio is muted.
 - [ ] User A's normal microphone audio continues while the screen share is hidden.
+- [ ] User B mutes or lowers the screen-share volume; only screen-share audio changes and User A's normal microphone audio remains audible.
 - [ ] User B shows the screen share again and audio behavior returns with the visible media.
 - [ ] User A stops screen share; User B does not hear a stop cue.
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -168,7 +168,7 @@ AudioContext analyser (speaking indicator)
 Speaker
 ```
 
-- **Output volume**: Global 1-100% + per-peer 0-200%
+- **Output volume**: Global 1-100%, per-peer microphone 0-200%, and per-screen-share audio 0-200%
 - **Amplification >100%**: Routed through WebAudio GainNode (gain > 1.0)
 - **Deafen**: Sets `audio.muted = true` on all remote elements
 - **Stop watching screen**: Hiding a remote screen share removes its screen-share audio track from playback while keeping the peer's normal microphone audio active.
@@ -211,6 +211,7 @@ await room.localParticipant.publishTrack(videoTrack, {
 - Hidden media stays as a compact placeholder with a `Show` action so the user can resume watching.
 - Hidden preferences are local to the current voice session and reset after leaving, refreshing, or switching voice channels.
 - Hiding a screen share also mutes that screen-share audio track; the participant's microphone audio continues normally.
+- The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
 
 ## Camera
 


### PR DESCRIPTION
## Summary

Fix screen-share audio volume so it no longer affects the broadcaster's normal microphone audio.

## Changes

- Split remote microphone audio and screen-share audio into separate playback streams.
- Keep per-peer microphone volume independent from per-screen-share audio volume.
- Preserve stop-watching behavior: hiding a screen share mutes only screen-share audio.
- Added unit coverage for microphone/screen-share audio splitting.
- Updated voice docs and release smoke checks.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`