### PR TITLE
ci: run core ui smoke on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   frontend:
     name: Checks / Frontend
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:
@@ -90,6 +90,23 @@ jobs:
       - name: Test
         working-directory: apps/web
         run: npm run test:run
+
+      - name: Install Playwright browsers
+        working-directory: apps/web
+        run: npx playwright install --with-deps chromium
+
+      - name: Core UI smoke
+        working-directory: apps/web
+        run: npm run test:e2e:ui-smoke
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-core-ui-smoke-playwright-report
+          path: apps/web/playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Build
         working-directory: apps/web

--- a/apps/web/TESTING.md
+++ b/apps/web/TESTING.md
@@ -35,7 +35,8 @@ npm run test:e2e:ui-smoke
 
 This Playwright suite runs against the real Vite UI with mocked API and WebSocket
 responses, so it does not require a backend. Use it as the fast PR guard for
-Friends, Requests, DM, and responsive shell regressions.
+Friends, Requests, DM, server chat, channel creation, quick switcher, message
+actions, voice settings, voice error recovery, and responsive shell regressions.
 
 ## Backend (`apps/server`)
 
@@ -72,10 +73,10 @@ Current workflows:
 - `.github/workflows/ci.yml`
   - Secret scan
   - Backend check/tests
-  - Frontend lint/build
+  - Frontend lint/unit tests/core UI smoke/build
 - `.github/workflows/dependency-security.yml`
   - Rust and npm dependency audits
 
 ---
 
-Last verified against code on 2026-03-14.
+Last verified against code on 2026-06-01.


### PR DESCRIPTION
## Summary
- Run the mocked core UI Playwright smoke suite as part of the frontend CI gate.
- Install Chromium for Playwright in CI and upload the Playwright report when the smoke gate fails.
- Update web testing documentation to reflect the v0.2.0 PR guard coverage.

## Validation
- npm run test:e2e:ui-smoke
- npm run lint
- npm run test:run
- npm run build
- git diff --check