### PR TITLE
style: update version badge styles and implement version formatting f…

### DIFF
--- a/apps/web/src/appVersion.test.ts
+++ b/apps/web/src/appVersion.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { formatAppVersionBadge } from './appVersion'
+
+describe('formatAppVersionBadge', () => {
+  it('adds a release prefix to plain semantic versions', () => {
+    expect(formatAppVersionBadge('0.2.0')).toBe('v0.2.0')
+    expect(formatAppVersionBadge(' 1.4.2 ')).toBe('v1.4.2')
+  })
+
+  it('keeps explicit release and candidate tags unchanged', () => {
+    expect(formatAppVersionBadge('v0.2.0')).toBe('v0.2.0')
+    expect(formatAppVersionBadge('sha-8da8941dbb1a')).toBe('sha-8da8941dbb1a')
+  })
+
+  it('hides empty versions', () => {
+    expect(formatAppVersionBadge('')).toBeNull()
+    expect(formatAppVersionBadge(undefined)).toBeNull()
+  })
+})

--- a/apps/web/src/appVersion.ts
+++ b/apps/web/src/appVersion.ts
@@ -1,0 +1,10 @@
+export function formatAppVersionBadge(rawVersion: string | null | undefined): string | null {
+  const version = rawVersion?.trim()
+  if (!version) return null
+
+  if (/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+    return `v${version}`
+  }
+
+  return version
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -353,11 +353,12 @@ body {
   cursor: pointer;
 }
 
-.shell-brand-beta {
+.shell-brand-release {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   height: 20px;
+  max-width: 164px;
   padding: 0 9px;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.16);
@@ -366,31 +367,31 @@ body {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.02em;
+  line-height: 1;
+  white-space: nowrap;
 }
 
-.shell-brand-beta::before {
+.shell-brand-release::before {
   content: '';
   width: 6px;
   height: 6px;
+  flex: 0 0 6px;
   border-radius: 999px;
   background: #9cc2ff;
   box-shadow: 0 0 0 3px rgba(156, 194, 255, 0.22), 0 0 8px rgba(156, 194, 255, 0.3);
 }
 
-.shell-brand-version {
+.shell-brand-release-separator {
+  color: rgba(200, 212, 238, 0.52);
+}
+
+.shell-brand-release-version {
   display: inline-flex;
   align-items: center;
-  max-width: 112px;
-  height: 20px;
-  padding: 0 8px;
-  border-radius: 999px;
-  border: 1px solid rgba(124, 171, 255, 0.22);
-  background: rgba(79, 127, 216, 0.12);
+  min-width: 0;
+  max-width: 92px;
   color: #dce8ff;
-  font-size: 11px;
   font-weight: 700;
-  line-height: 1;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   font-variant-numeric: tabular-nums;
@@ -12616,8 +12617,7 @@ textarea {
     display: none;
   }
 
-  .shell-brand-beta,
-  .shell-brand-version {
+  .shell-brand-release {
     display: none;
   }
 

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -22,14 +22,16 @@ import {
   checkForUpdates,
   DESKTOP_UPDATE_STATUS_EVENT,
   downloadAndInstallUpdate,
+  getDesktopAppVersion,
   type DesktopUpdateStatusDetail,
   type UpdateResult,
 } from '../updater'
 import { ROUTES } from '../routes'
 import { setPersistedSocialView } from '../socialView'
+import { formatAppVersionBadge } from '../appVersion'
 
 const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
-const APP_VERSION = (import.meta.env.VITE_APP_VERSION ?? '').trim()
+const BUILD_APP_VERSION = formatAppVersionBadge(import.meta.env.VITE_APP_VERSION)
 
 export default function AppShell() {
   const { user } = useAuthStore()
@@ -91,6 +93,23 @@ export default function AppShell() {
   const previousUnreadCountRef = useRef(0)
   const desktopUnreadInitializedRef = useRef(false)
   const [showQuickSwitcher, setShowQuickSwitcher] = useState(false)
+  const [desktopAppVersion, setDesktopAppVersion] = useState<string | null>(null)
+  const appVersionBadge = BUILD_APP_VERSION ?? desktopAppVersion
+
+  useEffect(() => {
+    if (BUILD_APP_VERSION || !isTauri()) return
+    let cancelled = false
+
+    void getDesktopAppVersion().then((version) => {
+      if (!cancelled) {
+        setDesktopAppVersion(formatAppVersionBadge(version))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (!userId) return
@@ -582,12 +601,18 @@ export default function AppShell() {
           <button type="button" className="shell-brand" onClick={() => navigate(ROUTES.home)}>
             <img src="/1024.png" alt="" className="shell-brand-logo" width={32} height={32} />
             <span>Voxpery</span>
-            <span className="shell-brand-beta" title="Preview build">Beta</span>
-            {APP_VERSION && (
-              <span className="shell-brand-version" title={`Running build ${APP_VERSION}`}>
-                {APP_VERSION}
-              </span>
-            )}
+            <span
+              className="shell-brand-release"
+              title={appVersionBadge ? `Beta channel, running build ${appVersionBadge}` : 'Beta channel'}
+            >
+              <span>Beta</span>
+              {appVersionBadge && (
+                <>
+                  <span className="shell-brand-release-separator" aria-hidden="true">·</span>
+                  <span className="shell-brand-release-version">{appVersionBadge}</span>
+                </>
+              )}
+            </span>
           </button>
         </div>
         <div className="shell-topbar-right">


### PR DESCRIPTION
## Summary
Merge "Beta" badge and version number into a single unified pill with `·` separator. Add dynamic desktop version resolution for Tauri builds.

## Changes
- `appVersion.ts` + tests: `formatAppVersionBadge` — normalizes semver (`0.2.0` → `v0.2.0`)
- `AppShell.tsx`: Single `.shell-brand-release` pill replacing separate Beta + version spans; fetches desktop version via `getDesktopAppVersion()` on Tauri
- `index.css`: `.shell-brand-beta` + `.shell-brand-version` → `.shell-brand-release` with separator, overflow ellipsis, mobile hide