### PR TITLE
Fix/mobile chat core regression pass

### DIFF
--- a/apps/web/src/components/MessageInlineActions.test.tsx
+++ b/apps/web/src/components/MessageInlineActions.test.tsx
@@ -46,10 +46,10 @@ describe('MessageInlineActions', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Report' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reply' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Report' })).not.toBeNull()
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull()
   })
 
   it('keeps the toolbar visible while its reaction picker is open', () => {
@@ -64,6 +64,6 @@ describe('MessageInlineActions', () => {
       />
     )
 
-    expect(container.querySelector('.message-inline-actions')).toHaveClass('is-visible')
+    expect(container.querySelector('.message-inline-actions')?.classList.contains('is-visible')).toBe(true)
   })
 })

--- a/apps/web/src/components/MessageInlineActions.test.tsx
+++ b/apps/web/src/components/MessageInlineActions.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import MessageInlineActions from './MessageInlineActions'
+
+describe('MessageInlineActions', () => {
+  it('keeps primary actions available for the message author', () => {
+    const onToggleReactionPicker = vi.fn()
+    const onReply = vi.fn()
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+
+    render(
+      <MessageInlineActions
+        messageId="message-1"
+        currentUserId="user-1"
+        authorUserId="user-1"
+        canReact
+        onToggleReactionPicker={onToggleReactionPicker}
+        onReply={onReply}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add reaction' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(onToggleReactionPicker).toHaveBeenCalledWith('message-1', expect.any(HTMLButtonElement))
+    expect(onReply).toHaveBeenCalledOnce()
+    expect(onEdit).toHaveBeenCalledOnce()
+    expect(onDelete).toHaveBeenCalledOnce()
+  })
+
+  it('keeps destructive owner actions hidden for another user message', () => {
+    render(
+      <MessageInlineActions
+        messageId="message-2"
+        currentUserId="user-1"
+        authorUserId="user-2"
+        onReply={vi.fn()}
+        onReport={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Report' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+  })
+
+  it('keeps the toolbar visible while its reaction picker is open', () => {
+    const { container } = render(
+      <MessageInlineActions
+        messageId="message-3"
+        currentUserId="user-1"
+        authorUserId="user-2"
+        canReact
+        onToggleReactionPicker={vi.fn()}
+        reactionPickerOpen
+      />
+    )
+
+    expect(container.querySelector('.message-inline-actions')).toHaveClass('is-visible')
+  })
+})

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4681,7 +4681,8 @@ body {
   position: relative;
 }
 
-.message:hover .message-inline-actions {
+.message:hover .message-inline-actions,
+.message:focus-within .message-inline-actions {
   opacity: 1;
 }
 
@@ -13705,6 +13706,7 @@ textarea {
     -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
     transform: none;
+    opacity: 1;
   }
 
   .message.message-compact .message-inline-actions {


### PR DESCRIPTION
## Summary

Improve mobile chat message action reliability.

## Changes

- Keep inline message actions visible on mobile instead of relying on hover behavior.
- Show message actions when the message row receives keyboard focus.
- Add regression tests for author actions, remote-message action limits, and reaction picker visibility.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`