### PR TITLE
test: cover core component regressions

### DIFF
--- a/apps/web/e2e/core-ui-smoke.spec.ts
+++ b/apps/web/e2e/core-ui-smoke.spec.ts
@@ -131,6 +131,143 @@ test.describe('mocked core UI smoke', () => {
     expect(hasHorizontalOverflow).toBe(false)
   })
 
+  test('creates a channel from the sidebar and makes it selectable', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const state = createMockCoreState({
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: {},
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/servers')
+    await page.locator('.channel-create-btn[title="Create Channel"]').click()
+
+    const modal = page.locator('.modal-create-channel')
+    await expect(modal.getByRole('heading', { name: 'Create Channel' })).toBeVisible()
+    await modal.getByPlaceholder('e.g. general').fill('raid-notes')
+    await modal.locator('input[list="channel-category-suggestions"]').fill('PLANNING')
+    await modal.getByPlaceholder('What is this channel for?').fill('Planning notes used by the smoke test.')
+    await modal.getByRole('button', { name: 'Create Channel' }).click()
+
+    await expect(modal).toBeHidden()
+    const createdChannel = state.channelsByServerId[server.id].find((channel) => channel.name === 'raid-notes')
+    expect(createdChannel).toBeTruthy()
+
+    await page.locator('.channel-item', { hasText: 'raid-notes' }).click()
+    await expect(page.locator('.chat-header .channel-title')).toHaveText('raid-notes')
+    await expect(page.getByPlaceholder('Message #raid-notes')).toBeVisible()
+  })
+
+  test('keeps quick switcher navigation wired to channels and DMs', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const state = createMockCoreState({
+      friends: buildFriends(4),
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: {},
+      dmChannels: [{
+        id: 'dm-friend-01',
+        peer_id: 'friend-01',
+        peer_username: 'Friend 01',
+        peer_avatar_url: null,
+        peer_status: 'online',
+        last_message_at: null,
+        unread_count: 0,
+      }],
+      dmMessagesByChannelId: { 'dm-friend-01': [] },
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/servers')
+    await page.getByTitle('Search servers, channels, and direct messages').click()
+    await page.getByPlaceholder('Search servers, channels, and direct messages').fill('announcements')
+    await page.getByRole('button', { name: /# announcements/ }).click()
+
+    await expect(page).toHaveURL(/\/servers/)
+    await expect(page.locator('.chat-header .channel-title')).toHaveText('announcements')
+
+    await page.getByTitle('Search servers, channels, and direct messages').click()
+    await page.getByPlaceholder('Search servers, channels, and direct messages').fill('Friend 01')
+    await page.getByRole('button', { name: /Friend 01/ }).click()
+
+    await expect(page).toHaveURL(/\/social\/dm/)
+    await expect(page.getByPlaceholder('Message @Friend 01')).toBeVisible()
+  })
+
+  test('keeps message actions wired for edit, reaction, pin, search, and delete', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const general = channels.find((channel) => channel.name === 'general')
+    if (!general) throw new Error('Core channel fixture is incomplete.')
+
+    const state = createMockCoreState({
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: {
+        [general.id]: [
+          buildServerMessage(general.id, 'Remote searchable topic', { id: 'friend-message' }),
+          buildServerMessage(general.id, 'Local editable note', {
+            id: 'own-message',
+            author: {
+              user_id: 'user-local',
+              username: 'localuser',
+              avatar_url: undefined,
+              role_color: '#93c5fd',
+            },
+          }),
+        ],
+      },
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/servers')
+    const ownRow = page.locator('[data-message-id="own-message"]')
+    const friendRow = page.locator('[data-message-id="friend-message"]')
+    await expect(ownRow).toBeVisible()
+    await expect(friendRow).toBeVisible()
+
+    await ownRow.hover()
+    await ownRow.getByRole('button', { name: 'Edit' }).click()
+    await ownRow.locator('input.home-search').fill('Edited local note')
+    await ownRow.getByTitle('Save').click()
+    await expect(page.getByText('Edited local note')).toBeVisible()
+    expect(state.messagesByChannelId[general.id].some((message) => message.content === 'Edited local note')).toBe(true)
+
+    await friendRow.hover()
+    await friendRow.getByRole('button', { name: 'Add reaction' }).click()
+    await page.getByRole('button', { name: 'thumbs up' }).click()
+    await expect(friendRow.locator('.message-reaction-btn')).toContainText('👍')
+    await expect(friendRow.locator('.message-reaction-btn')).toContainText('1')
+
+    await friendRow.hover()
+    await friendRow.getByRole('button', { name: 'Pin' }).click()
+    await page.getByRole('button', { name: 'Pinned messages' }).click()
+    await expect(page.locator('.chat-header-pinned-dropdown')).toContainText('Remote searchable topic')
+
+    await page.getByRole('button', { name: 'Pinned messages' }).click()
+    await page.getByRole('button', { name: 'Search in conversation' }).click()
+    await page.getByRole('textbox', { name: 'Search messages' }).fill('Remote searchable')
+    await expect(page.getByText('Remote searchable topic')).toBeVisible()
+    await expect(page.getByText('Edited local note')).toBeHidden()
+    await page.getByRole('button', { name: 'Close search' }).click()
+
+    await ownRow.hover()
+    await ownRow.getByRole('button', { name: 'Delete' }).click()
+    const confirmModal = page.locator('.confirm-modal', { hasText: 'Delete message' })
+    await confirmModal.getByRole('button', { name: 'Delete' }).click()
+    await expect(page.getByText('Edited local note')).toBeHidden()
+    expect(state.messagesByChannelId[general.id].some((message) => message.id === 'own-message')).toBe(false)
+  })
+
   test('opens Voice & Audio settings without overflowing the settings modal', async ({ page }) => {
     const state = createMockCoreState({ friends: buildFriends(3) })
     await installMockCoreApi(page, state)
@@ -186,6 +323,38 @@ test.describe('mocked core UI smoke', () => {
       return element.scrollWidth > element.clientWidth + 1
     })
     expect(hasHorizontalOverflow).toBe(false)
+  })
+
+  test('keeps the mobile member sheet usable from a server channel', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const state = createMockCoreState({
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: {},
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 390, height: 760 })
+
+    await page.goto('/servers')
+    await expect(page.locator('.chat-header .channel-title')).toHaveText('general')
+    await page.getByRole('button', { name: 'View members' }).click()
+
+    const sheet = page.locator('.mobile-member-sheet')
+    await expect(sheet).toBeVisible()
+    await expect(sheet.getByRole('heading', { name: 'Members' })).toBeVisible()
+    await expect(sheet).toContainText('2 members')
+    await expect(sheet).toContainText('localuser')
+    await expect(sheet).toContainText('Friend 01')
+
+    const hasHorizontalOverflow = await page.locator('.shell-layout').evaluate((element) => {
+      return element.scrollWidth > element.clientWidth + 1
+    })
+    expect(hasHorizontalOverflow).toBe(false)
+
+    await sheet.getByRole('button', { name: 'Close members panel' }).click()
+    await expect(sheet).toBeHidden()
   })
 })
 

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -25,6 +25,7 @@ export interface MockCoreState {
   channelsByServerId: Record<string, Channel[]>
   membersByServerId: Record<string, MemberInfo[]>
   messagesByChannelId: Record<string, MessageWithAuthor[]>
+  pinnedMessageIdsByChannelId: Record<string, string[]>
 }
 
 const DEFAULT_FEATURES: SystemFeatures = {
@@ -181,6 +182,7 @@ export function createMockCoreState(overrides: Partial<MockCoreState> = {}): Moc
     channelsByServerId: {},
     membersByServerId: {},
     messagesByChannelId: {},
+    pinnedMessageIdsByChannelId: {},
     ...overrides,
   }
 }
@@ -349,6 +351,33 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
     return
   }
 
+  if (pathname === '/api/channels' && method === 'POST') {
+    const body = request.postDataJSON() as {
+      server_id?: string
+      name?: string
+      description?: string
+      channel_type?: 'text' | 'voice'
+      category?: string
+    }
+    const serverId = body.server_id ?? state.servers[0]?.id ?? 'server-core'
+    const existing = state.channelsByServerId[serverId] ?? []
+    const name = body.name?.trim() || 'new-channel'
+    const channel: Channel = {
+      id: `${serverId}-${slugifyChannelName(name)}-${Date.now()}`,
+      server_id: serverId,
+      name,
+      description: body.description?.trim() || null,
+      channel_type: body.channel_type === 'voice' ? 'voice' : 'text',
+      category: body.category?.trim() || 'GENERAL',
+      position: existing.length,
+      my_permissions: ALL_PERMISSIONS,
+    }
+    state.channelsByServerId[serverId] = [...existing, channel]
+    state.messagesByChannelId[channel.id] = state.messagesByChannelId[channel.id] ?? []
+    await json(route, channel)
+    return
+  }
+
   if (pathname === '/api/webrtc/turn-credentials' && method === 'GET') {
     await json(route, { urls: [] })
     return
@@ -495,18 +524,95 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
 
   const serverPinsMatch = pathname.match(/^\/api\/messages\/([^/]+)\/pins$/)
   if (serverPinsMatch && method === 'GET') {
-    await json(route, [])
+    const channelId = serverPinsMatch[1]
+    const pinnedIds = new Set(state.pinnedMessageIdsByChannelId[channelId] ?? [])
+    const pins = (state.messagesByChannelId[channelId] ?? []).filter((message) => pinnedIds.has(message.id))
+    await json(route, pins)
     return
   }
 
   if (serverPinsMatch && method === 'POST') {
-    await json(route, buildServerMessage(serverPinsMatch[1], 'Pinned smoke message'))
+    const channelId = serverPinsMatch[1]
+    const body = request.postDataJSON() as { message_id?: string }
+    const messageId = body.message_id ?? ''
+    const message = findServerMessage(state, messageId)
+    if (!message) {
+      await json(route, { error: 'Message not found' }, 404)
+      return
+    }
+    const currentPins = state.pinnedMessageIdsByChannelId[channelId] ?? []
+    state.pinnedMessageIdsByChannelId[channelId] = Array.from(new Set([...currentPins, messageId]))
+    await json(route, message)
     return
   }
 
   const serverPinDeleteMatch = pathname.match(/^\/api\/messages\/([^/]+)\/pins\/([^/]+)$/)
   if (serverPinDeleteMatch && method === 'DELETE') {
+    const channelId = serverPinDeleteMatch[1]
+    const messageId = serverPinDeleteMatch[2]
+    state.pinnedMessageIdsByChannelId[channelId] = (state.pinnedMessageIdsByChannelId[channelId] ?? [])
+      .filter((id) => id !== messageId)
     await json(route, {})
+    return
+  }
+
+  const messageReactionMatch = pathname.match(/^\/api\/messages\/item\/([^/]+)\/reactions$/)
+  if (messageReactionMatch && (method === 'POST' || method === 'DELETE')) {
+    const messageId = messageReactionMatch[1]
+    const message = findServerMessage(state, messageId)
+    if (!message) {
+      await json(route, { error: 'Message not found' }, 404)
+      return
+    }
+    const emoji = method === 'POST'
+      ? ((request.postDataJSON() as { emoji?: string }).emoji ?? '')
+      : (url.searchParams.get('emoji') ?? '')
+    const existingReactions = message.reactions ?? []
+    if (method === 'POST') {
+      const current = existingReactions.find((reaction) => reaction.emoji === emoji)
+      message.reactions = current
+        ? existingReactions.map((reaction) =>
+          reaction.emoji === emoji
+            ? { ...reaction, count: Math.max(reaction.count, 0) + (reaction.reacted ? 0 : 1), reacted: true }
+            : reaction,
+        )
+        : [...existingReactions, { emoji, count: 1, reacted: true }]
+    } else {
+      message.reactions = existingReactions
+        .map((reaction) =>
+          reaction.emoji === emoji
+            ? { ...reaction, count: Math.max(reaction.count - (reaction.reacted ? 1 : 0), 0), reacted: false }
+            : reaction,
+        )
+        .filter((reaction) => reaction.count > 0)
+    }
+    await json(route, message)
+    return
+  }
+
+  const messageItemMatch = pathname.match(/^\/api\/messages\/item\/([^/]+)$/)
+  if (messageItemMatch && method === 'PATCH') {
+    const messageId = messageItemMatch[1]
+    const message = findServerMessage(state, messageId)
+    if (!message) {
+      await json(route, { error: 'Message not found' }, 404)
+      return
+    }
+    const body = request.postDataJSON() as { content?: string }
+    message.content = body.content ?? message.content
+    message.edited_at = new Date().toISOString()
+    await json(route, message)
+    return
+  }
+
+  if (messageItemMatch && method === 'DELETE') {
+    const messageId = messageItemMatch[1]
+    for (const [channelId, messages] of Object.entries(state.messagesByChannelId)) {
+      state.messagesByChannelId[channelId] = messages.filter((message) => message.id !== messageId)
+      state.pinnedMessageIdsByChannelId[channelId] = (state.pinnedMessageIdsByChannelId[channelId] ?? [])
+        .filter((id) => id !== messageId)
+    }
+    await json(route, { message: 'deleted', id: messageId })
     return
   }
 
@@ -583,6 +689,23 @@ function createServerMessage(
       role_color: '#93c5fd',
     },
   }
+}
+
+function slugifyChannelName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'channel'
+}
+
+function findServerMessage(state: MockCoreState, messageId: string): MessageWithAuthor | null {
+  for (const messages of Object.values(state.messagesByChannelId)) {
+    const message = messages.find((entry) => entry.id === messageId)
+    if (message) return message
+  }
+  return null
 }
 
 async function json(route: Route, body: unknown, status = 200) {


### PR DESCRIPTION
## Summary
- Add core component UI regression coverage for channel creation, quick switcher navigation, message actions, and mobile member sheet.
- Extend the mocked Playwright API fixture with channel creation plus message edit/delete/reaction/pin state handling.
- Keep the existing friends, DM, server chat, settings, and voice smoke flows running in one core UI suite.

## Validation
- npm run test:e2e:ui-smoke
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .