### PR TITLE
chore: update version to 0.1.13 in Cargo files and changelog

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5322,7 +5322,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13] - 2026-05-21
+
+### Changed
+- Improved screen share capture profiles and high-motion playback preference for smoother production sharing.
+- Separated screen share audio handling from microphone audio controls in voice calls.
+- Refreshed the README app preview asset so desktop and mobile screenshots render as one consistent composition.
+
+### Fixed
+- Fixed channel switching scroll anchoring so chat navigation stays on the latest messages more reliably.
+- Improved mobile screen share preview controls and remote media interaction polish.
+
+### Tests
+- Added regression coverage for core chat switching, inline message actions, voice call controls, remote media visibility, and screen share tuning behavior.
+
 ## [0.1.12] - 2026-05-19
 
 ### Changed


### PR DESCRIPTION
## Summary

Prepare the v0.1.13 release metadata and changelog.

## Changes

- Bumped desktop release metadata from `0.1.12` to `0.1.13`.
- Added the v0.1.13 changelog entry for recent chat, voice, screen share, and regression coverage improvements.

## Validation

- `cargo check --locked`
- `git diff --check`
- `graphify update .`