### PR TITLE
test: cover auth core UI regressions

### DIFF
--- a/apps/web/e2e/auth-core-regressions.spec.ts
+++ b/apps/web/e2e/auth-core-regressions.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test'
+import { createMockCoreState, installMockCoreApi } from './mock-core-api'
+
+const AUTH_FEATURES = {
+  google_oauth_enabled: false,
+  email_delivery_enabled: true,
+  email_verification_enabled: true,
+  email_verification_required: false,
+  password_reset_enabled: true,
+}
+
+test.describe('mocked auth and account regressions', () => {
+  test('disables email verification resend while the request is in flight', async ({ page }) => {
+    const state = createMockCoreState({
+      features: AUTH_FEATURES,
+      emailVerificationRequestDelayMs: 400,
+      user: {
+        ...createMockCoreState().user,
+        email: 'localuser@example.test',
+        email_verified: false,
+      },
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+    await expect(page.getByText(/localuser@example\.test/)).toBeVisible()
+    await expect(page.getByText(/Not verified/)).toBeVisible()
+
+    await page.getByRole('button', { name: 'Verify' }).click()
+    const sendingButton = page.getByRole('button', { name: 'Sending...' })
+    await expect(sendingButton).toBeVisible()
+    await expect(sendingButton).toBeDisabled()
+    expect(state.emailVerificationRequestCount).toBe(1)
+
+    await expect(page.locator('.toast-item', { hasText: 'Verification email sent' })).toBeVisible()
+    expect(state.emailVerificationRequestCount).toBe(1)
+  })
+
+  test('confirms an email verification token once and keeps the success state', async ({ page }) => {
+    const state = createMockCoreState({
+      features: AUTH_FEATURES,
+      user: {
+        ...createMockCoreState().user,
+        email_verified: false,
+      },
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/verify-email?token=valid-email-token')
+
+    await expect.poll(() => state.emailVerificationConfirmCountByToken['valid-email-token'] ?? 0).toBe(1)
+    await expect(page.getByText('Your email address has been verified.')).toBeVisible()
+    expect(state.user.email_verified).toBe(true)
+  })
+
+  test('shows success when a consumed verification token belongs to an already verified session', async ({ page }) => {
+    const state = createMockCoreState({
+      features: AUTH_FEATURES,
+      validEmailVerificationTokens: [],
+      user: {
+        ...createMockCoreState().user,
+        email_verified: true,
+      },
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/verify-email?token=consumed-email-token')
+
+    await expect.poll(() => state.emailVerificationConfirmCountByToken['consumed-email-token'] ?? 0).toBe(1)
+    await expect(page.getByText('Your email address has already been verified.')).toBeVisible()
+    await expect(page.getByText('Invalid email verification token')).toBeHidden()
+  })
+
+  test('keeps forgot-password and reset-password flows wired to the API', async ({ page }) => {
+    const state = createMockCoreState({ authenticated: false, features: AUTH_FEATURES })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/forgot-password')
+    await expect(page.getByRole('heading', { name: 'Reset Password' })).toBeVisible()
+    await page.getByPlaceholder('user@example.com').fill('localuser@example.test')
+    await page.getByRole('button', { name: 'Send Reset Link' }).click()
+    await expect(page.getByText('If that email exists, a reset link has been sent.')).toBeVisible()
+    expect(state.forgotPasswordRequestCount).toBe(1)
+
+    await page.goto('/reset-password?token=valid-reset-token')
+    const passwordInputs = page.locator('input[type="password"]')
+    await passwordInputs.nth(0).fill('new-password-123')
+    await passwordInputs.nth(1).fill('different-password')
+    await page.getByRole('button', { name: 'Reset Password' }).click()
+    await expect(page.getByRole('alert')).toContainText('Passwords do not match')
+    expect(state.resetPasswordRequestCount).toBe(0)
+
+    await passwordInputs.nth(1).fill('new-password-123')
+    await page.getByRole('button', { name: 'Reset Password' }).click()
+    await expect(page.getByText('Password reset successful. You can now sign in.')).toBeVisible()
+    expect(state.resetPasswordRequestCount).toBe(1)
+  })
+})

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -1,4 +1,4 @@
-import type { Page, Route } from '@playwright/test'
+import type { Page, Request, Route } from '@playwright/test'
 import type {
   Channel,
   DmChannel,
@@ -15,7 +15,9 @@ const AUTH_STORAGE_KEY = 'voxpery-auth'
 const ALL_PERMISSIONS = (1 << 13) - 1
 
 export interface MockCoreState {
+  authenticated: boolean
   user: UserPublic
+  features: SystemFeatures
   friends: Friend[]
   incomingRequests: FriendRequest[]
   outgoingRequests: FriendRequest[]
@@ -26,6 +28,13 @@ export interface MockCoreState {
   membersByServerId: Record<string, MemberInfo[]>
   messagesByChannelId: Record<string, MessageWithAuthor[]>
   pinnedMessageIdsByChannelId: Record<string, string[]>
+  emailVerificationRequestCount: number
+  emailVerificationConfirmCountByToken: Record<string, number>
+  emailVerificationRequestDelayMs: number
+  validEmailVerificationTokens: string[]
+  forgotPasswordRequestCount: number
+  resetPasswordRequestCount: number
+  validPasswordResetTokens: string[]
 }
 
 const DEFAULT_FEATURES: SystemFeatures = {
@@ -172,7 +181,9 @@ export function createMockCoreState(overrides: Partial<MockCoreState> = {}): Moc
   }
 
   return {
+    authenticated: true,
     user,
+    features: DEFAULT_FEATURES,
     friends: buildFriends(24),
     incomingRequests: buildRequests(10, 'incoming'),
     outgoingRequests: buildRequests(8, 'outgoing'),
@@ -183,20 +194,31 @@ export function createMockCoreState(overrides: Partial<MockCoreState> = {}): Moc
     membersByServerId: {},
     messagesByChannelId: {},
     pinnedMessageIdsByChannelId: {},
+    emailVerificationRequestCount: 0,
+    emailVerificationConfirmCountByToken: {},
+    emailVerificationRequestDelayMs: 0,
+    validEmailVerificationTokens: ['valid-email-token'],
+    forgotPasswordRequestCount: 0,
+    resetPasswordRequestCount: 0,
+    validPasswordResetTokens: ['valid-reset-token'],
     ...overrides,
   }
 }
 
 export async function installMockCoreApi(page: Page, state: MockCoreState = createMockCoreState()) {
   await page.addInitScript(
-    ({ authStorageKey, user }) => {
-      window.localStorage.setItem(
-        authStorageKey,
-        JSON.stringify({
-          state: { token: null, user },
-          version: 2,
-        }),
-      )
+    ({ authStorageKey, authenticated, user }) => {
+      if (authenticated) {
+        window.localStorage.setItem(
+          authStorageKey,
+          JSON.stringify({
+            state: { token: null, user },
+            version: 2,
+          }),
+        )
+      } else {
+        window.localStorage.removeItem(authStorageKey)
+      }
       window.localStorage.removeItem('voxpery-hidden-dm-peers')
       window.sessionStorage.clear()
 
@@ -276,7 +298,7 @@ export async function installMockCoreApi(page: Page, state: MockCoreState = crea
         value: MockWebSocket,
       })
     },
-    { authStorageKey: AUTH_STORAGE_KEY, user: state.user },
+    { authStorageKey: AUTH_STORAGE_KEY, authenticated: state.authenticated, user: state.user },
   )
 
   await page.route('http://localhost:3001/**', async (route) => {
@@ -296,12 +318,69 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
   }
 
   if (pathname === '/api/system/features' && method === 'GET') {
-    await json(route, DEFAULT_FEATURES)
+    await json(route, state.features)
     return
   }
 
   if (pathname === '/api/auth/me' && method === 'GET') {
+    if (!state.authenticated) {
+      await json(route, { error: 'Authentication required' }, 401)
+      return
+    }
     await json(route, state.user)
+    return
+  }
+
+  if (pathname === '/api/auth/forgot-password' && method === 'POST') {
+    state.forgotPasswordRequestCount += 1
+    await json(route, { message: 'If that email exists, a reset link has been sent.' })
+    return
+  }
+
+  if (pathname === '/api/auth/reset-password' && method === 'POST') {
+    state.resetPasswordRequestCount += 1
+    const body = parseJsonBody<{ token?: string; new_password?: string }>(request)
+    if (!body.token || !state.validPasswordResetTokens.includes(body.token)) {
+      await json(route, { error: 'Invalid password reset token' }, 400)
+      return
+    }
+    await json(route, { message: 'Password reset successful. You can now sign in.' })
+    return
+  }
+
+  if (pathname === '/api/auth/email/request-verification' && method === 'POST') {
+    state.emailVerificationRequestCount += 1
+    if (state.emailVerificationRequestDelayMs > 0) {
+      await delay(state.emailVerificationRequestDelayMs)
+    }
+    const body = parseJsonBody<{ email?: string }>(request)
+    if (body.email?.trim()) {
+      state.user = {
+        ...state.user,
+        email: body.email.trim().toLowerCase(),
+        email_verified: false,
+      }
+    }
+    await json(route, state.user)
+    return
+  }
+
+  if (pathname === '/api/auth/email/confirm' && method === 'POST') {
+    const body = parseJsonBody<{ token?: string }>(request)
+    const token = body.token?.trim() ?? ''
+    state.emailVerificationConfirmCountByToken[token] =
+      (state.emailVerificationConfirmCountByToken[token] ?? 0) + 1
+
+    if (!state.validEmailVerificationTokens.includes(token)) {
+      await json(route, { error: 'Invalid email verification token' }, 400)
+      return
+    }
+
+    state.user = {
+      ...state.user,
+      email_verified: true,
+    }
+    await json(route, { message: 'Your email address has been verified.' })
     return
   }
 
@@ -352,13 +431,13 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
   }
 
   if (pathname === '/api/channels' && method === 'POST') {
-    const body = request.postDataJSON() as {
+    const body = parseJsonBody<{
       server_id?: string
       name?: string
       description?: string
       channel_type?: 'text' | 'voice'
       category?: string
-    }
+    }>(request)
     const serverId = body.server_id ?? state.servers[0]?.id ?? 'server-core'
     const existing = state.channelsByServerId[serverId] ?? []
     const name = body.name?.trim() || 'new-channel'
@@ -408,7 +487,7 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
   }
 
   if (pathname === '/api/friends/requests' && method === 'POST') {
-    const body = request.postDataJSON() as { username?: string }
+    const body = parseJsonBody<{ username?: string }>(request)
     const next = buildRequests(1, 'outgoing')[0]
     state.outgoingRequests = [
       { ...next, id: `outgoing-request-${Date.now()}`, receiver_username: body.username ?? 'New Friend' },
@@ -503,7 +582,7 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
 
   if (dmMessagesMatch && method === 'POST') {
     const channelId = dmMessagesMatch[1]
-    const body = request.postDataJSON() as { content?: string; attachments?: unknown[] }
+    const body = parseJsonBody<{ content?: string; attachments?: unknown[] }>(request)
     const message = createDmMessage(state, channelId, body.content ?? '', body.attachments ?? [])
     state.dmMessagesByChannelId[channelId] = [
       ...(state.dmMessagesByChannelId[channelId] ?? []),
@@ -533,7 +612,7 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
 
   if (serverPinsMatch && method === 'POST') {
     const channelId = serverPinsMatch[1]
-    const body = request.postDataJSON() as { message_id?: string }
+    const body = parseJsonBody<{ message_id?: string }>(request)
     const messageId = body.message_id ?? ''
     const message = findServerMessage(state, messageId)
     if (!message) {
@@ -565,7 +644,7 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
       return
     }
     const emoji = method === 'POST'
-      ? ((request.postDataJSON() as { emoji?: string }).emoji ?? '')
+      ? (parseJsonBody<{ emoji?: string }>(request).emoji ?? '')
       : (url.searchParams.get('emoji') ?? '')
     const existingReactions = message.reactions ?? []
     if (method === 'POST') {
@@ -598,7 +677,7 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
       await json(route, { error: 'Message not found' }, 404)
       return
     }
-    const body = request.postDataJSON() as { content?: string }
+    const body = parseJsonBody<{ content?: string }>(request)
     message.content = body.content ?? message.content
     message.edited_at = new Date().toISOString()
     await json(route, message)
@@ -624,7 +703,7 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
 
   if (serverMessagesMatch && method === 'POST') {
     const channelId = serverMessagesMatch[1]
-    const body = request.postDataJSON() as { content?: string; attachments?: unknown[] }
+    const body = parseJsonBody<{ content?: string; attachments?: unknown[] }>(request)
     const message = createServerMessage(state, channelId, body.content ?? '', body.attachments ?? [])
     state.messagesByChannelId[channelId] = [
       ...(state.messagesByChannelId[channelId] ?? []),
@@ -708,10 +787,24 @@ function findServerMessage(state: MockCoreState, messageId: string): MessageWith
   return null
 }
 
+function parseJsonBody<T extends Record<string, unknown>>(request: Request): Partial<T> {
+  const raw = request.postData()
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as Partial<T>
+  } catch {
+    return {}
+  }
+}
+
 async function json(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,
     contentType: 'application/json',
     body: JSON.stringify(body),
   })
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts --project=chromium",
+    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts --project=chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",

--- a/apps/web/src/pages/VerifyEmailPage.tsx
+++ b/apps/web/src/pages/VerifyEmailPage.tsx
@@ -13,7 +13,7 @@ export default function VerifyEmailPage() {
   const setUser = useAuthStore((s) => s.setUser)
   const verifyToken = useMemo(() => new URLSearchParams(location.search).get('token')?.trim() ?? '', [location.search])
   const authRef = useRef({ token, user })
-  const submittedVerificationTokensRef = useRef(new Set<string>())
+  const verificationRequestsRef = useRef(new Map<string, ReturnType<typeof authApi.confirmEmailVerification>>())
   const [verificationState, setVerificationState] = useState<{
     verifyToken: string
     status: 'success' | 'error'
@@ -31,13 +31,17 @@ export default function VerifyEmailPage() {
 
   useEffect(() => {
     if (!verifyToken) return
-    if (submittedVerificationTokensRef.current.has(verifyToken)) return
-    submittedVerificationTokensRef.current.add(verifyToken)
 
     let cancelled = false
     let redirectTimeout: number | null = null
     const { token: currentToken, user: currentUser } = authRef.current
-    authApi.confirmEmailVerification(currentToken ?? null, verifyToken)
+    let verificationRequest = verificationRequestsRef.current.get(verifyToken)
+    if (!verificationRequest) {
+      verificationRequest = authApi.confirmEmailVerification(currentToken ?? null, verifyToken)
+      verificationRequestsRef.current.set(verifyToken, verificationRequest)
+    }
+
+    verificationRequest
       .then(async (result) => {
         if (cancelled) return
         if (currentUser) {
@@ -65,10 +69,10 @@ export default function VerifyEmailPage() {
           authApi.getMe(currentToken ?? null)
             .then((freshUser) => {
               if (cancelled) return
-              if (currentToken) setAuth(currentToken, freshUser)
-              else setUser(freshUser)
+            if (currentToken) setAuth(currentToken, freshUser)
+            else setUser(freshUser)
 
-              if (freshUser.email_verified) {
+            if (freshUser.email_verified) {
                 setVerificationState({
                   verifyToken,
                   status: 'success',


### PR DESCRIPTION
## Summary
- Add mocked Playwright coverage for auth/account core regressions.
- Cover email verification resend pending state, single confirm behavior, consumed-token success handling, forgot password, and reset password flows.
- Extend the core mock API with auth feature flags and auth endpoint fixtures.
- Include the new auth regression spec in the CI core UI smoke command.
- Harden VerifyEmailPage against duplicate confirm requests under React StrictMode.

## Validation
- npm run test:e2e -- e2e/auth-core-regressions.spec.ts --project=chromium
- npm run test:e2e:ui-smoke
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .