### PR TITLE
ci: publish docker images only for releases by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,9 @@ jobs:
       - security
       - backend
       - frontend
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -183,8 +183,8 @@ You can prebuild and push images, then let Compose pull them during deploy inste
 
 Recommended tagging strategy:
 
-- `sha-<commit>` for every main-branch image build
 - `vX.Y.Z` for release tag builds
+- `sha-<commit>` for manually published main-candidate builds
 
 Do not use `latest` for production deploys. Production should deploy an exact
 image tag so the running image can be tied back to a commit or release tag and
@@ -220,7 +220,9 @@ The bundled manual deploy workflow uses a deploy channel:
 - `latest-release` (default): finds the newest `v*` tag, checks out that tag,
   and deploys the matching `vX.Y.Z` image tag.
 - `main-candidate`: checks out `main` (or the optional `git_ref`) and deploys
-  the matching `sha-<commit>` image tag for pre-release verification.
+  the matching `sha-<commit>` image tag for pre-release verification. Run the
+  `CI` workflow manually on the selected ref first so Docker Hub has that
+  candidate image.
 - `custom`: requires both `git_ref` and `image_tag` for explicit rollback or
   advanced operations.
 
@@ -228,11 +230,18 @@ All channels refuse the Docker `latest` tag. The default `latest-release`
 channel keeps manual deploys close to one-click while still pinning production
 to a concrete release version.
 
+Docker images are published automatically only for `v*` tag pushes. Main-branch
+pushes run validation but do not push Docker images, keeping Docker Hub focused
+on stable releases. When you need a pre-release `main-candidate` deploy, run the
+`CI` workflow manually for the target branch or ref; it will publish the matching
+`sha-<commit>` server and web images.
+
 CI-built web images embed the resolved deploy tag as `VITE_APP_VERSION` and show
 it beside the `Beta` badge in the top bar. This should match the selected server
-and web image tag (`vX.Y.Z` for stable releases or `sha-<commit>` for main
-candidates). For manual image builds, pass `--build-arg VITE_APP_VERSION=<tag>`
-to keep the visible badge aligned with the image tag.
+and web image tag (`vX.Y.Z` for stable releases or `sha-<commit>` for manually
+published main candidates). For manual image builds, pass
+`--build-arg VITE_APP_VERSION=<tag>` to keep the visible badge aligned with the
+image tag.
 
 ## 8) Backups
 

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -62,7 +62,7 @@ Voxpery follows Semantic Versioning:
 - **Required PR gates**: `Checks / Secret Scan`, `Checks / Backend`, and `Checks / Frontend`. Keep these fast and deterministic so branch protection can require them on every PR.
 - **Security monitoring gates**: CodeQL and dependency security audit workflows run on PRs, schedules, or manually. Review their output before release; an upstream-blocked advisory needs an explicit release decision rather than being silently ignored.
 - **Release smoke gates**: run the manual `Release Smoke` workflow against the release candidate API before tagging or publishing. Use strict security headers for production candidates and enable browser E2E only when the candidate environment is ready for it.
-- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish jobs must produce immutable `sha-<commit>` tags for main-branch builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
+- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish runs automatically for `v*` tag pushes and can be triggered manually for pre-release main candidates. Docker publish jobs must produce immutable `sha-<commit>` tags for manually published main-candidate builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
 
 ### Release Checklist
 
@@ -82,8 +82,8 @@ Voxpery follows Semantic Versioning:
 ### Release Workflow Rules
 
 - Prefer tag-driven releases: push the `v*` tag from the signed-off commit and let tag-triggered CI/release jobs build the immutable candidate.
-- Main-branch Docker images are commit-tagged as `sha-<commit>` and release Docker images are tagged with both `vX.Y.Z` and `sha-<commit>`. The web image embeds the selected deploy tag in the top-bar version badge. Do not rely on `latest` for production deploys.
-- Manual production deploys should use the default `latest-release` channel for normal stable releases, `main-candidate` for pre-release verification, and `custom` only for explicit rollback or advanced operations. Each channel resolves to a concrete image tag before deploying.
+- Release Docker images are tagged with both `vX.Y.Z` and `sha-<commit>`. Manually published main-candidate Docker images are commit-tagged as `sha-<commit>`. The web image embeds the selected deploy tag in the top-bar version badge. Do not rely on `latest` for production deploys.
+- Manual production deploys should use the default `latest-release` channel for normal stable releases, `main-candidate` for pre-release verification after manually publishing the candidate image, and `custom` only for explicit rollback or advanced operations. Each channel resolves to a concrete image tag before deploying.
 - If a GitHub Release is created manually and workflows do not run, do not announce it as ready. Run the appropriate manual workflow against the exact tag/ref or recreate the tag/release intentionally.
 - Manual desktop release workflow runs must use the exact release tag/ref, set `smoke_checklist_confirmed=yes`, and use `platform=all` for production releases unless the release is explicitly a single-platform hotfix/test.
 - Keep the release draft until `latest.json`, installer assets, signature files, and release notes all point to the same version and tag.

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -35,6 +35,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] `Release Smoke` ran with strict security headers enabled for production candidates.
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
+- [ ] For `main-candidate` deploys, the manual `CI` workflow published Docker images for the exact candidate ref before deploy.
 - [ ] Manual deploy workflow resolved the expected deploy channel and exact Docker image tag recorded in Release Candidate Info.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 


### PR DESCRIPTION
## Summary
- Stop publishing Docker images automatically on every main push.
- Keep automatic Docker publishing for `v*` release tags.
- Allow manual CI dispatch to publish `sha-<commit>` images for main-candidate verification.
- Update deployment, operations, and release smoke docs for the release-tag-first Docker publishing flow.

## Validation
- `git diff --check`
- `graphify update .`