### PR TITLE
fix(screen-share): enhance controls visibility and interaction for sc…

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8375,7 +8375,9 @@ a.community-open-btn:hover {
 }
 
 .screen-share-preview:hover .screen-share-controls-bar,
-.screen-share-preview:fullscreen:hover .screen-share-controls-bar {
+.screen-share-preview:focus-within .screen-share-controls-bar,
+.screen-share-preview:fullscreen:hover .screen-share-controls-bar,
+.screen-share-preview:fullscreen:focus-within .screen-share-controls-bar {
   opacity: 1;
   pointer-events: auto;
 }
@@ -8531,7 +8533,9 @@ a.community-open-btn:hover {
 }
 
 .screen-share-preview:hover .screen-share-info-overlay,
-.screen-share-preview:fullscreen:hover .screen-share-info-overlay {
+.screen-share-preview:focus-within .screen-share-info-overlay,
+.screen-share-preview:fullscreen:hover .screen-share-info-overlay,
+.screen-share-preview:fullscreen:focus-within .screen-share-info-overlay {
   opacity: 1;
 }
 
@@ -8543,6 +8547,25 @@ a.community-open-btn:hover {
 .screen-share-preview.is-mouse-idle .screen-share-info-overlay {
   opacity: 0 !important;
   pointer-events: none !important;
+}
+
+@media (hover: none) {
+  .screen-share-preview .screen-share-controls-bar,
+  .screen-share-preview:fullscreen .screen-share-controls-bar,
+  .screen-share-preview.is-mouse-idle .screen-share-controls-bar {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+
+  .screen-share-preview .screen-share-info-overlay,
+  .screen-share-preview:fullscreen .screen-share-info-overlay,
+  .screen-share-preview.is-mouse-idle .screen-share-info-overlay {
+    opacity: 1 !important;
+  }
+
+  .screen-share-preview.is-mouse-idle {
+    cursor: auto;
+  }
 }
 
 .voice-stage-tile {


### PR DESCRIPTION
## Summary

Improve mobile voice media controls so remote camera and screen share actions stay accessible on touch devices.

## Changes

- Expose voice media tile controls when the tile receives keyboard focus.
- Keep remote camera and screen share controls visible on touch surfaces that do not support hover.
- Preserve the existing desktop hover behavior and mouse-idle hiding behavior for pointer devices.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`