### PR TITLE
feat: enhance friends list scrolling and layout adjustments

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6936,7 +6936,7 @@ body {
   font-family: inherit;
   font-size: 13px;
   font-weight: 500;
-  line-height: 1;
+  line-height: 1.2;
   transition: all 0.2s ease;
   cursor: pointer;
   justify-content: center;
@@ -6961,7 +6961,7 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   font: inherit;
-  line-height: 1;
+  line-height: 1.2;
 }
 
 .home-chip-badge {
@@ -6994,6 +6994,28 @@ body {
   overflow: hidden;
   background: rgba(255, 255, 255, 0.02);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.home-friends-scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding-right: 2px;
+  padding-bottom: 16px;
+}
+
+.home-friends-scroll--requests {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.home-friends-scroll--requests .home-list-group + .home-list-group {
+  margin-top: 0;
 }
 
 .home-list-group+.home-list-group {
@@ -7513,6 +7535,10 @@ body {
 /* Requests tab: Add Friend card */
 .home-requests-add-card {
   margin-bottom: 20px;
+}
+
+.home-friends-scroll--requests .home-requests-add-card {
+  margin-bottom: 0;
 }
 
 .home-requests-add-card .home-list-title {

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1061,7 +1061,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                 </button>
               </div>
               {friendsFilter === 'requests' ? (
-                <>
+                <div className="home-friends-scroll home-friends-scroll--requests">
                   <div className="home-list-group home-requests-add-card">
                     <div className="home-list-title">Add a Friend</div>
                     <div className="home-add-row">
@@ -1127,97 +1127,99 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                       ))
                     )}
                   </div>
-                </>
-              ) : (
-              <div className="home-list-group">
-                <div className="home-list-title">
-                  {friendsFilter === 'online'
-                    ? `Online Friends — ${onlineFriends.length}`
-                    : `All Friends — ${friends.length}`}
                 </div>
-                {socialBootstrapLoading ? (
-                  <div className="home-list-skeleton" aria-hidden="true">
-                    <div className="home-list-skeleton-row" />
-                    <div className="home-list-skeleton-row" />
-                    <div className="home-list-skeleton-row" />
-                  </div>
-                ) : visibleFriends.length === 0 ? (
-                  friends.length === 0 ? (
-                    <OnboardingCard
-                      title="Start your social graph"
-                      description="Add a friend or jump into the official Voxpery community so you have someone to message right away."
-                      actions={[
-                        {
-                          label: 'Add a friend',
-                          onClick: () => setFriendsFilter('requests'),
-                          icon: <MessageSquarePlus size={14} />,
-                        },
-                        {
-                          label: voxperyServer ? 'Open community' : 'Join community',
-                          onClick: () => {
-                            void openOfficialCommunity()
-                          },
-                          variant: 'secondary',
-                          icon: <Compass size={14} />,
-                        },
-                      ]}
-                    />
-                  ) : (
-                    <div className="home-empty-row">
+              ) : (
+                <div className="home-friends-scroll">
+                  <div className="home-list-group">
+                    <div className="home-list-title">
                       {friendsFilter === 'online'
-                        ? "No one's online right now."
-                        : 'No friends found for this view.'}
+                        ? `Online Friends — ${onlineFriends.length}`
+                        : `All Friends — ${friends.length}`}
                     </div>
-                  )
-                ) : (
-                  visibleFriends.map((friend) => {
-                    return (
-                      <div
-                        key={friend.id}
-                        className={`home-member-row is-clickable ${openingDmPeerId === friend.id ? 'is-loading' : ''}`}
-                        aria-disabled={openingDmPeerId === friend.id}
-                      >
-                        <button
-                          type="button"
-                          className="home-member-main"
-                          aria-label={`Message ${friend.username}`}
-                          disabled={openingDmPeerId === friend.id}
-                          onClick={() => void openMessageForFriend(friend.id)}
-                        >
-                          <div className={`home-member-avatar avatar-status-${['online', 'dnd', 'offline'].includes((friend.status ?? '').toLowerCase()) ? (friend.status ?? 'offline').toLowerCase() : 'offline'}`}>
-                            {friend.avatar_url ? (
-                              <img src={resolveAvatarUrl(friend.avatar_url) ?? ''} alt="" />
-                            ) : (
-                              friend.username.charAt(0).toUpperCase()
-                            )}
-                          </div>
-                          <div className="home-member-meta">
-                            <div>{friend.username}</div>
-                            <span>
-                              <span className={`home-presence-pill home-presence-pill-${normalizePresence(friend.status)}`}>
-                                <span className="home-presence-pill-dot" aria-hidden />
-                                {presenceLabel(friend.status)}
-                              </span>
-                            </span>
-                          </div>
-                        </button>
-                        <button
-                          type="button"
-                          className="home-member-action home-member-action--trailing danger"
-                          title="Remove friend"
-                          disabled={openingDmPeerId === friend.id}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setRemoveFriendTarget(friend)
-                          }}
-                        >
-                          <UserMinus size={15} />
-                        </button>
+                    {socialBootstrapLoading ? (
+                      <div className="home-list-skeleton" aria-hidden="true">
+                        <div className="home-list-skeleton-row" />
+                        <div className="home-list-skeleton-row" />
+                        <div className="home-list-skeleton-row" />
                       </div>
-                    )
-                  })
-                )}
-              </div>
+                    ) : visibleFriends.length === 0 ? (
+                      friends.length === 0 ? (
+                        <OnboardingCard
+                          title="Start your social graph"
+                          description="Add a friend or jump into the official Voxpery community so you have someone to message right away."
+                          actions={[
+                            {
+                              label: 'Add a friend',
+                              onClick: () => setFriendsFilter('requests'),
+                              icon: <MessageSquarePlus size={14} />,
+                            },
+                            {
+                              label: voxperyServer ? 'Open community' : 'Join community',
+                              onClick: () => {
+                                void openOfficialCommunity()
+                              },
+                              variant: 'secondary',
+                              icon: <Compass size={14} />,
+                            },
+                          ]}
+                        />
+                      ) : (
+                        <div className="home-empty-row">
+                          {friendsFilter === 'online'
+                            ? "No one's online right now."
+                            : 'No friends found for this view.'}
+                        </div>
+                      )
+                    ) : (
+                      visibleFriends.map((friend) => {
+                        return (
+                          <div
+                            key={friend.id}
+                            className={`home-member-row is-clickable ${openingDmPeerId === friend.id ? 'is-loading' : ''}`}
+                            aria-disabled={openingDmPeerId === friend.id}
+                          >
+                            <button
+                              type="button"
+                              className="home-member-main"
+                              aria-label={`Message ${friend.username}`}
+                              disabled={openingDmPeerId === friend.id}
+                              onClick={() => void openMessageForFriend(friend.id)}
+                            >
+                              <div className={`home-member-avatar avatar-status-${['online', 'dnd', 'offline'].includes((friend.status ?? '').toLowerCase()) ? (friend.status ?? 'offline').toLowerCase() : 'offline'}`}>
+                                {friend.avatar_url ? (
+                                  <img src={resolveAvatarUrl(friend.avatar_url) ?? ''} alt="" />
+                                ) : (
+                                  friend.username.charAt(0).toUpperCase()
+                                )}
+                              </div>
+                              <div className="home-member-meta">
+                                <div>{friend.username}</div>
+                                <span>
+                                  <span className={`home-presence-pill home-presence-pill-${normalizePresence(friend.status)}`}>
+                                    <span className="home-presence-pill-dot" aria-hidden />
+                                    {presenceLabel(friend.status)}
+                                  </span>
+                                </span>
+                              </div>
+                            </button>
+                            <button
+                              type="button"
+                              className="home-member-action home-member-action--trailing danger"
+                              title="Remove friend"
+                              disabled={openingDmPeerId === friend.id}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                setRemoveFriendTarget(friend)
+                              }}
+                            >
+                              <UserMinus size={15} />
+                            </button>
+                          </div>
+                        )
+                      })
+                    )}
+                  </div>
+                </div>
               )}
             </>
           )}


### PR DESCRIPTION
Summary

Fix Friends page scrolling and tab label clipping.

Changes

- Added a dedicated scroll region for Friends content so Online, All, and Requests lists remain usable with many entries.
- Kept the Friends tab row fixed while list/request content scrolls underneath.
- Fixed tight tab label line-height that clipped descenders like the `q` in Requests.

Validation

- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .