### PR TITLE
fix: resolve chat scroll anchoring regression and improve message loa…

### DIFF
--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Channel } from '../api'
 import ChatArea from './ChatArea'
 
@@ -77,7 +77,12 @@ function renderChatArea(overrides?: Partial<React.ComponentProps<typeof ChatArea
 
 describe('ChatArea regressions', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     scrollToIndex.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('re-anchors switched channels to their latest rendered message', async () => {
@@ -109,9 +114,9 @@ describe('ChatArea regressions', () => {
     })
   })
 
-  it('keeps older-message pagination out of the latest-message snap path', async () => {
+  it('auto-loads older messages near the top without snapping to latest', async () => {
     const onLoadOlder = vi.fn()
-    const { rerender } = renderChatArea({
+    const { container, rerender } = renderChatArea({
       hasMoreOlder: true,
       onLoadOlder,
     })
@@ -121,7 +126,9 @@ describe('ChatArea regressions', () => {
     })
 
     scrollToIndex.mockClear()
-    fireEvent.click(screen.getByRole('button', { name: 'Load older messages' }))
+    const scroller = container.querySelector('.chat-messages') as HTMLDivElement
+    scroller.scrollTop = 72
+    fireEvent.scroll(scroller)
 
     expect(onLoadOlder).toHaveBeenCalledOnce()
     expect(screen.getByRole('button', { name: 'Jump to latest messages' })).toBeInTheDocument()
@@ -152,6 +159,177 @@ describe('ChatArea regressions', () => {
       expect(screen.getByText('prepended')).toBeInTheDocument()
     })
     expect(scrollToIndex).not.toHaveBeenCalledWith(2, { align: 'end' })
+  })
+
+  it('cancels pending latest anchoring when the user manually scrolls after a channel switch', () => {
+    vi.useFakeTimers()
+    const { container, rerender, unmount } = renderChatArea()
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    scrollToIndex.mockClear()
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('off-topic', 'off-topic')}
+        messages={[message('message-3', 'older', 2), message('message-4', 'newest', 3)]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    scrollToIndex.mockClear()
+
+    const scroller = container.querySelector('.chat-messages') as HTMLDivElement
+    scroller.scrollTop = 240
+    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.scroll(scroller)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(scrollToIndex).not.toHaveBeenCalled()
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('keeps a switched channel pending until its messages arrive', () => {
+    vi.useFakeTimers()
+    const { rerender, unmount } = renderChatArea()
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    scrollToIndex.mockClear()
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('off-topic', 'off-topic')}
+        messages={[]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1200)
+    })
+
+    scrollToIndex.mockClear()
+    rerender(
+      <ChatArea
+        activeChannel={channel('off-topic', 'off-topic')}
+        messages={[message('message-3', 'older', 2), message('message-4', 'newest', 3)]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('keeps channel-switch latest anchoring through passive scroll events from list changes', () => {
+    vi.useFakeTimers()
+    const { container, rerender, unmount } = renderChatArea()
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    scrollToIndex.mockClear()
+
+    const scroller = container.querySelector('.chat-messages') as HTMLDivElement
+    scroller.scrollTop = 240
+    fireEvent.wheel(scroller, { deltaY: -80 })
+    fireEvent.scroll(scroller)
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('off-topic', 'off-topic')}
+        messages={[]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    scroller.scrollTop = 120
+    fireEvent.scroll(scroller)
+
+    scrollToIndex.mockClear()
+    rerender(
+      <ChatArea
+        activeChannel={channel('off-topic', 'off-topic')}
+        messages={[message('message-3', 'older', 2), message('message-4', 'newest', 3)]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    unmount()
+    vi.useRealTimers()
+  })
+
+  it('does not re-lock to latest when the user scrolls slightly upward near the bottom', () => {
+    const { container, rerender } = renderChatArea()
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    scrollToIndex.mockClear()
+
+    const scroller = container.querySelector('.chat-messages') as HTMLDivElement
+    scroller.scrollTop = 1060
+    fireEvent.wheel(scroller, { deltaY: -24 })
+    fireEvent.scroll(scroller)
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('general', 'general')}
+        messages={[
+          message('message-1', 'hello', 0),
+          message('message-2', 'latest', 1),
+          message('message-3', 'new arrival', 2),
+        ]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    expect(scrollToIndex).not.toHaveBeenCalledWith(2, { align: 'end' })
+    expect(screen.getByRole('button', { name: 'Jump to latest messages' })).toBeInTheDocument()
   })
 
   it('renders inline stickers and GIFs as chat media instead of text links', () => {

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, useState, useCallback, useLayoutEffect, type FormEvent, type KeyboardEvent, type ReactNode } from 'react'
+import { useRef, useEffect, useMemo, useState, useCallback, useLayoutEffect, type FormEvent, type KeyboardEvent, type ReactNode, type TouchEvent, type WheelEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { Hash, Volume2, Send, Paperclip, X, Save, Search, ChevronRight, Smile, Pin, PinOff, Users, ArrowDown } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -28,6 +28,7 @@ type MentionUser = {
 /** Synthetic entry for @all mention (server-wide). Shown at top when user types @. */
 const MENTION_ALL: MentionUser = { user_id: '__all__', username: 'all' }
 const BOTTOM_LOCK_THRESHOLD_PX = 120
+const TOP_AUTO_LOAD_THRESHOLD_PX = 96
 const MESSAGE_GROUP_WINDOW_MS = 5 * 60 * 1000
 const ESTIMATED_GROUPED_MESSAGE_ROW_PX = 24
 const ESTIMATED_MESSAGE_GROUP_ROW_PX = 52
@@ -534,8 +535,19 @@ export default function ChatArea({
     const lastBottomAnchoredChannelIdRef = useRef<string | null>(null)
     const pendingLatestAnchorChannelIdRef = useRef<string | null>(null)
     const latestAnchorCleanupRef = useRef<(() => void) | null>(null)
+    const programmaticScrollRef = useRef(0)
+    const userReadingHistoryRef = useRef(false)
+    const lastKnownScrollTopRef = useRef(0)
+    const touchStartYRef = useRef<number | null>(null)
     const preservingOlderMessagesRef = useRef(false)
-    const olderMessagesAnchorRef = useRef<{ scrollTop: number; scrollHeight: number } | null>(null)
+    const olderLoadRequestedRef = useRef(false)
+    const olderMessagesAnchorRef = useRef<{
+        scrollTop: number
+        scrollHeight: number
+        messageId?: string
+        messageIndex?: number
+        offsetTop?: number
+    } | null>(null)
     const prevViewActiveRef = useRef(isViewActive)
     const [showJumpToLatest, setShowJumpToLatest] = useState(false)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -614,6 +626,40 @@ export default function ChatArea({
 
     const virtualCount = messages.length + (typingIndicatorLabel ? 1 : 0)
 
+    const isNearBottom = useCallback((el: HTMLDivElement) => {
+        const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+        return distanceToBottom < BOTTOM_LOCK_THRESHOLD_PX
+    }, [])
+
+    const isAtBottom = useCallback((el: HTMLDivElement) => {
+        const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+        return distanceToBottom <= 4
+    }, [])
+
+    const runProgrammaticScroll = useCallback((fn: () => void) => {
+        programmaticScrollRef.current += 1
+        try {
+            fn()
+        } finally {
+            window.requestAnimationFrame(() => {
+                programmaticScrollRef.current = Math.max(0, programmaticScrollRef.current - 1)
+            })
+        }
+    }, [])
+
+    const cancelLatestAnchor = useCallback(() => {
+        latestAnchorCleanupRef.current?.()
+        latestAnchorCleanupRef.current = null
+        pendingLatestAnchorChannelIdRef.current = null
+    }, [])
+
+    const markUserReadingHistory = useCallback(() => {
+        cancelLatestAnchor()
+        userReadingHistoryRef.current = true
+        shouldAutoScrollRef.current = false
+        setShowJumpToLatest((prev) => (messages.length > 0 ? true : prev))
+    }, [cancelLatestAnchor, messages.length])
+
     const rowVirtualizer = useVirtualizer({
         count: virtualCount,
         getScrollElement: () => messagesScrollRef.current,
@@ -633,10 +679,72 @@ export default function ChatArea({
         const el = messagesScrollRef.current
         const anchor = olderMessagesAnchorRef.current
         if (!el || !anchor) return
+        if (anchor.messageId && typeof anchor.offsetTop === 'number') {
+            const anchorIndex = messages.findIndex((message) => message.id === anchor.messageId)
+            const anchoredMessage = Array
+                .from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+                .find((item) => item.dataset.messageId === anchor.messageId)
+            if (!anchoredMessage && anchorIndex >= 0) {
+                runProgrammaticScroll(() => {
+                    rowVirtualizer.scrollToIndex(anchorIndex, { align: 'start' })
+                    el.scrollTop = Math.max(0, el.scrollTop - Math.max(0, anchor.offsetTop ?? 0))
+                    lastKnownScrollTopRef.current = el.scrollTop
+                })
+                shouldAutoScrollRef.current = false
+                setShowJumpToLatest(true)
+                return
+            }
+            if (anchoredMessage) {
+                const currentOffsetTop = anchoredMessage.getBoundingClientRect().top - el.getBoundingClientRect().top
+                const delta = currentOffsetTop - anchor.offsetTop
+                if (Math.abs(delta) > 1) {
+                    runProgrammaticScroll(() => {
+                        el.scrollTop += delta
+                        lastKnownScrollTopRef.current = el.scrollTop
+                    })
+                }
+                shouldAutoScrollRef.current = false
+                setShowJumpToLatest(true)
+                return
+            }
+        }
         el.scrollTop = anchor.scrollTop + Math.max(0, el.scrollHeight - anchor.scrollHeight)
         shouldAutoScrollRef.current = false
         setShowJumpToLatest(true)
+    }, [messages, rowVirtualizer, runProgrammaticScroll])
+
+    const captureOlderMessagesAnchor = useCallback(() => {
+        const el = messagesScrollRef.current
+        if (!el) return null
+        const scrollerRect = el.getBoundingClientRect()
+        const messageItems = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+        const firstVisibleItem = messageItems
+            .map((item) => ({ item, rect: item.getBoundingClientRect() }))
+            .filter(({ rect }) => rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom)
+            .sort((a, b) => Math.abs(a.rect.top - scrollerRect.top) - Math.abs(b.rect.top - scrollerRect.top))[0]?.item
+        const messageId = firstVisibleItem?.dataset.messageId
+        const messageIndex = Number(firstVisibleItem?.dataset.index)
+        return {
+            scrollTop: el.scrollTop,
+            scrollHeight: el.scrollHeight,
+            messageId,
+            messageIndex: Number.isFinite(messageIndex) ? messageIndex : undefined,
+            offsetTop: firstVisibleItem ? firstVisibleItem.getBoundingClientRect().top - scrollerRect.top : undefined,
+        }
     }, [])
+
+    const startOlderMessagesLoad = useCallback(() => {
+        if (!hasMoreOlder || loadingOlder || olderLoadRequestedRef.current) return
+        if (!onLoadOlder || messages.length === 0) return
+        olderLoadRequestedRef.current = true
+        olderMessagesAnchorRef.current = captureOlderMessagesAnchor()
+        cancelLatestAnchor()
+        userReadingHistoryRef.current = true
+        preservingOlderMessagesRef.current = true
+        shouldAutoScrollRef.current = false
+        setShowJumpToLatest(true)
+        onLoadOlder()
+    }, [cancelLatestAnchor, captureOlderMessagesAnchor, hasMoreOlder, loadingOlder, messages.length, onLoadOlder])
 
     /* Jump to bottom before paint when opening/switching chats so the user does
        not see a visible "top -> bottom" scroll animation on first render. */
@@ -645,27 +753,43 @@ export default function ChatArea({
         if (preservingOlderMessagesRef.current) return false
         const el = messagesScrollRef.current
         if (!el || el.clientHeight <= 0) return false
-        shouldAutoScrollRef.current = true
-        setShowJumpToLatest(false)
-        const lastIndex = virtualCount - 1
-        el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
-        if (lastIndex >= 0) {
-            rowVirtualizer.scrollToIndex(lastIndex, { align: 'end' })
-        }
-        requestAnimationFrame(() => {
-            if (expectedChannelId && currentChatChannelIdRef.current !== expectedChannelId) return
-            const latest = messagesScrollRef.current
-            if (!latest || latest.clientHeight <= 0) return
-            latest.scrollTop = Math.max(0, latest.scrollHeight - latest.clientHeight)
+        let snapped = false
+        runProgrammaticScroll(() => {
+            userReadingHistoryRef.current = false
+            shouldAutoScrollRef.current = true
+            setShowJumpToLatest(false)
+            const lastIndex = virtualCount - 1
+            el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
+            lastKnownScrollTopRef.current = el.scrollTop
             if (lastIndex >= 0) {
                 rowVirtualizer.scrollToIndex(lastIndex, { align: 'end' })
             }
+            snapped = true
         })
-        return true
-    }, [rowVirtualizer, virtualCount])
+        requestAnimationFrame(() => {
+            if (expectedChannelId && currentChatChannelIdRef.current !== expectedChannelId) return
+            if (expectedChannelId && pendingLatestAnchorChannelIdRef.current !== expectedChannelId) return
+            const latest = messagesScrollRef.current
+            if (!latest || latest.clientHeight <= 0) return
+            runProgrammaticScroll(() => {
+                userReadingHistoryRef.current = false
+                shouldAutoScrollRef.current = true
+                setShowJumpToLatest(false)
+                latest.scrollTop = Math.max(0, latest.scrollHeight - latest.clientHeight)
+                lastKnownScrollTopRef.current = latest.scrollTop
+                const lastIndex = virtualCount - 1
+                if (lastIndex >= 0) {
+                    rowVirtualizer.scrollToIndex(lastIndex, { align: 'end' })
+                }
+            })
+        })
+        return snapped
+    }, [rowVirtualizer, runProgrammaticScroll, virtualCount])
+    const snapToBottomRef = useRef(snapToBottom)
+    snapToBottomRef.current = snapToBottom
 
     const scheduleLatestAnchor = useCallback((channelId: string) => {
-        latestAnchorCleanupRef.current?.()
+        cancelLatestAnchor()
         pendingLatestAnchorChannelIdRef.current = channelId
         let cancelled = false
         const rafIds: number[] = []
@@ -676,7 +800,7 @@ export default function ChatArea({
             if (pendingLatestAnchorChannelIdRef.current !== channelId) return
             shouldAutoScrollRef.current = true
             setShowJumpToLatest(false)
-            snapToBottom(channelId)
+            snapToBottomRef.current(channelId)
         }
         const queueRaf = (remaining: number) => {
             const id = window.requestAnimationFrame(() => {
@@ -690,17 +814,12 @@ export default function ChatArea({
         for (const delay of [48, 120, 260, 520]) {
             timeoutIds.push(window.setTimeout(snapIfCurrent, delay))
         }
-        timeoutIds.push(window.setTimeout(() => {
-            if (!cancelled && pendingLatestAnchorChannelIdRef.current === channelId) {
-                pendingLatestAnchorChannelIdRef.current = null
-            }
-        }, 760))
         latestAnchorCleanupRef.current = () => {
             cancelled = true
             for (const id of rafIds) window.cancelAnimationFrame(id)
             for (const id of timeoutIds) window.clearTimeout(id)
         }
-    }, [snapToBottom])
+    }, [cancelLatestAnchor])
 
     const syncAutoScrollState = useCallback(() => {
         if (activeChannel?.id && pendingLatestAnchorChannelIdRef.current === activeChannel.id) {
@@ -715,12 +834,61 @@ export default function ChatArea({
         }
         const el = messagesScrollRef.current
         if (!el) return
-        const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-        const isNearBottom = distanceToBottom < BOTTOM_LOCK_THRESHOLD_PX
-        shouldAutoScrollRef.current = isNearBottom
-        const nextShowJump = !isNearBottom && messages.length > 0
+        if (userReadingHistoryRef.current) {
+            if (isAtBottom(el)) {
+                userReadingHistoryRef.current = false
+                shouldAutoScrollRef.current = true
+                setShowJumpToLatest(false)
+                return
+            }
+            shouldAutoScrollRef.current = false
+            setShowJumpToLatest((prev) => (messages.length > 0 ? true : prev))
+            return
+        }
+        const nearBottom = isNearBottom(el)
+        shouldAutoScrollRef.current = nearBottom
+        const nextShowJump = !nearBottom && messages.length > 0
         setShowJumpToLatest((prev) => (prev === nextShowJump ? prev : nextShowJump))
-    }, [activeChannel?.id, messages.length])
+    }, [activeChannel?.id, isAtBottom, isNearBottom, messages.length])
+
+    const handleMessagesScroll = useCallback(() => {
+        const el = messagesScrollRef.current
+        if (el && programmaticScrollRef.current === 0) {
+            if (activeChannel?.id && pendingLatestAnchorChannelIdRef.current === activeChannel.id) {
+                lastKnownScrollTopRef.current = el.scrollTop
+                syncAutoScrollState()
+                return
+            }
+            const previousScrollTop = lastKnownScrollTopRef.current
+            if (el.scrollTop < previousScrollTop - 1) {
+                markUserReadingHistory()
+            }
+            lastKnownScrollTopRef.current = el.scrollTop
+        }
+        if (el && el.scrollTop <= TOP_AUTO_LOAD_THRESHOLD_PX) {
+            startOlderMessagesLoad()
+        }
+        syncAutoScrollState()
+    }, [activeChannel?.id, markUserReadingHistory, startOlderMessagesLoad, syncAutoScrollState])
+
+    const handleWheelScrollIntent = useCallback((event: WheelEvent<HTMLDivElement>) => {
+        if (event.deltaY < 0) {
+            markUserReadingHistory()
+        }
+    }, [markUserReadingHistory])
+
+    const handleTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
+        touchStartYRef.current = event.touches[0]?.clientY ?? null
+    }, [])
+
+    const handleTouchMoveScrollIntent = useCallback((event: TouchEvent<HTMLDivElement>) => {
+        const startY = touchStartYRef.current
+        const nextY = event.touches[0]?.clientY ?? null
+        if (startY != null && nextY != null && nextY > startY + 2) {
+            markUserReadingHistory()
+        }
+        touchStartYRef.current = nextY
+    }, [markUserReadingHistory])
 
     /* When switching channel/DM, aggressively re-anchor to the latest visible
        content so returning to a previously read chat does not keep an older
@@ -731,14 +899,16 @@ export default function ChatArea({
         if (lastBottomAnchoredChannelIdRef.current === channelId) return
         lastBottomAnchoredChannelIdRef.current = channelId
         if (!channelId) return
+        userReadingHistoryRef.current = false
+        lastKnownScrollTopRef.current = messagesScrollRef.current?.scrollTop ?? 0
         preservingOlderMessagesRef.current = false
         olderMessagesAnchorRef.current = null
         shouldAutoScrollRef.current = true
         scheduleLatestAnchor(channelId)
         return () => {
-            latestAnchorCleanupRef.current?.()
+            cancelLatestAnchor()
         }
-    }, [activeChannel?.id, scheduleLatestAnchor])
+    }, [activeChannel?.id, cancelLatestAnchor, scheduleLatestAnchor])
 
     /* Scroll to bottom when opening a chat or when messages load (e.g. DM opened
        from Messages view). useLayoutEffect keeps the first painted frame already
@@ -783,6 +953,11 @@ export default function ChatArea({
             })
         })
     }, [loadingOlder, messages.length, restoreOlderMessagesAnchor])
+
+    useEffect(() => {
+        if (loadingOlder) return
+        olderLoadRequestedRef.current = false
+    }, [activeChannel?.id, loadingOlder, messages.length])
 
     useEffect(() => {
         const spacer = virtualListSpacerRef.current
@@ -976,6 +1151,7 @@ export default function ChatArea({
         const hasText = messageInput.trim().length > 0
         const hasAttachments = draftAttachments.length > 0
         if (!hasForcedContent && !hasText && !hasAttachments) return
+        userReadingHistoryRef.current = false
         preservingOlderMessagesRef.current = false
         olderMessagesAnchorRef.current = null
         pendingSubmitAutoScrollRef.current = true
@@ -1059,15 +1235,16 @@ export default function ChatArea({
         setEmojiOpen(false)
         setReactionPickerMessageId(null)
         setShowJumpToLatest(false)
+        userReadingHistoryRef.current = false
         preservingOlderMessagesRef.current = false
         olderMessagesAnchorRef.current = null
     }, [activeChannel?.id])
 
     useEffect(() => {
         return () => {
-            latestAnchorCleanupRef.current?.()
+            cancelLatestAnchor()
         }
-    }, [])
+    }, [cancelLatestAnchor])
 
     useLayoutEffect(() => {
         syncAutoScrollState()
@@ -1642,34 +1819,14 @@ export default function ChatArea({
             <div
                 className="chat-messages chat-messages-virtual"
                 ref={setMessagesScrollRef}
-                onScroll={() => {
-                    syncAutoScrollState()
-                }}
+                onWheel={handleWheelScrollIntent}
+                onTouchStart={handleTouchStart}
+                onTouchMove={handleTouchMoveScrollIntent}
+                onScroll={handleMessagesScroll}
             >
                 {hasMoreOlder && messages.length > 0 && (
-                    <div className="chat-load-older">
-                        <button
-                            type="button"
-                            className="btn btn-secondary btn-sm"
-                            disabled={loadingOlder}
-                            onClick={() => {
-                                const el = messagesScrollRef.current
-                                if (el) {
-                                    olderMessagesAnchorRef.current = {
-                                        scrollTop: el.scrollTop,
-                                        scrollHeight: el.scrollHeight,
-                                    }
-                                }
-                                latestAnchorCleanupRef.current?.()
-                                pendingLatestAnchorChannelIdRef.current = null
-                                preservingOlderMessagesRef.current = true
-                                shouldAutoScrollRef.current = false
-                                setShowJumpToLatest(true)
-                                onLoadOlder?.()
-                            }}
-                        >
-                            {loadingOlder ? 'Loading…' : 'Load older messages'}
-                        </button>
+                    <div className="chat-load-older" aria-live="polite">
+                        {loadingOlder ? 'Loading older messages…' : 'Scroll up for older messages'}
                     </div>
                 )}
                 {loading ? (
@@ -1765,6 +1922,7 @@ export default function ChatArea({
                                 <div
                                     key={msg.id}
                                     data-index={virtualRow.index}
+                                    data-message-id={msg.id}
                                     ref={rowVirtualizer.measureElement}
                                     className={`virtual-list-item ${virtualRow.index === 0 ? 'virtual-list-item-first' : ''}`}
                                     style={{ transform: `translateY(${Math.round(virtualRow.start)}px)` }}
@@ -1894,6 +2052,7 @@ export default function ChatArea({
                         type="button"
                         className="chat-jump-to-latest"
                         onClick={() => {
+                            userReadingHistoryRef.current = false
                             preservingOlderMessagesRef.current = false
                             olderMessagesAnchorRef.current = null
                             snapToBottom()


### PR DESCRIPTION
## Summary

Fix chat scroll anchoring regressions and make older message loading feel closer to Discord-style chat navigation.

## Changes

- Keep channel switches anchored to the latest message, even when messages arrive after the channel view opens.
- Prevent manual upward scrolling from being pulled back down by delayed auto-scroll or virtualizer updates.
- Preserve user scroll intent while reading history; new messages no longer force-jump to latest.
- Replace manual "Load older messages" button behavior with automatic older-message loading near the top.
- Improve older-message anchoring so prepended history keeps the viewport stable.
- Added regression coverage for channel switching, manual scroll cancellation, delayed message arrival, passive scroll events, and older-message loading.

## Validation

- npm run test:run -- ChatArea.test.tsx
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .