### PR TITLE
feat: add mark DM channel as read functionality and update API docume…

### DIFF
--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -192,6 +192,7 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
         .route("/channels", get(list_dm_channels))
         .route("/channels/{peer_id}", post(get_or_create_dm_channel))
         .route("/channels/{channel_id}/read-state", get(get_dm_read_state))
+        .route("/channels/{channel_id}/read", post(mark_dm_channel_read))
         .route(
             "/channels/{channel_id}/pins",
             get(list_dm_pins).post(pin_dm_message),
@@ -628,6 +629,29 @@ async fn get_dm_read_state(
     Ok(Json(DmReadState {
         peer_last_read_message_id: peer_last,
     }))
+}
+
+async fn mark_dm_channel_read(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path(channel_id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    check_dm_access(&state, channel_id, claims.sub).await?;
+    let last_message_id = sqlx::query_scalar::<_, Option<Uuid>>(
+        r#"SELECT id
+           FROM dm_messages
+           WHERE channel_id = $1
+           ORDER BY created_at DESC
+           LIMIT 1"#,
+    )
+    .bind(channel_id)
+    .fetch_optional(&state.db)
+    .await?
+    .flatten();
+
+    mark_dm_read(&state, channel_id, claims.sub, last_message_id).await?;
+    publish_dm_read(&state, channel_id, claims.sub, last_message_id).await;
+    Ok(Json(serde_json::json!({ "message": "DM marked read" })))
 }
 
 async fn search_dm_messages(

--- a/apps/web/src/api/dm.ts
+++ b/apps/web/src/api/dm.ts
@@ -63,6 +63,12 @@ export const dmApi = {
     readState: (channelId: string, token: AuthToken) =>
         apiFetch<DmReadState>(`/api/dm/channels/${channelId}/read-state`, { token }),
 
+    markRead: (channelId: string, token: AuthToken) =>
+        apiFetch<void>(`/api/dm/channels/${channelId}/read`, {
+            method: 'POST',
+            token,
+        }),
+
     listPins: (channelId: string, token: AuthToken) =>
         apiFetch<MessageWithAuthor[]>(`/api/dm/channels/${channelId}/pins`, { token }),
 

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -440,6 +440,12 @@ export default function AppShell() {
                   title: incomingMessage?.author?.username ?? channel.peer_username,
                   body: 'sent you a direct message',
                   tag: `dm:${channel.id}`,
+                  onClick: () => {
+                    setPersistedSocialView('dm')
+                    setActiveDmChannelId(channel.id)
+                    clearDmUnread(channel.id)
+                    navigate(ROUTES.dm)
+                  },
                 })
               }
             }

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -21,6 +21,7 @@ const apiMocks = vi.hoisted(() => ({
   listDmChannels: vi.fn(),
   getOrCreateDmChannel: vi.fn(),
   listDmMessages: vi.fn(),
+  markDmRead: vi.fn(),
   listDmPins: vi.fn(),
   createWebSocket: vi.fn(),
 }))
@@ -36,6 +37,7 @@ vi.mock('../api', () => ({
     listChannels: apiMocks.listDmChannels,
     getOrCreateChannel: apiMocks.getOrCreateDmChannel,
     listMessages: apiMocks.listDmMessages,
+    markRead: apiMocks.markDmRead,
     listPins: apiMocks.listDmPins,
     searchMessages: vi.fn(),
     sendMessage: vi.fn(),
@@ -131,6 +133,7 @@ describe('HomePage friends list', () => {
     apiMocks.listFriendRequests.mockResolvedValue({ incoming: [], outgoing: [] })
     apiMocks.listDmChannels.mockResolvedValue([])
     apiMocks.listDmMessages.mockResolvedValue([])
+    apiMocks.markDmRead.mockResolvedValue(undefined)
     apiMocks.listDmPins.mockResolvedValue([])
   })
 
@@ -162,6 +165,25 @@ describe('HomePage friends list', () => {
         title: 'DM failed',
         message: 'Could not create DM',
       })
+    })
+  })
+
+  it('refreshes the active DM when returning from another app area', async () => {
+    const channel = dmChannel('dm-cilo')
+    sessionStorage.setItem('voxpery-social-view', 'dm')
+    useAppStore.setState({
+      activeDmChannelId: channel.id,
+      dmChannels: [channel],
+      dmChannelIds: [channel.id],
+      dmUnread: { [channel.id]: 1 },
+    })
+    apiMocks.listDmMessages.mockResolvedValue([])
+
+    renderHomePage()
+
+    await waitFor(() => {
+      expect(apiMocks.listDmMessages).toHaveBeenCalledWith(channel.id, null)
+      expect(useAppStore.getState().dmUnread[channel.id]).toBe(0)
     })
   })
 

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -143,6 +143,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const isUuid = (s: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s)
 
   const [view, setView] = useState<SocialView>('friends')
+  const isDmConversationVisible = isMessagesView && location.pathname === ROUTES.dm && view === 'dm'
   const [friendsFilter, setFriendsFilter] = useState<FriendsFilter>('online')
   const [socialBootstrapLoading, setSocialBootstrapLoading] = useState(true)
   const [incomingRequests, setIncomingRequests] = useState<FriendRequest[]>([])
@@ -224,9 +225,11 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [dmDraftAttachments, setDmDraftAttachments] = useState<DraftAttachmentItem[]>([])
   const dmMessagesByChannelRef = useRef<Record<string, UiDmMessage[]>>({})
   const activeDmChannelIdRef = useRef(activeDmChannelId)
+  const isDmConversationVisibleRef = useRef(isDmConversationVisible)
   const dmMessagesRequestRef = useRef(0)
   const pushToast = useToastStore((s) => s.pushToast)
   useEffect(() => { activeDmChannelIdRef.current = activeDmChannelId }, [activeDmChannelId])
+  useEffect(() => { isDmConversationVisibleRef.current = isDmConversationVisible }, [isDmConversationVisible])
 
   // Use user so web works: on web token is null, auth is via httpOnly cookie.
   const refreshServersAndFriends = useCallback(async () => {
@@ -331,9 +334,20 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   }, [token, user, setActiveDmChannelId, setView])
 
   useEffect(() => {
-    if (!user || !activeDmChannelId) return
+    if (!user || !activeDmChannelId) {
+      setDmUnreadDividerCount(0)
+      return
+    }
+    if (!isDmConversationVisible) {
+      setDmUnreadDividerCount(0)
+      return
+    }
+
+    const unreadCount = useAppStore.getState().dmUnread[activeDmChannelId] ?? 0
+    setDmUnreadDividerCount(unreadCount > 0 ? unreadCount : 0)
+    clearDmUnread(activeDmChannelId)
     void refreshActiveDmConversation(activeDmChannelId)
-  }, [activeDmChannelId, refreshActiveDmConversation, user])
+  }, [activeDmChannelId, clearDmUnread, isDmConversationVisible, refreshActiveDmConversation, user])
 
   useEffect(() => {
     if (!user || !activeDmChannelId) return
@@ -464,18 +478,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       ; (document.activeElement as HTMLElement | null)?.blur()
   }, [view])
 
-  /* Mark DM as read whenever the conversation is visible (fixes badge when landing on / with same DM still in state) */
-  useEffect(() => {
-    if (view === 'dm' && activeDmChannelId) {
-      const unreadCount = useAppStore.getState().dmUnread[activeDmChannelId] ?? 0
-      setDmUnreadDividerCount(unreadCount > 0 ? unreadCount : 0)
-      clearDmUnread(activeDmChannelId)
-      return
-    }
-
-    setDmUnreadDividerCount(0)
-  }, [view, activeDmChannelId, clearDmUnread, location.pathname])
-
   useEffect(() => {
     if (!isConnected || dmChannels.length === 0) return
     const ids = dmChannels.map((c) => c.id)
@@ -514,9 +516,15 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         dmMessagesByChannelRef.current[channelId] = next
         return next
       })
+      if (isDmConversationVisibleRef.current) {
+        clearDmUnread(channelId)
+        void dmApi.markRead(channelId, token).catch(() => {
+          // Best-effort read sync; the next conversation refresh will reconcile.
+        })
+      }
     })
     return () => unsub()
-  }, [subscribe, user?.id])
+  }, [clearDmUnread, subscribe, token, user?.id])
 
   // Keep friends list and DM channel peer status in sync with PresenceUpdate (online/offline)
   useEffect(() => {

--- a/docs/API.md
+++ b/docs/API.md
@@ -226,6 +226,8 @@ Notes:
 - `PATCH /api/dm/messages/item/:message_id`
 - `DELETE /api/dm/messages/item/:message_id`
 - `GET /api/dm/channels/:channel_id/read-state`
+- `POST /api/dm/channels/:channel_id/read`
+  - Marks the current user's DM read state through the latest message in the channel and emits a `DmRead` WebSocket event for the user's other sessions.
 - `GET /api/dm/channels/:channel_id/pins`
 - `POST /api/dm/channels/:channel_id/pins`
 - `DELETE /api/dm/channels/:channel_id/pins/:message_id`


### PR DESCRIPTION
Summary

Fix DM unread badges staying visible after opening a DM from a notification while returning from another app area.

Changes

- Added a dedicated DM mark-read endpoint.
- Sync backend read state when an active DM becomes visible again.
- Keep visible DM conversations read when new messages arrive in real time.
- Wire DM notification clicks to open the related conversation directly.
- Added regression coverage for returning to an active DM with unread state.
- Updated API docs for the new read endpoint.

Validation

- cargo check --locked
- npm run lint
- npm run test:run
- npm run build
- git diff --check