### PR TITLE
feat: add friend dm action button

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7352,6 +7352,14 @@ body {
   color: #94a3b8;
 }
 
+.home-member-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 .home-member-action {
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 6px;
@@ -7366,13 +7374,23 @@ body {
   cursor: pointer;
 }
 
+.home-member-action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.home-member-action:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.65);
+  outline-offset: 2px;
+}
+
 .home-member-action:hover {
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-.home-member-action--trailing {
-  margin-left: auto;
+.home-member-action--message:hover {
+  color: var(--text-primary);
 }
 
 .home-member-action.danger {

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -152,6 +152,20 @@ describe('HomePage friends list', () => {
     expect(screen.getByTestId('dm-chat')).not.toBeNull()
   })
 
+  it('opens a DM from the friend action button', async () => {
+    apiMocks.getOrCreateDmChannel.mockResolvedValue(dmChannel('dm-cilo'))
+
+    renderHomePage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open DM with cilo' }))
+
+    await waitFor(() => {
+      expect(apiMocks.getOrCreateDmChannel).toHaveBeenCalledWith('friend-cilo', null)
+      expect(useAppStore.getState().activeDmChannelId).toBe('dm-cilo')
+    })
+    expect(screen.getByTestId('dm-chat')).not.toBeNull()
+  })
+
   it('shows a toast when opening a DM fails', async () => {
     apiMocks.getOrCreateDmChannel.mockRejectedValue(new Error('Could not create DM'))
 

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { Activity, ArrowRight, Check, Coffee, Compass, Github, Inbox, MessageSquarePlus, Send, UserMinus, Users, X } from 'lucide-react'
+import { Activity, ArrowRight, Check, Coffee, Compass, Github, Inbox, MessageCircle, MessageSquarePlus, Send, UserMinus, Users, X } from 'lucide-react'
 import {
   attachmentApi,
   dmApi,
@@ -1202,18 +1202,33 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                                 </span>
                               </div>
                             </button>
-                            <button
-                              type="button"
-                              className="home-member-action home-member-action--trailing danger"
-                              title="Remove friend"
-                              disabled={openingDmPeerId === friend.id}
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                setRemoveFriendTarget(friend)
-                              }}
-                            >
-                              <UserMinus size={15} />
-                            </button>
+                            <div className="home-member-actions">
+                              <button
+                                type="button"
+                                className="home-member-action home-member-action--message"
+                                title="Send message"
+                                aria-label={`Open DM with ${friend.username}`}
+                                disabled={openingDmPeerId === friend.id}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  void openMessageForFriend(friend.id)
+                                }}
+                              >
+                                <MessageCircle size={15} />
+                              </button>
+                              <button
+                                type="button"
+                                className="home-member-action danger"
+                                title="Remove friend"
+                                disabled={openingDmPeerId === friend.id}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  setRemoveFriendTarget(friend)
+                                }}
+                              >
+                                <UserMinus size={15} />
+                              </button>
+                            </div>
                           </div>
                         )
                       })


### PR DESCRIPTION
## Summary

Add an explicit DM action button to each Friends list row.

## Changes

- Added a neutral message icon action next to the existing remove-friend action.
- Kept remove-friend as the rightmost danger action.
- Added accessibility labels and a test for opening DMs from the new action button.

## Validation

- npm run test:run -- HomePage.test.tsx
- npm run lint
- npm run build
- npm run test:run
- git diff --check