### PR TITLE
ci: use immutable docker image tags for deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,31 @@ jobs:
         id: tags
         shell: bash
         run: |
+          short_sha="${GITHUB_SHA::12}"
+          sha_tag="sha-${short_sha}"
+
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "primary_tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            {
+              echo "display_tag=${GITHUB_REF_NAME}"
+              echo "backend_tags<<EOF"
+              echo "voxpery/voxpery-server:${GITHUB_REF_NAME}"
+              echo "voxpery/voxpery-server:${sha_tag}"
+              echo "EOF"
+              echo "frontend_tags<<EOF"
+              echo "voxpery/voxpery-web:${GITHUB_REF_NAME}"
+              echo "voxpery/voxpery-web:${sha_tag}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "primary_tag=latest" >> "$GITHUB_OUTPUT"
+            {
+              echo "display_tag=${sha_tag}"
+              echo "backend_tags<<EOF"
+              echo "voxpery/voxpery-server:${sha_tag}"
+              echo "EOF"
+              echo "frontend_tags<<EOF"
+              echo "voxpery/voxpery-web:${sha_tag}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push backend
@@ -158,7 +179,7 @@ jobs:
           context: ./apps/server
           file: ./apps/server/Dockerfile
           push: true
-          tags: voxpery/voxpery-server:${{ steps.tags.outputs.primary_tag }}
+          tags: ${{ steps.tags.outputs.backend_tags }}
           cache-from: type=gha,scope=${{ matrix.component }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}
 
@@ -169,10 +190,11 @@ jobs:
           context: ./apps/web
           file: ./apps/web/Dockerfile
           push: true
-          tags: voxpery/voxpery-web:${{ steps.tags.outputs.primary_tag }}
+          tags: ${{ steps.tags.outputs.frontend_tags }}
           build-args: |
             VITE_API_URL=${{ secrets.VITE_API_URL }}
             TURNSTILE_SITE_KEY_PUBLIC=${{ secrets.VITE_TURNSTILE_SITE_KEY }}
+            VITE_APP_VERSION=${{ steps.tags.outputs.display_tag }}
             APP_ENV=production
           cache-from: type=gha,scope=${{ matrix.component }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,24 @@ name: Manual Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+      release_channel:
+        description: 'What to deploy: latest release tag, current main candidate, or custom tag/ref'
+        required: true
+        default: latest-release
+        type: choice
+        options:
+          - latest-release
+          - main-candidate
+          - custom
+      image_tag:
+        description: 'Custom mode only: immutable Docker image tag, for example sha-abc123def456 or v0.2.0'
+        required: false
+        type: string
+      git_ref:
+        description: 'Custom mode only: Git ref to checkout on the server for compose/deployment files'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,16 +36,85 @@ jobs:
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5
+        env:
+          DEPLOY_RELEASE_CHANNEL: ${{ inputs.release_channel }}
+          DEPLOY_IMAGE_TAG: ${{ inputs.image_tag }}
+          DEPLOY_GIT_REF: ${{ inputs.git_ref }}
         with:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DEPLOY_RELEASE_CHANNEL,DEPLOY_IMAGE_TAG,DEPLOY_GIT_REF
           command_timeout: 25m
           script: |
             cd ~/voxpery
-            git fetch --prune origin "+refs/heads/main:refs/remotes/origin/main"
-            git checkout --detach refs/remotes/origin/main
-            IMAGE_TAG="latest"
+            RELEASE_CHANNEL="${DEPLOY_RELEASE_CHANNEL:-latest-release}"
+            IMAGE_TAG="${DEPLOY_IMAGE_TAG}"
+            GIT_REF="${DEPLOY_GIT_REF}"
+
+            git fetch --prune --tags origin "+refs/heads/*:refs/remotes/origin/*"
+
+            case "${RELEASE_CHANNEL}" in
+              latest-release)
+                GIT_REF="$(git for-each-ref refs/tags/v* --sort=-v:refname --format='%(refname:short)' | head -n 1)"
+                if [ -z "${GIT_REF}" ]; then
+                  echo "Refusing deploy: no v* release tags were found."
+                  exit 1
+                fi
+                IMAGE_TAG="${GIT_REF}"
+                ;;
+              main-candidate)
+                GIT_REF="${GIT_REF:-main}"
+                if git rev-parse --verify --quiet "refs/remotes/origin/${GIT_REF}" >/dev/null; then
+                  resolved_commit="$(git rev-parse "refs/remotes/origin/${GIT_REF}")"
+                else
+                  resolved_commit="$(git rev-parse "${GIT_REF}")"
+                fi
+                short_commit="$(printf '%s' "${resolved_commit}" | cut -c1-12)"
+                IMAGE_TAG="sha-${short_commit}"
+                ;;
+              custom)
+                if [ -z "${IMAGE_TAG}" ] || [ -z "${GIT_REF}" ]; then
+                  echo "Refusing deploy: custom mode requires both image_tag and git_ref."
+                  exit 1
+                fi
+                ;;
+              *)
+                echo "Refusing deploy: unsupported release_channel '${RELEASE_CHANNEL}'."
+                exit 1
+                ;;
+            esac
+
+            if [ -z "${IMAGE_TAG}" ] || [ "${IMAGE_TAG}" = "latest" ]; then
+              echo "Refusing deploy: image_tag must be an immutable tag, not '${IMAGE_TAG:-empty}'."
+              exit 1
+            fi
+
+            case "${IMAGE_TAG}" in
+              *[!A-Za-z0-9_.-]*)
+                echo "Refusing deploy: image_tag contains unsupported characters."
+                exit 1
+                ;;
+            esac
+
+            if [ -z "${GIT_REF}" ]; then
+              echo "Refusing deploy: git_ref is required."
+              exit 1
+            fi
+
+            case "${GIT_REF}" in
+              -*|*..*|*~*|*^*|*:*|*\\*|*[!A-Za-z0-9_./-]*)
+                echo "Refusing deploy: git_ref contains unsupported characters."
+                exit 1
+                ;;
+            esac
+
+            if git rev-parse --verify --quiet "refs/remotes/origin/${GIT_REF}" >/dev/null; then
+              git checkout --detach "refs/remotes/origin/${GIT_REF}"
+            else
+              git checkout --detach "${GIT_REF}"
+            fi
+
             docker compose --profile security config >/dev/null
             export VOXPERY_SERVER_IMAGE="voxpery/voxpery-server:${IMAGE_TAG}"
             export VOXPERY_WEB_IMAGE="voxpery/voxpery-web:${IMAGE_TAG}"
@@ -36,4 +123,4 @@ jobs:
             docker image prune -f
             curl -fsS http://127.0.0.1:3001/health >/dev/null
             curl -fsS http://127.0.0.1:${WEB_PORT:-5173}/healthz >/dev/null
-            echo "Deploy complete: ref=main image_tag=${IMAGE_TAG}"
+            echo "Deploy complete: release_channel=${RELEASE_CHANNEL} git_ref=${GIT_REF} commit=$(git rev-parse HEAD) image_tag=${IMAGE_TAG}"

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -9,9 +9,11 @@ COPY . .
 
 ARG VITE_API_URL=http://localhost:3001
 ARG TURNSTILE_SITE_KEY_PUBLIC=
+ARG VITE_APP_VERSION=
 
 RUN VITE_API_URL="${VITE_API_URL}" \
     VITE_TURNSTILE_SITE_KEY="${TURNSTILE_SITE_KEY_PUBLIC}" \
+    VITE_APP_VERSION="${VITE_APP_VERSION}" \
     npm run build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -377,6 +377,25 @@ body {
   box-shadow: 0 0 0 3px rgba(156, 194, 255, 0.22), 0 0 8px rgba(156, 194, 255, 0.3);
 }
 
+.shell-brand-version {
+  display: inline-flex;
+  align-items: center;
+  max-width: 112px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 171, 255, 0.22);
+  background: rgba(79, 127, 216, 0.12);
+  color: #dce8ff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+}
+
 .shell-brand-logo {
   display: block;
   object-fit: contain;
@@ -12597,7 +12616,8 @@ textarea {
     display: none;
   }
 
-  .shell-brand-beta {
+  .shell-brand-beta,
+  .shell-brand-version {
     display: none;
   }
 

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -29,6 +29,7 @@ import { ROUTES } from '../routes'
 import { setPersistedSocialView } from '../socialView'
 
 const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+const APP_VERSION = (import.meta.env.VITE_APP_VERSION ?? '').trim()
 
 export default function AppShell() {
   const { user } = useAuthStore()
@@ -582,6 +583,11 @@ export default function AppShell() {
             <img src="/1024.png" alt="" className="shell-brand-logo" width={32} height={32} />
             <span>Voxpery</span>
             <span className="shell-brand-beta" title="Preview build">Beta</span>
+            {APP_VERSION && (
+              <span className="shell-brand-version" title={`Running build ${APP_VERSION}`}>
+                {APP_VERSION}
+              </span>
+            )}
           </button>
         </div>
         <div className="shell-topbar-right">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       args:
         VITE_API_URL: ${VITE_API_URL:-http://localhost:3001}
         TURNSTILE_SITE_KEY_PUBLIC: ${VITE_TURNSTILE_SITE_KEY:-}
+        VITE_APP_VERSION: ${VITE_APP_VERSION:-}
         APP_ENV: ${APP_ENV:-development}
     container_name: voxpery-web
     restart: unless-stopped

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -183,14 +183,18 @@ You can prebuild and push images, then let Compose pull them during deploy inste
 
 Recommended tagging strategy:
 
-- `latest` for rolling production deploys
-- `sha-<commit>` when you want to pin an exact build
+- `sha-<commit>` for every main-branch image build
+- `vX.Y.Z` for release tag builds
+
+Do not use `latest` for production deploys. Production should deploy an exact
+image tag so the running image can be tied back to a commit or release tag and
+rolled back safely.
 
 Example:
 
 ```bash
 docker build -t <dockerhub-user>/voxpery-server:<tag> ./apps/server
-docker build -t <dockerhub-user>/voxpery-web:<tag> ./apps/web
+docker build --build-arg VITE_APP_VERSION=<tag> -t <dockerhub-user>/voxpery-web:<tag> ./apps/web
 docker push <dockerhub-user>/voxpery-server:<tag>
 docker push <dockerhub-user>/voxpery-web:<tag>
 ```
@@ -202,12 +206,33 @@ VOXPERY_SERVER_IMAGE=<dockerhub-user>/voxpery-server:<tag>
 VOXPERY_WEB_IMAGE=<dockerhub-user>/voxpery-web:<tag>
 ```
 
-Current production deploy workflow can then use:
+Production deploys should pull the exact image tag selected for the release:
 
 ```bash
+export VOXPERY_SERVER_IMAGE=voxpery/voxpery-server:<tag>
+export VOXPERY_WEB_IMAGE=voxpery/voxpery-web:<tag>
 docker compose pull server web
 docker compose up -d --no-build --remove-orphans
 ```
+
+The bundled manual deploy workflow uses a deploy channel:
+
+- `latest-release` (default): finds the newest `v*` tag, checks out that tag,
+  and deploys the matching `vX.Y.Z` image tag.
+- `main-candidate`: checks out `main` (or the optional `git_ref`) and deploys
+  the matching `sha-<commit>` image tag for pre-release verification.
+- `custom`: requires both `git_ref` and `image_tag` for explicit rollback or
+  advanced operations.
+
+All channels refuse the Docker `latest` tag. The default `latest-release`
+channel keeps manual deploys close to one-click while still pinning production
+to a concrete release version.
+
+CI-built web images embed the resolved deploy tag as `VITE_APP_VERSION` and show
+it beside the `Beta` badge in the top bar. This should match the selected server
+and web image tag (`vX.Y.Z` for stable releases or `sha-<commit>` for main
+candidates). For manual image builds, pass `--build-arg VITE_APP_VERSION=<tag>`
+to keep the visible badge aligned with the image tag.
 
 ## 8) Backups
 

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -62,7 +62,7 @@ Voxpery follows Semantic Versioning:
 - **Required PR gates**: `Checks / Secret Scan`, `Checks / Backend`, and `Checks / Frontend`. Keep these fast and deterministic so branch protection can require them on every PR.
 - **Security monitoring gates**: CodeQL and dependency security audit workflows run on PRs, schedules, or manually. Review their output before release; an upstream-blocked advisory needs an explicit release decision rather than being silently ignored.
 - **Release smoke gates**: run the manual `Release Smoke` workflow against the release candidate API before tagging or publishing. Use strict security headers for production candidates and enable browser E2E only when the candidate environment is ready for it.
-- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs.
+- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish jobs must produce immutable `sha-<commit>` tags for main-branch builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
 
 ### Release Checklist
 
@@ -75,12 +75,15 @@ Voxpery follows Semantic Versioning:
 7. Validate critical paths: auth, messaging+websocket, voice join/leave.
 8. Create and push the Git tag (for example `v0.1.5`) from the exact signed-off commit.
 9. Confirm tag-triggered release jobs, Docker publish jobs, and desktop artifact jobs ran against that exact tag/ref.
-10. Verify release assets and updater metadata before publishing or announcing the release.
-11. Publish GitHub Release notes only after artifacts, signatures, and smoke sign-off are complete.
+10. Record the exact Docker image tag selected for production deploy and verify the manual deploy workflow used that tag.
+11. Verify release assets and updater metadata before publishing or announcing the release.
+12. Publish GitHub Release notes only after artifacts, signatures, and smoke sign-off are complete.
 
 ### Release Workflow Rules
 
 - Prefer tag-driven releases: push the `v*` tag from the signed-off commit and let tag-triggered CI/release jobs build the immutable candidate.
+- Main-branch Docker images are commit-tagged as `sha-<commit>` and release Docker images are tagged with both `vX.Y.Z` and `sha-<commit>`. The web image embeds the selected deploy tag in the top-bar version badge. Do not rely on `latest` for production deploys.
+- Manual production deploys should use the default `latest-release` channel for normal stable releases, `main-candidate` for pre-release verification, and `custom` only for explicit rollback or advanced operations. Each channel resolves to a concrete image tag before deploying.
 - If a GitHub Release is created manually and workflows do not run, do not announce it as ready. Run the appropriate manual workflow against the exact tag/ref or recreate the tag/release intentionally.
 - Manual desktop release workflow runs must use the exact release tag/ref, set `smoke_checklist_confirmed=yes`, and use `platform=all` for production releases unless the release is explicitly a single-platform hotfix/test.
 - Keep the release draft until `latest.json`, installer assets, signature files, and release notes all point to the same version and tag.

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -9,6 +9,8 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - Version:
 - Commit SHA:
 - Git ref / tag:
+- Deploy channel:
+- Docker image tag:
 - Release type: `web-only` / `desktop` / `voice` / `security` / `hotfix`
 - Tester:
 - Date (UTC):
@@ -20,7 +22,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 
 - [ ] `Checks / Secret Scan`
 - [ ] `Checks / Backend`
-- [ ] `Checks / Frontend` (lint, unit tests, build)
+- [ ] `Checks / Frontend` (lint, unit tests, core UI smoke, build)
 
 ## 2) Security and Release Gates (mandatory)
 
@@ -32,6 +34,9 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Manual `Release Smoke` workflow run URL is recorded in Release Candidate Info.
 - [ ] `Release Smoke` ran with strict security headers enabled for production candidates.
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
+- [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
+- [ ] Manual deploy workflow resolved the expected deploy channel and exact Docker image tag recorded in Release Candidate Info.
+- [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
 ## 3) Web Smoke Tests (mandatory)
 


### PR DESCRIPTION
## Summary
- Publish Docker images with immutable commit SHA tags on main and with both release and commit SHA tags on `v*` releases.
- Replace direct Docker `latest` deploys with channel-based manual deploys: `latest-release`, `main-candidate`, and `custom`.
- Embed the resolved deploy tag into the web image as `VITE_APP_VERSION` and show it beside the `Beta` badge in the top bar.
- Document the immutable image/deploy process and the visible build tag in deployment, operations, and release smoke docs.

## Validation
- `cd apps/web && npm run lint`
- `cd apps/web && npm run test:run`
- `cd apps/web && npm run build`
- `cd apps/web && npm run test:e2e:ui-smoke`
- `git diff --check`
- `graphify update .`