### PR TITLE
feat: implement friend DM channel opening and sorting functionality

### DIFF
--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -417,7 +417,16 @@ async fn get_or_create_dm_channel(
                     WHERE m.channel_id = c.id
                     ORDER BY m.created_at DESC
                     LIMIT 1
-                  ) as last_message_at
+                  ) as last_message_at,
+                  (
+                    SELECT COUNT(*)
+                    FROM dm_messages m
+                    LEFT JOIN dm_channel_reads r
+                      ON r.channel_id = c.id AND r.user_id = $1
+                    WHERE m.channel_id = c.id
+                      AND m.user_id <> $1
+                      AND (r.read_at IS NULL OR m.created_at > r.read_at)
+                  ) as unread_count
            FROM dm_channels c
            INNER JOIN dm_channel_members peer_m
              ON peer_m.channel_id = c.id AND peer_m.user_id <> $1

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -1264,6 +1264,101 @@ async fn friends_endpoints_require_auth() {
 }
 
 #[tokio::test]
+async fn friend_dm_channel_open_returns_channel_info() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app().await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    let alice_username = format!("alice{}", &suffix[..8]);
+    let bob_username = format!("bob{}", &suffix[8..16]);
+    let (alice_token, _) = register_user(
+        &mut app,
+        &format!("{alice_username}@example.com"),
+        &alice_username,
+        "password123",
+    )
+    .await;
+    let (bob_token, bob_id) = register_user(
+        &mut app,
+        &format!("{bob_username}@example.com"),
+        &bob_username,
+        "password123",
+    )
+    .await;
+
+    let alice_auth = format!("Bearer {alice_token}");
+    let bob_auth = format!("Bearer {bob_token}");
+
+    let friend_request_body = json!({ "username": bob_username });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/friends/requests")
+        .header("Authorization", &alice_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&friend_request_body).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "send friend request failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/friends/requests")
+        .header("Authorization", &bob_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "list friend requests failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let requests: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let request_id = requests["incoming"][0]["id"].as_str().unwrap();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/friends/requests/{request_id}/accept"))
+        .header("Authorization", &bob_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "accept friend request failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/dm/channels/{bob_id}"))
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "open friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let channel: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channel["peer_id"].as_str().unwrap(), bob_id.to_string());
+    assert_eq!(channel["peer_username"].as_str().unwrap(), bob_username);
+    assert_eq!(channel["unread_count"].as_i64().unwrap(), 0);
+}
+
+#[tokio::test]
 async fn strict_username_validation_rejects_invalid_usernames() {
     let Some(_) = test_db_url() else {
         eprintln!("SKIP: DATABASE_URL not set");

--- a/apps/web/src/friendsList.test.ts
+++ b/apps/web/src/friendsList.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { DmChannel, Friend } from './api'
+import { getVisibleFriendsForFilter, upsertDmChannel } from './friendsList'
+
+function friend(id: string, username: string, status: string): Friend {
+  return {
+    id,
+    username,
+    avatar_url: null,
+    status,
+  }
+}
+
+function dmChannel(id: string, peerUsername: string): DmChannel {
+  return {
+    id,
+    peer_id: `peer-${id}`,
+    peer_username: peerUsername,
+    peer_avatar_url: null,
+    peer_status: 'online',
+    last_message_at: null,
+    unread_count: 0,
+  }
+}
+
+describe('friends list helpers', () => {
+  it('orders all friends with active users first, then alphabetically', () => {
+    const visible = getVisibleFriendsForFilter(
+      [
+        friend('offline-a', 'Aaron', 'offline'),
+        friend('online-z', 'Zed', 'online'),
+        friend('dnd-b', 'Bella', 'dnd'),
+        friend('offline-c', 'Clara', 'offline'),
+        friend('online-a', 'Adam', 'online'),
+      ],
+      'all',
+    )
+
+    expect(visible.map((item) => item.username)).toEqual(['Adam', 'Bella', 'Zed', 'Aaron', 'Clara'])
+  })
+
+  it('keeps the online filter limited to active friends', () => {
+    const visible = getVisibleFriendsForFilter(
+      [
+        friend('offline-a', 'Aaron', 'offline'),
+        friend('online-z', 'Zed', 'online'),
+        friend('dnd-b', 'Bella', 'dnd'),
+      ],
+      'online',
+    )
+
+    expect(visible.map((item) => item.username)).toEqual(['Bella', 'Zed'])
+  })
+
+  it('upserts opened DM channels without leaving stale duplicates', () => {
+    const current = [dmChannel('old-a', 'alpha'), dmChannel('old-b', 'bravo')]
+    const updated = { ...dmChannel('old-b', 'bravo'), unread_count: 2 }
+
+    expect(upsertDmChannel(current, updated)).toEqual([updated, current[0]])
+    expect(upsertDmChannel(current, dmChannel('new-c', 'charlie')).map((channel) => channel.id)).toEqual([
+      'new-c',
+      'old-a',
+      'old-b',
+    ])
+  })
+})

--- a/apps/web/src/friendsList.ts
+++ b/apps/web/src/friendsList.ts
@@ -1,0 +1,40 @@
+import type { DmChannel, Friend } from './api'
+
+export type FriendsFilter = 'all' | 'online' | 'requests'
+
+const friendNameCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+export function normalizePresence(status?: string | null): 'online' | 'dnd' | 'offline' {
+  const normalized = (status ?? 'offline').toLowerCase()
+  if (normalized === 'online' || normalized === 'dnd') return normalized
+  return 'offline'
+}
+
+export function isActiveFriend(friend: Pick<Friend, 'status'>): boolean {
+  return normalizePresence(friend.status) !== 'offline'
+}
+
+function compareFriendNames(a: Pick<Friend, 'id' | 'username'>, b: Pick<Friend, 'id' | 'username'>): number {
+  const byName = friendNameCollator.compare(a.username, b.username)
+  if (byName !== 0) return byName
+  return a.id.localeCompare(b.id)
+}
+
+export function compareFriendsForList(a: Friend, b: Friend): number {
+  const aActive = isActiveFriend(a)
+  const bActive = isActiveFriend(b)
+  if (aActive !== bActive) return aActive ? -1 : 1
+  return compareFriendNames(a, b)
+}
+
+export function getVisibleFriendsForFilter(friends: Friend[], filter: Exclude<FriendsFilter, 'requests'>): Friend[] {
+  const source = filter === 'online' ? friends.filter(isActiveFriend) : friends
+  return [...source].sort(compareFriendsForList)
+}
+
+export function upsertDmChannel(channels: DmChannel[], channel: DmChannel): DmChannel[] {
+  return [channel, ...channels.filter((existing) => existing.id !== channel.id)]
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6933,8 +6933,10 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  font-family: inherit;
   font-size: 13px;
   font-weight: 500;
+  line-height: 1;
   transition: all 0.2s ease;
   cursor: pointer;
   justify-content: center;
@@ -6951,6 +6953,15 @@ body {
   background: rgba(59, 130, 246, 0.15);
   border-color: rgba(59, 130, 246, 0.4);
   box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.1) inset;
+}
+
+.home-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: inherit;
+  line-height: 1;
 }
 
 .home-chip-badge {
@@ -7186,6 +7197,35 @@ body {
 
 .home-member-row.is-clickable:hover {
   background: rgba(59, 130, 246, 0.06);
+}
+
+.home-member-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+}
+
+.home-member-main:disabled {
+  cursor: wait;
+}
+
+.home-member-main:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.65);
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+
+.home-member-row.is-loading {
+  opacity: 0.72;
 }
 
 .home-member-avatar {

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DmChannel, Friend } from '../api'
+import { ROUTES } from '../routes'
+import { useAppStore } from '../stores/app'
+import { useAuthStore } from '../stores/auth'
+import { useSocketStore } from '../stores/socket'
+import { useToastStore } from '../stores/toast'
+import HomePage from './HomePage'
+
+const apiMocks = vi.hoisted(() => ({
+  listServers: vi.fn(),
+  joinServer: vi.fn(),
+  listFriends: vi.fn(),
+  listFriendRequests: vi.fn(),
+  sendFriendRequest: vi.fn(),
+  acceptFriendRequest: vi.fn(),
+  rejectFriendRequest: vi.fn(),
+  removeFriend: vi.fn(),
+  listDmChannels: vi.fn(),
+  getOrCreateDmChannel: vi.fn(),
+  listDmMessages: vi.fn(),
+  listDmPins: vi.fn(),
+  createWebSocket: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  attachmentApi: {},
+  authApi: {
+    getMe: vi.fn(),
+    logout: vi.fn(),
+  },
+  createWebSocket: apiMocks.createWebSocket,
+  dmApi: {
+    listChannels: apiMocks.listDmChannels,
+    getOrCreateChannel: apiMocks.getOrCreateDmChannel,
+    listMessages: apiMocks.listDmMessages,
+    listPins: apiMocks.listDmPins,
+    searchMessages: vi.fn(),
+    sendMessage: vi.fn(),
+    pinMessage: vi.fn(),
+    unpinMessage: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    editMessage: vi.fn(),
+    deleteMessage: vi.fn(),
+  },
+  friendApi: {
+    list: apiMocks.listFriends,
+    requests: apiMocks.listFriendRequests,
+    sendRequest: apiMocks.sendFriendRequest,
+    acceptRequest: apiMocks.acceptFriendRequest,
+    rejectRequest: apiMocks.rejectFriendRequest,
+    remove: apiMocks.removeFriend,
+  },
+  isAuthError: vi.fn(() => false),
+  resolveAvatarUrl: (url: string | null) => url,
+  serverApi: {
+    list: apiMocks.listServers,
+    join: apiMocks.joinServer,
+  },
+}))
+
+vi.mock('../components/ChatArea', () => ({
+  default: () => <div data-testid="dm-chat">DM chat</div>,
+}))
+
+function friend(id: string, username: string, status: string): Friend {
+  return {
+    id,
+    username,
+    avatar_url: null,
+    status,
+  }
+}
+
+function dmChannel(id: string, peerId = 'friend-cilo', peerUsername = 'cilo'): DmChannel {
+  return {
+    id,
+    peer_id: peerId,
+    peer_username: peerUsername,
+    peer_avatar_url: null,
+    peer_status: 'online',
+    last_message_at: null,
+    unread_count: 0,
+  }
+}
+
+function renderHomePage() {
+  return render(
+    <MemoryRouter initialEntries={[ROUTES.home]}>
+      <Routes>
+        <Route path={ROUTES.home} element={<HomePage />} />
+        <Route path={ROUTES.dm} element={<HomePage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('HomePage friends list', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+    window.scrollTo = vi.fn()
+
+    useAuthStore.setState({
+      token: null,
+      user: {
+        id: 'user-1',
+        username: 'admin',
+        email: 'admin@example.test',
+        email_verified: true,
+        status: 'online',
+        dm_privacy: 'friends',
+      },
+      loggingOut: false,
+    })
+    useAppStore.getState().resetSessionState()
+    useToastStore.setState({ toasts: [] })
+    useSocketStore.setState({
+      socket: null,
+      isConnected: false,
+      listeners: new Set(),
+      reconnectListeners: new Set(),
+    })
+
+    apiMocks.listServers.mockResolvedValue([])
+    apiMocks.listFriends.mockResolvedValue([friend('friend-cilo', 'cilo', 'dnd')])
+    apiMocks.listFriendRequests.mockResolvedValue({ incoming: [], outgoing: [] })
+    apiMocks.listDmChannels.mockResolvedValue([])
+    apiMocks.listDmMessages.mockResolvedValue([])
+    apiMocks.listDmPins.mockResolvedValue([])
+  })
+
+  it('opens a DM when a friend row is selected', async () => {
+    apiMocks.getOrCreateDmChannel.mockResolvedValue(dmChannel('dm-cilo'))
+
+    renderHomePage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Message cilo' }))
+
+    await waitFor(() => {
+      expect(apiMocks.getOrCreateDmChannel).toHaveBeenCalledWith('friend-cilo', null)
+      expect(useAppStore.getState().activeDmChannelId).toBe('dm-cilo')
+    })
+    expect(useAppStore.getState().dmChannels[0]?.id).toBe('dm-cilo')
+    expect(screen.getByTestId('dm-chat')).not.toBeNull()
+  })
+
+  it('shows a toast when opening a DM fails', async () => {
+    apiMocks.getOrCreateDmChannel.mockRejectedValue(new Error('Could not create DM'))
+
+    renderHomePage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Message cilo' }))
+
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts[0]).toMatchObject({
+        level: 'error',
+        title: 'DM failed',
+        message: 'Could not create DM',
+      })
+    })
+  })
+
+  it('orders the All friends tab with active friends first', async () => {
+    apiMocks.listFriends.mockResolvedValue([
+      friend('offline-a', 'Aaron', 'offline'),
+      friend('online-z', 'Zed', 'online'),
+      friend('dnd-b', 'Bella', 'dnd'),
+      friend('offline-c', 'Clara', 'offline'),
+      friend('online-a', 'Adam', 'online'),
+    ])
+
+    renderHomePage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'All' }))
+
+    await waitFor(() => {
+      const friendRows = screen.getAllByRole('button', { name: /^Message / })
+      expect(friendRows.map((row) => row.getAttribute('aria-label'))).toEqual([
+        'Message Adam',
+        'Message Bella',
+        'Message Zed',
+        'Message Aaron',
+        'Message Clara',
+      ])
+    })
+  })
+})

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -34,20 +34,18 @@ import { type SocialView, getPersistedSocialView, setPersistedSocialView } from 
 import { formatBadgeCount } from '../formatUnreadBadgeCount'
 import { createReplyContentSnippet } from '../replyPreview'
 import { ROUTES } from '../routes'
-
-type FriendsFilter = 'all' | 'online' | 'requests'
+import {
+  type FriendsFilter,
+  getVisibleFriendsForFilter,
+  normalizePresence,
+  upsertDmChannel,
+} from '../friendsList'
 
 const HIDDEN_DM_PEERS_KEY = 'voxpery-hidden-dm-peers'
 
 function isDmAccessForbidden(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
   return msg.includes('No access') || msg.includes('403') || msg.includes('Forbidden')
-}
-
-function normalizePresence(status?: string | null): 'online' | 'dnd' | 'offline' {
-  const normalized = (status ?? 'offline').toLowerCase()
-  if (normalized === 'online' || normalized === 'dnd') return normalized
-  return 'offline'
 }
 
 function presenceLabel(status?: string | null): string {
@@ -164,6 +162,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [addFriendMessage, setAddFriendMessage] = useState<string | null>(null)
   const [removeFriendTarget, setRemoveFriendTarget] = useState<Friend | null>(null)
   const [removingFriend, setRemovingFriend] = useState(false)
+  const [openingDmPeerId, setOpeningDmPeerId] = useState<string | null>(null)
   const isMobileSocialSidebarOpen = mobileSidebarPanel === 'social'
   const friends = storeFriends
   const dmChannels = useMemo(
@@ -295,8 +294,11 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     }
   }, [navigate, pushToast, setActiveServer, setServers, token, voxperyServer])
 
-  const onlineFriends = friends.filter((f) => f.status !== 'offline')
-  const visibleFriends = friendsFilter === 'online' ? onlineFriends : friends
+  const onlineFriends = useMemo(() => getVisibleFriendsForFilter(friends, 'online'), [friends])
+  const visibleFriends = useMemo(
+    () => (friendsFilter === 'requests' ? [] : getVisibleFriendsForFilter(friends, friendsFilter)),
+    [friends, friendsFilter],
+  )
   const refreshActiveDmConversation = useCallback(async (channelId: string) => {
     if (!user) return
     const requestId = ++dmMessagesRequestRef.current
@@ -548,20 +550,41 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     return () => unsub()
   }, [refreshServersAndFriends, subscribe, userId])
 
-  const openMessageForFriend = async (friendId: string) => {
-    if (!user) return
-    const channel = await dmApi.getOrCreateChannel(friendId, token)
-    setHiddenDmPeerIds((prev) => prev.filter((id) => id !== channel.peer_id))
-    setView('dm')
-    setPersistedSocialView('dm')
-    setActiveDmChannelId(channel.id)
-    clearDmUnread(channel.id)
-    const prev = useAppStore.getState().dmChannels
-    if (!prev.some((c) => c.id === channel.id)) {
-      setStoreDmChannels([channel, ...prev])
+  const openMessageForFriend = useCallback(async (friendId: string) => {
+    if (!user || openingDmPeerId) return
+    setOpeningDmPeerId(friendId)
+    try {
+      const channel = await dmApi.getOrCreateChannel(friendId, token)
+      const nextChannels = upsertDmChannel(useAppStore.getState().dmChannels, channel)
+
+      setHiddenDmPeerIds((prev) => prev.filter((id) => id !== channel.peer_id))
+      setStoreDmChannels(nextChannels)
+      setDmChannelIds(nextChannels.map((dmChannel) => dmChannel.id))
+      setActiveDmChannelId(channel.id)
+      clearDmUnread(channel.id)
+      setView('dm')
+      setPersistedSocialView('dm')
+      navigate(ROUTES.dm)
+    } catch (err) {
+      pushToast({
+        level: 'error',
+        title: 'DM failed',
+        message: err instanceof Error ? err.message : 'Could not open direct message.',
+      })
+    } finally {
+      setOpeningDmPeerId(null)
     }
-    navigate(ROUTES.dm)
-  }
+  }, [
+    clearDmUnread,
+    navigate,
+    openingDmPeerId,
+    pushToast,
+    setActiveDmChannelId,
+    setDmChannelIds,
+    setStoreDmChannels,
+    token,
+    user,
+  ])
 
   const sendFriendRequest = async () => {
     if (!user || !addFriendUsername.trim()) return
@@ -1007,7 +1030,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                   onClick={() => setFriendsFilter('online')}
                 >
                   <Activity size={14} />
-                  Online
+                  <span className="home-chip-label">Online</span>
                 </button>
                 <button
                   type="button"
@@ -1015,7 +1038,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                   onClick={() => setFriendsFilter('all')}
                 >
                   <Users size={14} />
-                  All
+                  <span className="home-chip-label">All</span>
                 </button>
                 <button
                   type="button"
@@ -1023,7 +1046,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                   onClick={() => setFriendsFilter('requests')}
                 >
                   <MessageSquarePlus size={14} />
-                  Requests
+                  <span className="home-chip-label">Requests</span>
                   {incomingRequests.length > 0 && (
                     <span className="home-chip-badge">{formatBadgeCount(incomingRequests.length)}</span>
                   )}
@@ -1143,29 +1166,38 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                     return (
                       <div
                         key={friend.id}
-                        className="home-member-row is-clickable"
-                        onClick={() => openMessageForFriend(friend.id)}
+                        className={`home-member-row is-clickable ${openingDmPeerId === friend.id ? 'is-loading' : ''}`}
+                        aria-disabled={openingDmPeerId === friend.id}
                       >
-                        <div className={`home-member-avatar avatar-status-${['online', 'dnd', 'offline'].includes((friend.status ?? '').toLowerCase()) ? (friend.status ?? 'offline').toLowerCase() : 'offline'}`}>
-                          {friend.avatar_url ? (
-                            <img src={resolveAvatarUrl(friend.avatar_url) ?? ''} alt="" />
-                          ) : (
-                            friend.username.charAt(0).toUpperCase()
-                          )}
-                        </div>
-                        <div className="home-member-meta">
-                          <div>{friend.username}</div>
-                          <span>
-                            <span className={`home-presence-pill home-presence-pill-${normalizePresence(friend.status)}`}>
-                              <span className="home-presence-pill-dot" aria-hidden />
-                              {presenceLabel(friend.status)}
+                        <button
+                          type="button"
+                          className="home-member-main"
+                          aria-label={`Message ${friend.username}`}
+                          disabled={openingDmPeerId === friend.id}
+                          onClick={() => void openMessageForFriend(friend.id)}
+                        >
+                          <div className={`home-member-avatar avatar-status-${['online', 'dnd', 'offline'].includes((friend.status ?? '').toLowerCase()) ? (friend.status ?? 'offline').toLowerCase() : 'offline'}`}>
+                            {friend.avatar_url ? (
+                              <img src={resolveAvatarUrl(friend.avatar_url) ?? ''} alt="" />
+                            ) : (
+                              friend.username.charAt(0).toUpperCase()
+                            )}
+                          </div>
+                          <div className="home-member-meta">
+                            <div>{friend.username}</div>
+                            <span>
+                              <span className={`home-presence-pill home-presence-pill-${normalizePresence(friend.status)}`}>
+                                <span className="home-presence-pill-dot" aria-hidden />
+                                {presenceLabel(friend.status)}
+                              </span>
                             </span>
-                          </span>
-                        </div>
+                          </div>
+                        </button>
                         <button
                           type="button"
                           className="home-member-action home-member-action--trailing danger"
                           title="Remove friend"
+                          disabled={openingDmPeerId === friend.id}
                           onClick={(e) => {
                             e.stopPropagation()
                             setRemoveFriendTarget(friend)


### PR DESCRIPTION
Summary

Fix Friends list DM opening and align Friends tab ordering/typography.

Changes

- Fixed DM channel open/create response so friend-row DM opens no longer fail with an internal server error.
- Made Online/All friend rows reliably open the related DM and update DM route/state/unread data.
- Added error toast feedback when opening a DM fails.
- Sorted All friends with active users first, then alphabetically.
- Normalized Online, All, and Requests tab label typography for a consistent Friends UI.
- Added regression coverage for DM opening, DM failure feedback, friend sorting, and backend DM channel response.

Validation

- npm run lint
- npm run test:run
- npm run build
- cargo check --locked
- cargo test --locked friend_dm_channel_open_returns_channel_info --test integration
- graphify update .