### PR TITLE
release: bump version to 0.2.0

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5322,7 +5322,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.1.13"
+version = "0.2.0"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3141,7 +3141,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-01
+
+### Added
+- Added a friend DM action button in the friends list for quicker direct-message access.
+- Added mocked core UI smoke and component regression coverage for the main social, chat, voice, and media surfaces.
+
+### Changed
+- Improved friends-list scrolling, tab layouts, and bottom-dock spacing behavior.
+- Switched Docker publishing toward immutable release tags, with manual candidate images still available before a release tag is cut.
+- Prepared the web, server, and desktop package metadata for the `v0.2.0` release.
+- Updated non-breaking web, server, and desktop dependencies.
+
+### Fixed
+- Fixed chat scroll anchoring regressions around message loading and channel navigation.
+- Fixed direct-message opening, sorting, notification read-state, and mark-as-read behavior.
+- Resolved security alerts from an unused server npm manifest and credential-like integration-test fixtures.
+
+### Tests
+- Added CI coverage for core UI smoke flows on pull requests.
+
 ## [0.1.13] - 2026-05-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Bump web, server, and desktop package metadata to `0.2.0`.
- Sync desktop Tauri and Cargo lock versions for the release.
- Add the `0.2.0` changelog section with the release highlights since `0.1.13`.

## Validation
- `cd apps/web && npm.cmd run lint`
- `cd apps/web && npm.cmd run test:run`
- `cd apps/web && npm.cmd run build`
- `cd apps/web && npm.cmd run test:e2e:ui-smoke`
- `cargo check --manifest-path apps/server/Cargo.toml --locked`
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --locked`
- `git diff --check`
- `graphify update .`