### PR TITLE
fix(screen-share): add degradation preference to screen share profile…

### DIFF
--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -22,18 +22,21 @@ describe('screen share quality profiles', () => {
       framerate: 30,
       bitrate: 5_000_000,
       contentHint: 'detail',
+      degradationPreference: 'maintain-resolution',
     })
     expect(resolveScreenShareProfileForMode('video')).toEqual({
       resolution: '1080p',
       framerate: 60,
       bitrate: 7_000_000,
       contentHint: 'motion',
+      degradationPreference: 'maintain-framerate',
     })
     expect(resolveScreenShareProfileForMode('gaming')).toEqual({
       resolution: '1080p',
       framerate: 60,
       bitrate: 9_000_000,
       contentHint: 'motion',
+      degradationPreference: 'maintain-framerate',
     })
   })
 

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -13,18 +13,38 @@ const DEFAULT_INPUT_VOLUME = 80
 export type ScreenShareResolution = '720p' | '1080p'
 export type ScreenShareFramerate = 30 | 60
 export type ScreenShareQuality = 'auto' | 'presentation' | 'video' | 'gaming'
+export type ScreenShareDegradationPreference = 'maintain-resolution' | 'maintain-framerate'
 
 export type ScreenShareProfile = {
     resolution: ScreenShareResolution
     framerate: ScreenShareFramerate
     bitrate: number
     contentHint: 'detail' | 'motion'
+    degradationPreference: ScreenShareDegradationPreference
 }
 
 export const SCREEN_SHARE_PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'auto'>, ScreenShareProfile> = {
-    presentation: { resolution: '1080p', framerate: 30, bitrate: 5_000_000, contentHint: 'detail' },
-    video: { resolution: '1080p', framerate: 60, bitrate: 7_000_000, contentHint: 'motion' },
-    gaming: { resolution: '1080p', framerate: 60, bitrate: 9_000_000, contentHint: 'motion' },
+    presentation: {
+        resolution: '1080p',
+        framerate: 30,
+        bitrate: 5_000_000,
+        contentHint: 'detail',
+        degradationPreference: 'maintain-resolution',
+    },
+    video: {
+        resolution: '1080p',
+        framerate: 60,
+        bitrate: 7_000_000,
+        contentHint: 'motion',
+        degradationPreference: 'maintain-framerate',
+    },
+    gaming: {
+        resolution: '1080p',
+        framerate: 60,
+        bitrate: 9_000_000,
+        contentHint: 'motion',
+        degradationPreference: 'maintain-framerate',
+    },
 }
 
 export function normalizeScreenShareQuality(value: string | null | undefined): ScreenShareQuality {
@@ -218,6 +238,7 @@ export function useLocalMedia() {
         maxBitrate: number
         maxFramerate: number
         contentHint: 'detail' | 'motion'
+        degradationPreference: ScreenShareDegradationPreference
     } => {
         const displaySurface = videoTrack?.getSettings?.().displaySurface
         const profile = resolveScreenShareProfile(displaySurface)
@@ -225,6 +246,7 @@ export function useLocalMedia() {
             maxBitrate: profile.bitrate,
             maxFramerate: profile.framerate,
             contentHint: profile.contentHint,
+            degradationPreference: profile.degradationPreference,
         }
     }, [resolveScreenShareProfile])
 

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -732,6 +732,7 @@ export function useLiveKitVoice() {
         screenShareEncoding: screenVideo
           ? { maxBitrate: screenVideo.maxBitrate, maxFramerate: screenVideo.maxFramerate }
           : undefined,
+        degradationPreference: screenVideo?.degradationPreference,
         simulcast: false,  // Screen share: full quality, no simulcast layers
       })
     }

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -42,6 +42,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] `Video` profile publishes at the UI-described 1080p60 behavior.
 - [ ] `Gaming` profile publishes at the UI-described 1080p60 behavior with the higher bitrate profile.
 - [ ] `Auto` chooses by shared surface: monitor -> gaming, browser/tab -> video, window/unknown -> presentation.
+- [ ] Monitor/game and browser/video shares stay motion-first under load: frame pacing remains smooth before sharpness is preserved.
 - [ ] User A starts screen share; User B sees the screen tile.
 - [ ] User B hears the screen-start cue only once for the screen video track.
 - [ ] Sharing screen audio does not play a duplicate start cue.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -201,8 +201,8 @@ await room.localParticipant.publishTrack(videoTrack, {
 ### Content Hints
 
 - **Auto screen share**: Starts with a 1080p60 capture envelope, then reapplies the selected surface profile after `displaySurface` is known.
-- **Presentation/window share**: `contentHint = 'detail'` at 1080p30 to preserve text sharpness while limiting traffic.
-- **Browser tab/video and monitor/gaming share**: `contentHint = 'motion'` at 1080p60 for smoother motion.
+- **Presentation/window share**: `contentHint = 'detail'` at 1080p30 and `maintain-resolution` degradation to preserve text sharpness while limiting traffic.
+- **Browser tab/video and monitor/gaming share**: `contentHint = 'motion'` at 1080p60 and `maintain-framerate` degradation so motion streams trade resolution before they stall on dropped frames.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
 
 ### Remote Viewing Controls


### PR DESCRIPTION
## Summary

Improve motion-first screen share behavior for video and gaming streams.

## Changes

- Added explicit screen share degradation preferences to quality profiles.
- Kept presentation/window sharing resolution-first for sharper text and detail.
- Set video and gaming screen share profiles to prefer framerate under pressure.
- Passed the selected degradation preference into LiveKit screen share publishing.
- Updated voice docs and smoke coverage for motion-first screen share validation.

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`

## Manual Follow-up

- Verify on production with two users in the same voice channel:
  - Gaming and Video screen shares should feel smoother under motion.
  - Presentation shares should keep text/detail readability.