### PR TITLE
test: add mocked core ui smoke coverage

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -12,6 +12,8 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
 
 # Editor directories and files
 .vscode/*

--- a/apps/web/TESTING.md
+++ b/apps/web/TESTING.md
@@ -22,9 +22,20 @@ E2E (Playwright):
 
 ```bash
 npm run test:e2e
+npm run test:e2e:ui-smoke
 npm run test:e2e:ui
 npm run test:e2e:headed
 ```
+
+Mocked core UI smoke:
+
+```bash
+npm run test:e2e:ui-smoke
+```
+
+This Playwright suite runs against the real Vite UI with mocked API and WebSocket
+responses, so it does not require a backend. Use it as the fast PR guard for
+Friends, Requests, DM, and responsive shell regressions.
 
 ## Backend (`apps/server`)
 

--- a/apps/web/e2e/core-ui-smoke.spec.ts
+++ b/apps/web/e2e/core-ui-smoke.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Locator } from '@playwright/test'
+import {
+  buildFriends,
+  buildRequests,
+  createMockCoreState,
+  installMockCoreApi,
+} from './mock-core-api'
+
+test.describe('mocked core UI smoke', () => {
+  test('keeps Friends tabs scrollable and friend actions reachable', async ({ page }) => {
+    const state = createMockCoreState({
+      friends: buildFriends(30),
+      incomingRequests: buildRequests(36, 'incoming'),
+      outgoingRequests: buildRequests(30, 'outgoing'),
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+
+    await expect(page.getByRole('button', { name: /Online/ })).toBeVisible()
+    await expect(page.getByText('Online Friends — 30')).toBeVisible()
+    await expectScrollable(page.locator('.home-friends-scroll').first())
+
+    await page.getByRole('button', { name: /All/ }).click()
+    await expect(page.getByText('All Friends — 30')).toBeVisible()
+    await expectScrollable(page.locator('.home-friends-scroll').first())
+    await expect(page.getByRole('button', { name: 'Open DM with Friend 01' })).toBeVisible()
+
+    const allScroller = page.locator('.home-friends-scroll').first()
+    await allScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
+    await expect(page.getByText('Friend 30')).toBeVisible()
+
+    await page.getByRole('button', { name: /Requests/ }).click()
+    const requestScroller = page.locator('.home-friends-scroll--requests')
+    await expect(page.getByText('Incoming')).toBeVisible()
+    await expect(page.getByText('Outgoing')).toBeVisible()
+    await expectScrollable(requestScroller)
+
+    await requestScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
+    await expect(page.getByText('Request Out 30')).toBeVisible()
+  })
+
+  test('opens a DM from the Friends action button and sends a message', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(8) })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: /All/ }).click()
+    await page.getByRole('button', { name: 'Open DM with Friend 01' }).click()
+
+    await expect(page).toHaveURL(/\/social\/dm/)
+    const messageInput = page.getByPlaceholder('Message @Friend 01')
+    await expect(messageInput).toBeVisible()
+
+    const content = `Mocked smoke message ${Date.now()}`
+    await messageInput.fill(content)
+    await messageInput.press('Enter')
+
+    await expect(page.getByText(content)).toBeVisible()
+    expect(state.dmMessagesByChannelId['dm-friend-01']?.some((message) => message.content === content)).toBe(true)
+  })
+
+  test('keeps the Friends surface usable on mobile viewport', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(18) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 390, height: 760 })
+
+    await page.goto('/social')
+
+    await expect(page.getByRole('button', { name: /Online/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /All/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Requests/ })).toBeVisible()
+
+    await page.getByRole('button', { name: /All/ }).click()
+    await expect(page.getByRole('button', { name: 'Open DM with Friend 01' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Message Friend 01' })).toBeVisible()
+
+    const hasHorizontalOverflow = await page.locator('.home-main').evaluate((element) => {
+      return element.scrollWidth > element.clientWidth + 1
+    })
+    expect(hasHorizontalOverflow).toBe(false)
+  })
+})
+
+async function expectScrollable(locator: Locator) {
+  await expect.poll(async () => {
+    return locator.evaluate((element) => element.scrollHeight > element.clientHeight)
+  }).toBe(true)
+}

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -1,0 +1,330 @@
+import type { Page, Route } from '@playwright/test'
+import type {
+  DmChannel,
+  Friend,
+  FriendRequest,
+  MessageWithAuthor,
+  Server,
+  SystemFeatures,
+  UserPublic,
+} from '../src/api'
+
+const AUTH_STORAGE_KEY = 'voxpery-auth'
+
+export interface MockCoreState {
+  user: UserPublic
+  friends: Friend[]
+  incomingRequests: FriendRequest[]
+  outgoingRequests: FriendRequest[]
+  dmChannels: DmChannel[]
+  dmMessagesByChannelId: Record<string, MessageWithAuthor[]>
+  servers: Server[]
+}
+
+const DEFAULT_FEATURES: SystemFeatures = {
+  google_oauth_enabled: false,
+  email_delivery_enabled: false,
+  email_verification_enabled: false,
+  email_verification_required: false,
+  password_reset_enabled: false,
+}
+
+export function buildFriends(count: number): Friend[] {
+  return Array.from({ length: count }, (_, index) => {
+    const n = index + 1
+    return {
+      id: `friend-${String(n).padStart(2, '0')}`,
+      username: `Friend ${String(n).padStart(2, '0')}`,
+      avatar_url: null,
+      status: n % 3 === 0 ? 'dnd' : 'online',
+    }
+  })
+}
+
+export function buildRequests(count: number, direction: 'incoming' | 'outgoing'): FriendRequest[] {
+  return Array.from({ length: count }, (_, index) => {
+    const n = index + 1
+    const label = `${direction === 'incoming' ? 'Request In' : 'Request Out'} ${String(n).padStart(2, '0')}`
+    return {
+      id: `${direction}-request-${String(n).padStart(2, '0')}`,
+      requester_id: direction === 'incoming' ? `requester-${n}` : 'user-local',
+      receiver_id: direction === 'incoming' ? 'user-local' : `receiver-${n}`,
+      requester_username: direction === 'incoming' ? label : 'You',
+      receiver_username: direction === 'incoming' ? 'You' : label,
+      status: 'pending',
+      created_at: new Date(Date.UTC(2026, 0, n)).toISOString(),
+    }
+  })
+}
+
+export function createMockCoreState(overrides: Partial<MockCoreState> = {}): MockCoreState {
+  const user: UserPublic = {
+    id: 'user-local',
+    username: 'localuser',
+    email: 'localuser@example.test',
+    email_verified: true,
+    avatar_url: undefined,
+    status: 'online',
+    dm_privacy: 'friends',
+    google_connected: false,
+    has_password: true,
+    username_changed_at: null,
+  }
+
+  return {
+    user,
+    friends: buildFriends(24),
+    incomingRequests: buildRequests(10, 'incoming'),
+    outgoingRequests: buildRequests(8, 'outgoing'),
+    dmChannels: [],
+    dmMessagesByChannelId: {},
+    servers: [],
+    ...overrides,
+  }
+}
+
+export async function installMockCoreApi(page: Page, state: MockCoreState = createMockCoreState()) {
+  await page.addInitScript(
+    ({ authStorageKey, user }) => {
+      window.localStorage.setItem(
+        authStorageKey,
+        JSON.stringify({
+          state: { token: null, user },
+          version: 2,
+        }),
+      )
+      window.localStorage.removeItem('voxpery-hidden-dm-peers')
+      window.sessionStorage.clear()
+
+      class MockWebSocket extends EventTarget {
+        static CONNECTING = 0
+        static OPEN = 1
+        static CLOSING = 2
+        static CLOSED = 3
+
+        readyState = MockWebSocket.CONNECTING
+        onopen: ((event: Event) => void) | null = null
+        onclose: ((event: CloseEvent) => void) | null = null
+        onmessage: ((event: MessageEvent) => void) | null = null
+        onerror: ((event: Event) => void) | null = null
+
+        constructor() {
+          super()
+          window.setTimeout(() => {
+            this.readyState = MockWebSocket.OPEN
+            const event = new Event('open')
+            this.onopen?.(event)
+            this.dispatchEvent(event)
+          }, 0)
+        }
+
+        send() {}
+
+        close() {
+          this.readyState = MockWebSocket.CLOSED
+          const event = new CloseEvent('close', { code: 1000, reason: 'mock closed' })
+          this.onclose?.(event)
+          this.dispatchEvent(event)
+        }
+      }
+
+      Object.defineProperty(window, 'WebSocket', {
+        configurable: true,
+        writable: true,
+        value: MockWebSocket,
+      })
+    },
+    { authStorageKey: AUTH_STORAGE_KEY, user: state.user },
+  )
+
+  await page.route('http://localhost:3001/**', async (route) => {
+    await handleMockApiRoute(route, state)
+  })
+}
+
+async function handleMockApiRoute(route: Route, state: MockCoreState) {
+  const request = route.request()
+  const url = new URL(request.url())
+  const method = request.method()
+  const pathname = url.pathname
+
+  if (pathname === '/health') {
+    await route.fulfill({ status: 200, contentType: 'text/plain', body: 'ok' })
+    return
+  }
+
+  if (pathname === '/api/system/features' && method === 'GET') {
+    await json(route, DEFAULT_FEATURES)
+    return
+  }
+
+  if (pathname === '/api/auth/me' && method === 'GET') {
+    await json(route, state.user)
+    return
+  }
+
+  if (pathname === '/api/servers' && method === 'GET') {
+    await json(route, state.servers)
+    return
+  }
+
+  if (pathname === '/api/friends' && method === 'GET') {
+    await json(route, state.friends)
+    return
+  }
+
+  if (pathname === '/api/friends/requests' && method === 'GET') {
+    await json(route, {
+      incoming: state.incomingRequests,
+      outgoing: state.outgoingRequests,
+    })
+    return
+  }
+
+  if (pathname === '/api/friends/requests' && method === 'POST') {
+    const body = request.postDataJSON() as { username?: string }
+    const next = buildRequests(1, 'outgoing')[0]
+    state.outgoingRequests = [
+      { ...next, id: `outgoing-request-${Date.now()}`, receiver_username: body.username ?? 'New Friend' },
+      ...state.outgoingRequests,
+    ]
+    await json(route, {})
+    return
+  }
+
+  const acceptMatch = pathname.match(/^\/api\/friends\/requests\/([^/]+)\/accept$/)
+  if (acceptMatch && method === 'POST') {
+    const requestId = acceptMatch[1]
+    const accepted = state.incomingRequests.find((item) => item.id === requestId)
+    state.incomingRequests = state.incomingRequests.filter((item) => item.id !== requestId)
+    if (accepted) {
+      state.friends = [
+        {
+          id: accepted.requester_id,
+          username: accepted.requester_username,
+          avatar_url: null,
+          status: 'online',
+        },
+        ...state.friends,
+      ]
+    }
+    await json(route, {})
+    return
+  }
+
+  const rejectMatch = pathname.match(/^\/api\/friends\/requests\/([^/]+)\/reject$/)
+  if (rejectMatch && method === 'POST') {
+    const requestId = rejectMatch[1]
+    state.incomingRequests = state.incomingRequests.filter((item) => item.id !== requestId)
+    state.outgoingRequests = state.outgoingRequests.filter((item) => item.id !== requestId)
+    await json(route, {})
+    return
+  }
+
+  const removeFriendMatch = pathname.match(/^\/api\/friends\/([^/]+)$/)
+  if (removeFriendMatch && method === 'DELETE') {
+    const friendId = removeFriendMatch[1]
+    state.friends = state.friends.filter((friend) => friend.id !== friendId)
+    await json(route, {})
+    return
+  }
+
+  if (pathname === '/api/dm/channels' && method === 'GET') {
+    await json(route, state.dmChannels)
+    return
+  }
+
+  const createDmMatch = pathname.match(/^\/api\/dm\/channels\/([^/]+)$/)
+  if (createDmMatch && method === 'POST') {
+    const peerId = createDmMatch[1]
+    const friend = state.friends.find((item) => item.id === peerId)
+    const channel = upsertDmChannel(state, {
+      id: `dm-${peerId}`,
+      peer_id: peerId,
+      peer_username: friend?.username ?? 'Unknown Friend',
+      peer_avatar_url: friend?.avatar_url ?? null,
+      peer_status: friend?.status ?? 'offline',
+      last_message_at: null,
+      unread_count: 0,
+    })
+    await json(route, channel)
+    return
+  }
+
+  const dmReadStateMatch = pathname.match(/^\/api\/dm\/channels\/([^/]+)\/read-state$/)
+  if (dmReadStateMatch && method === 'GET') {
+    await json(route, { peer_last_read_message_id: null })
+    return
+  }
+
+  const dmReadMatch = pathname.match(/^\/api\/dm\/channels\/([^/]+)\/read$/)
+  if (dmReadMatch && method === 'POST') {
+    await json(route, {})
+    return
+  }
+
+  const dmPinsMatch = pathname.match(/^\/api\/dm\/channels\/([^/]+)\/pins$/)
+  if (dmPinsMatch && method === 'GET') {
+    await json(route, [])
+    return
+  }
+
+  const dmMessagesMatch = pathname.match(/^\/api\/dm\/messages\/([^/]+)$/)
+  if (dmMessagesMatch && method === 'GET') {
+    await json(route, state.dmMessagesByChannelId[dmMessagesMatch[1]] ?? [])
+    return
+  }
+
+  if (dmMessagesMatch && method === 'POST') {
+    const channelId = dmMessagesMatch[1]
+    const body = request.postDataJSON() as { content?: string; attachments?: unknown[] }
+    const message = createDmMessage(state, channelId, body.content ?? '', body.attachments ?? [])
+    state.dmMessagesByChannelId[channelId] = [
+      ...(state.dmMessagesByChannelId[channelId] ?? []),
+      message,
+    ]
+    await json(route, message)
+    return
+  }
+
+  await json(route, { error: `Unhandled mocked endpoint: ${method} ${pathname}` }, 404)
+}
+
+function upsertDmChannel(state: MockCoreState, channel: DmChannel): DmChannel {
+  state.dmChannels = [channel, ...state.dmChannels.filter((item) => item.id !== channel.id)]
+  if (!state.dmMessagesByChannelId[channel.id]) {
+    state.dmMessagesByChannelId[channel.id] = []
+  }
+  return channel
+}
+
+function createDmMessage(
+  state: MockCoreState,
+  channelId: string,
+  content: string,
+  attachments: unknown[],
+): MessageWithAuthor {
+  return {
+    id: `message-${channelId}-${Date.now()}`,
+    channel_id: channelId,
+    content,
+    attachments: attachments as MessageWithAuthor['attachments'],
+    reactions: [],
+    edited_at: null,
+    created_at: new Date().toISOString(),
+    author: {
+      user_id: state.user.id,
+      username: state.user.username,
+      avatar_url: state.user.avatar_url,
+      role_color: null,
+    },
+  }
+}
+
+async function json(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts --project=chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7028,6 +7028,10 @@ body {
   background: rgba(122, 170, 231, 0.48);
 }
 
+.home-friends-scroll>.home-list-group {
+  flex: 0 0 auto;
+}
+
 .home-friends-scroll--requests {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Add a mocked Playwright core UI smoke suite for fast frontend regression coverage.

## Changes

- Added backend-free mocked API and WebSocket helpers for Playwright.
- Added core UI smoke tests for Friends tabs, Requests scrolling, DM open/send, and mobile Friends layout.
- Added `npm run test:e2e:ui-smoke` as a fast Chromium-only PR guard.
- Ignored Playwright generated report/result folders.
- Fixed a Requests tab clipping issue caught by the new smoke test by preventing Friends list groups from shrinking inside the scroll container.

## Validation

- npm run test:e2e:ui-smoke
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .