### PR TITLE
Chore/manual deploy build candidate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: Security / CodeQL
 
 on:
   pull_request:

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -1,4 +1,4 @@
-name: Dependency Security
+name: Security / Dependency Audit
 
 on:
   pull_request:
@@ -19,7 +19,7 @@ env:
 
 jobs:
   security-deps:
-    name: Dependency Security Audit
+    name: Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Manual Deploy
+name: Deploy / Production
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_channel:
-        description: 'What to deploy: latest release tag, current main candidate, or custom tag/ref'
+        description: 'What to deploy: latest release tag, build+deploy a main candidate, or custom tag/ref'
         required: true
         default: latest-release
         type: choice
@@ -29,17 +29,170 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    name: Resolve Deploy Target
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      release_channel: ${{ steps.target.outputs.release_channel }}
+      git_ref: ${{ steps.target.outputs.git_ref }}
+      image_tag: ${{ steps.target.outputs.image_tag }}
+      build_candidate: ${{ steps.target.outputs.build_candidate }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve target
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RELEASE_CHANNEL="${{ inputs.release_channel }}"
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          GIT_REF="${{ inputs.git_ref }}"
+          BUILD_CANDIDATE="false"
+
+          git fetch --prune --tags origin "+refs/heads/*:refs/remotes/origin/*"
+
+          case "${RELEASE_CHANNEL}" in
+            latest-release)
+              GIT_REF="$(git for-each-ref refs/tags/v* --sort=-v:refname --format='%(refname:short)' | head -n 1)"
+              if [ -z "${GIT_REF}" ]; then
+                echo "Refusing deploy: no v* release tags were found."
+                exit 1
+              fi
+              IMAGE_TAG="${GIT_REF}"
+              ;;
+            main-candidate)
+              requested_ref="${GIT_REF:-main}"
+              if git rev-parse --verify --quiet "refs/remotes/origin/${requested_ref}" >/dev/null; then
+                resolved_commit="$(git rev-parse "refs/remotes/origin/${requested_ref}")"
+              else
+                resolved_commit="$(git rev-parse "${requested_ref}")"
+              fi
+              short_commit="$(printf '%s' "${resolved_commit}" | cut -c1-12)"
+              GIT_REF="${resolved_commit}"
+              IMAGE_TAG="sha-${short_commit}"
+              BUILD_CANDIDATE="true"
+              ;;
+            custom)
+              if [ -z "${IMAGE_TAG}" ] || [ -z "${GIT_REF}" ]; then
+                echo "Refusing deploy: custom mode requires both image_tag and git_ref."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Refusing deploy: unsupported release_channel '${RELEASE_CHANNEL}'."
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${IMAGE_TAG}" ] || [ "${IMAGE_TAG}" = "latest" ]; then
+            echo "Refusing deploy: image_tag must be an immutable tag, not '${IMAGE_TAG:-empty}'."
+            exit 1
+          fi
+
+          case "${IMAGE_TAG}" in
+            *[!A-Za-z0-9_.-]*)
+              echo "Refusing deploy: image_tag contains unsupported characters."
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${GIT_REF}" ]; then
+            echo "Refusing deploy: git_ref is required."
+            exit 1
+          fi
+
+          case "${GIT_REF}" in
+            -*|*..*|*~*|*^*|*:*|*\\*|*[!A-Za-z0-9_./-]*)
+              echo "Refusing deploy: git_ref contains unsupported characters."
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "release_channel=${RELEASE_CHANNEL}"
+            echo "git_ref=${GIT_REF}"
+            echo "image_tag=${IMAGE_TAG}"
+            echo "build_candidate=${BUILD_CANDIDATE}"
+          } >> "$GITHUB_OUTPUT"
+
+  publish_candidate:
+    name: ${{ matrix.component == 'backend' && 'Publish Candidate / Docker Backend' || 'Publish Candidate / Docker Frontend' }}
+    needs: prepare
+    if: needs.prepare.outputs.build_candidate == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - backend
+          - frontend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.git_ref }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push backend
+        if: matrix.component == 'backend'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./apps/server
+          file: ./apps/server/Dockerfile
+          push: true
+          tags: voxpery/voxpery-server:${{ needs.prepare.outputs.image_tag }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+
+      - name: Build and push frontend
+        if: matrix.component == 'frontend'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./apps/web
+          file: ./apps/web/Dockerfile
+          push: true
+          tags: voxpery/voxpery-web:${{ needs.prepare.outputs.image_tag }}
+          build-args: |
+            VITE_API_URL=${{ secrets.VITE_API_URL }}
+            TURNSTILE_SITE_KEY_PUBLIC=${{ secrets.VITE_TURNSTILE_SITE_KEY }}
+            VITE_APP_VERSION=${{ needs.prepare.outputs.image_tag }}
+            APP_ENV=production
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+
   deploy:
     name: Deploy to Production
+    needs:
+      - prepare
+      - publish_candidate
+    if: >-
+      always()
+      && needs.prepare.result == 'success'
+      && (needs.publish_candidate.result == 'success' || needs.publish_candidate.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5
         env:
-          DEPLOY_RELEASE_CHANNEL: ${{ inputs.release_channel }}
-          DEPLOY_IMAGE_TAG: ${{ inputs.image_tag }}
-          DEPLOY_GIT_REF: ${{ inputs.git_ref }}
+          DEPLOY_RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
+          DEPLOY_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          DEPLOY_GIT_REF: ${{ needs.prepare.outputs.git_ref }}
         with:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -4,7 +4,7 @@
 # Set repo secret VITE_API_URL and repo variable or secret VITE_TURNSTILE_SITE_KEY
 # so the desktop app points to your API and can render production CAPTCHA.
 
-name: Release desktop
+name: Release / Desktop
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,4 +1,4 @@
-name: Release Smoke
+name: Release / Smoke
 
 on:
   workflow_dispatch:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -188,7 +188,7 @@ You can prebuild and push images, then let Compose pull them during deploy inste
 Recommended tagging strategy:
 
 - `vX.Y.Z` for release tag builds
-- `sha-<commit>` for manually published main-candidate builds
+- `sha-<commit>` for manually deployed main-candidate builds
 
 Do not use `latest` for production deploys. Production should deploy an exact
 image tag so the running image can be tied back to a commit or release tag and
@@ -223,10 +223,9 @@ The bundled manual deploy workflow uses a deploy channel:
 
 - `latest-release` (default): finds the newest `v*` tag, checks out that tag,
   and deploys the matching `vX.Y.Z` image tag.
-- `main-candidate`: checks out `main` (or the optional `git_ref`) and deploys
-  the matching `sha-<commit>` image tag for pre-release verification. Run the
-  `CI` workflow manually on the selected ref first so Docker Hub has that
-  candidate image.
+- `main-candidate`: resolves `main` (or the optional `git_ref`) to an exact
+  commit, builds and pushes the matching `sha-<commit>` server and web images,
+  then deploys that same immutable image tag for pre-release verification.
 - `custom`: requires both `git_ref` and `image_tag` for explicit rollback or
   advanced operations.
 
@@ -237,13 +236,13 @@ to a concrete release version.
 Docker images are published automatically only for `v*` tag pushes. Main-branch
 pushes run validation but do not push Docker images, keeping Docker Hub focused
 on stable releases. When you need a pre-release `main-candidate` deploy, run the
-`CI` workflow manually for the target branch or ref; it will publish the matching
-`sha-<commit>` server and web images.
+manual deploy workflow with the `main-candidate` channel; it publishes the
+matching `sha-<commit>` server and web images before deploying them.
 
 CI-built web images embed the resolved deploy tag as `VITE_APP_VERSION` and show
 it beside the `Beta` badge in the top bar. This should match the selected server
 and web image tag (`vX.Y.Z` for stable releases or `sha-<commit>` for manually
-published main candidates). For manual image builds, pass
+deployed main candidates). For manual image builds, pass
 `--build-arg VITE_APP_VERSION=<tag>` to keep the visible badge aligned with the
 image tag.
 

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -58,7 +58,7 @@ Before publishing or announcing a desktop release:
 - Every updater asset referenced by `latest.json` must have a matching `.sig` file.
 - Artifact URLs in `latest.json` must point to release assets for the same version, not draft-only, private, temporary, or older release URLs.
 - The updater public key injected into `apps/desktop/src-tauri/tauri.conf.json` must match the private key used to sign the release artifacts.
-- Manual `Release desktop` workflow runs must target the exact release tag/ref and use `smoke_checklist_confirmed=yes`.
+- Manual `Release / Desktop` workflow runs must target the exact release tag/ref and use `smoke_checklist_confirmed=yes`.
 - Production desktop releases should build all supported platforms. Single-platform manual runs are acceptable for test or explicit hotfix scopes only and must be noted in the release checklist.
 - If a GitHub Release exists but the desktop workflow did not run or did not attach updater metadata, keep the release as draft until the workflow is rerun against the correct tag/ref.
 

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -61,7 +61,7 @@ Voxpery follows Semantic Versioning:
 
 - **Required PR gates**: `Checks / Secret Scan`, `Checks / Backend`, and `Checks / Frontend`. Keep these fast and deterministic so branch protection can require them on every PR.
 - **Security monitoring gates**: CodeQL and dependency security audit workflows run on PRs, schedules, or manually. Review their output before release; an upstream-blocked advisory needs an explicit release decision rather than being silently ignored.
-- **Release smoke gates**: run the manual `Release Smoke` workflow against the release candidate API before tagging or publishing. Use strict security headers for production candidates and enable browser E2E only when the candidate environment is ready for it.
+- **Release smoke gates**: run the manual `Release / Smoke` workflow against the release candidate API before tagging or publishing. Use strict security headers for production candidates and enable browser E2E only when the candidate environment is ready for it.
 - **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish runs automatically for `v*` tag pushes; the manual deploy workflow builds and publishes immutable `sha-<commit>` images before deploying a `main-candidate`. Docker publish jobs must produce immutable `sha-<commit>` tags for manually deployed main-candidate builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
 
 ### Release Checklist
@@ -69,7 +69,7 @@ Voxpery follows Semantic Versioning:
 1. Prepare the candidate from updated `main` and keep the final release commit SHA recorded.
 2. Update docs for behavior changes and update the changelog entry before creating the tag.
 3. Ensure required PR gates are green on the release branch and no security monitoring gate is ignored without a recorded decision.
-4. Run the manual `Release Smoke` workflow against the release candidate API and record the workflow run URL in [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md).
+4. Run the manual `Release / Smoke` workflow against the release candidate API and record the workflow run URL in [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md).
 5. Complete and sign off [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md) (required).
 6. Validate [DESKTOP_RELEASE_HARDENING.md](DESKTOP_RELEASE_HARDENING.md) if desktop artifacts are part of the release.
 7. Validate critical paths: auth, messaging+websocket, voice join/leave.

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -62,7 +62,7 @@ Voxpery follows Semantic Versioning:
 - **Required PR gates**: `Checks / Secret Scan`, `Checks / Backend`, and `Checks / Frontend`. Keep these fast and deterministic so branch protection can require them on every PR.
 - **Security monitoring gates**: CodeQL and dependency security audit workflows run on PRs, schedules, or manually. Review their output before release; an upstream-blocked advisory needs an explicit release decision rather than being silently ignored.
 - **Release smoke gates**: run the manual `Release Smoke` workflow against the release candidate API before tagging or publishing. Use strict security headers for production candidates and enable browser E2E only when the candidate environment is ready for it.
-- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish runs automatically for `v*` tag pushes and can be triggered manually for pre-release main candidates. Docker publish jobs must produce immutable `sha-<commit>` tags for manually published main-candidate builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
+- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish runs automatically for `v*` tag pushes; the manual deploy workflow builds and publishes immutable `sha-<commit>` images before deploying a `main-candidate`. Docker publish jobs must produce immutable `sha-<commit>` tags for manually deployed main-candidate builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
 
 ### Release Checklist
 
@@ -82,8 +82,8 @@ Voxpery follows Semantic Versioning:
 ### Release Workflow Rules
 
 - Prefer tag-driven releases: push the `v*` tag from the signed-off commit and let tag-triggered CI/release jobs build the immutable candidate.
-- Release Docker images are tagged with both `vX.Y.Z` and `sha-<commit>`. Manually published main-candidate Docker images are commit-tagged as `sha-<commit>`. The web image embeds the selected deploy tag in the top-bar version badge. Do not rely on `latest` for production deploys.
-- Manual production deploys should use the default `latest-release` channel for normal stable releases, `main-candidate` for pre-release verification after manually publishing the candidate image, and `custom` only for explicit rollback or advanced operations. Each channel resolves to a concrete image tag before deploying.
+- Release Docker images are tagged with both `vX.Y.Z` and `sha-<commit>`. Manually deployed main-candidate Docker images are commit-tagged as `sha-<commit>`. The web image embeds the selected deploy tag in the top-bar version badge. Do not rely on `latest` for production deploys.
+- Manual production deploys should use the default `latest-release` channel for normal stable releases, `main-candidate` for one-click pre-release build-and-deploy verification, and `custom` only for explicit rollback or advanced operations. Each channel resolves to a concrete image tag before deploying.
 - If a GitHub Release is created manually and workflows do not run, do not announce it as ready. Run the appropriate manual workflow against the exact tag/ref or recreate the tag/release intentionally.
 - Manual desktop release workflow runs must use the exact release tag/ref, set `smoke_checklist_confirmed=yes`, and use `platform=all` for production releases unless the release is explicitly a single-platform hotfix/test.
 - Keep the release draft until `latest.json`, installer assets, signature files, and release notes all point to the same version and tag.

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -35,7 +35,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] `Release Smoke` ran with strict security headers enabled for production candidates.
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
-- [ ] For `main-candidate` deploys, the manual `CI` workflow published Docker images for the exact candidate ref before deploy.
+- [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
 - [ ] Manual deploy workflow resolved the expected deploy channel and exact Docker image tag recorded in Release Candidate Info.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -15,7 +15,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - Tester:
 - Date (UTC):
 - Environment:
-- Release Smoke workflow run URL:
+- Release / Smoke workflow run URL:
 - Desktop artifact workflow run URL, if applicable:
 
 ## 1) Required PR Gates (must be green)
@@ -26,13 +26,13 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 
 ## 2) Security and Release Gates (mandatory)
 
-- [ ] Relevant `CodeQL` analyzers are green or did not run because no matching files changed.
-- [ ] `Dependency Security Audit` is reviewed; unresolved upstream-blocked advisories have an explicit release decision recorded.
+- [ ] Relevant `Security / CodeQL` analyzers are green or did not run because no matching files changed.
+- [ ] `Security / Dependency Audit` is reviewed; unresolved upstream-blocked advisories have an explicit release decision recorded.
 - [ ] Web container health responds through the host mapping (`curl -f http://localhost:${WEB_PORT:-5173}/healthz`) while the container uses unprivileged nginx on internal port `8080`.
 - [ ] Remote avatar/server icon/inline media proxy rejects localhost/private targets and still loads normal public HTTPS images.
-- [ ] Manual `Release Smoke` workflow completed successfully against the release candidate API.
-- [ ] Manual `Release Smoke` workflow run URL is recorded in Release Candidate Info.
-- [ ] `Release Smoke` ran with strict security headers enabled for production candidates.
+- [ ] Manual `Release / Smoke` workflow completed successfully against the release candidate API.
+- [ ] Manual `Release / Smoke` workflow run URL is recorded in Release Candidate Info.
+- [ ] `Release / Smoke` ran with strict security headers enabled for production candidates.
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.


### PR DESCRIPTION
## Summary
- Build and publish main-candidate Docker images inside the manual deploy workflow before deploying.
- Resolve deploy targets to immutable tags/refs and deploy the same tag that was built.
- Rename custom workflows into CI/Deploy/Security/Release groups for a cleaner Actions sidebar.
- Update deployment, operations, desktop release, and release smoke docs for the new workflow names and one-click main-candidate flow.

## Validation
- git diff --check
- graphify update .