### PR TITLE
fix: keep friends list above bottom dock

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7003,7 +7003,6 @@ body {
 
 .home-friends-scroll {
   flex: 1 1 auto;
-  height: 100%;
   min-width: 0;
   min-height: 0;
   overflow-x: hidden;
@@ -7013,7 +7012,7 @@ body {
   scrollbar-width: thin;
   scrollbar-color: rgba(122, 170, 231, 0.36) transparent;
   padding-right: 2px;
-  padding-bottom: 16px;
+  padding-bottom: calc(16px + 80px);
 }
 
 .home-friends-scroll::-webkit-scrollbar {
@@ -13313,6 +13312,11 @@ textarea {
     min-height: max-content;
     overflow: visible;
     padding-bottom: calc(12px + var(--mobile-bottom-dock-height) + env(safe-area-inset-bottom, 0px));
+  }
+
+  .home-friends-scroll {
+    padding-bottom: 16px;
+    scrollbar-gutter: auto;
   }
 
   .home-main-dm .social-content-dm {


### PR DESCRIPTION
## Summary

Fix Friends list clipping behind the bottom dock in production.

## Changes

- Let the Friends list scroll area use flex sizing instead of forcing `height: 100%`.
- Add desktop bottom safe space so the last Friends/Requests rows can scroll above the bottom dock.
- Keep mobile spacing unchanged because mobile already pads the outer Friends container for the bottom dock.

## Validation

- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .