### PR TITLE
test: cover release and settings UI regressions

### DIFF
--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -36,6 +36,10 @@ export interface MockCoreState {
   forgotPasswordRequestCount: number
   resetPasswordRequestCount: number
   validPasswordResetTokens: string[]
+  dataExportRequestCount: number
+  changePasswordRequestCount: number
+  deleteAccountRequestCount: number
+  lastDeleteAccountConfirm: string | null
 }
 
 const DEFAULT_FEATURES: SystemFeatures = {
@@ -203,6 +207,10 @@ export function createMockCoreState(overrides: Partial<MockCoreState> = {}): Moc
     forgotPasswordRequestCount: 0,
     resetPasswordRequestCount: 0,
     validPasswordResetTokens: ['valid-reset-token'],
+    dataExportRequestCount: 0,
+    changePasswordRequestCount: 0,
+    deleteAccountRequestCount: 0,
+    lastDeleteAccountConfirm: null,
     ...overrides,
   }
 }
@@ -330,6 +338,66 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
       return
     }
     await json(route, state.user)
+    return
+  }
+
+  if (pathname === '/api/auth/data-export' && method === 'GET') {
+    state.dataExportRequestCount += 1
+    await json(route, {
+      export: {
+        format: 'voxpery-data-export-v1',
+        generated_at: new Date(Date.UTC(2026, 0, 15, 12, 0, 0)).toISOString(),
+        description: 'Mocked Playwright data export.',
+        privacy_notes: ['No internal tokens are included.'],
+        limits: {
+          server_messages: 'mocked',
+          direct_messages: 'mocked',
+        },
+      },
+      account: {
+        username: state.user.username,
+        email: state.user.email ?? '',
+        status: state.user.status ?? 'online',
+        dm_privacy: state.user.dm_privacy ?? 'friends',
+        created_at: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+        google_connected: !!state.user.google_connected,
+      },
+      profile: {
+        has_avatar: !!state.user.avatar_url,
+      },
+      servers: [],
+      relationships: {
+        friends: state.friends,
+        friend_requests: [],
+      },
+      messages: {
+        server: [],
+        direct: [],
+      },
+    })
+    return
+  }
+
+  if (pathname === '/api/auth/change-password' && method === 'POST') {
+    state.changePasswordRequestCount += 1
+    await json(route, { message: 'Password changed successfully.' })
+    return
+  }
+
+  if (pathname === '/api/auth/account' && method === 'DELETE') {
+    state.deleteAccountRequestCount += 1
+    const body = parseJsonBody<{ confirm?: string }>(request)
+    state.lastDeleteAccountConfirm = body.confirm ?? null
+    if (body.confirm !== 'DELETE') {
+      await json(route, { error: 'Invalid confirmation text' }, 400)
+      return
+    }
+    await json(route, { message: 'Account deleted.' })
+    return
+  }
+
+  if (pathname === '/api/auth/logout' && method === 'POST') {
+    await json(route, {})
     return
   }
 

--- a/apps/web/e2e/release-settings-core-regressions.spec.ts
+++ b/apps/web/e2e/release-settings-core-regressions.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test'
+import {
+  buildFriends,
+  createMockCoreState,
+  installMockCoreApi,
+} from './mock-core-api'
+
+test.describe('mocked release and settings regressions', () => {
+  test('shows the beta channel and build version in a single brand badge', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(3) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+
+    const releaseBadge = page.locator('.shell-brand-release')
+    await expect(releaseBadge).toBeVisible()
+    await expect(releaseBadge).toContainText('Beta')
+    await expect(releaseBadge).toContainText('v0.2.0-test')
+    await expect(releaseBadge).toHaveAttribute('title', 'Beta channel, running build v0.2.0-test')
+
+    const hasHorizontalOverflow = await page.locator('.shell-topbar').evaluate((element) => {
+      return element.scrollWidth > element.clientWidth + 1
+    })
+    expect(hasHorizontalOverflow).toBe(false)
+  })
+
+  test('keeps profile password modal validation and submission wired', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(2) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+    await page.locator('.user-setting-row', { hasText: 'Password' }).getByRole('button', { name: 'Change' }).click()
+    const passwordModal = page.locator('.pw-modal', { hasText: 'Change password' })
+    await expect(passwordModal).toBeVisible()
+
+    const currentPassword = passwordModal.locator('#pw-old')
+    const newPassword = passwordModal.locator('#pw-new')
+    const confirmPassword = passwordModal.locator('#pw-confirm')
+    const confirmButton = passwordModal.getByRole('button', { name: 'Confirm' })
+
+    await expect(confirmButton).toBeDisabled()
+    await currentPassword.fill('old-password-123')
+    await newPassword.fill('new-password-123')
+    await confirmPassword.fill('different-password')
+    await expect(passwordModal.getByText('Passwords do not match')).toBeVisible()
+    await expect(confirmButton).toBeDisabled()
+
+    await confirmPassword.fill('new-password-123')
+    await expect(confirmButton).toBeEnabled()
+    await confirmButton.click()
+
+    await expect(passwordModal.getByText(/Password changed! Redirecting to login/)).toBeVisible()
+    expect(state.changePasswordRequestCount).toBe(1)
+  })
+
+  test('keeps Privacy & Data export and delete-account guardrails reachable', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(2) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('button', { name: 'Privacy & Data' }).click()
+
+    const modal = page.locator('.user-settings-modal')
+    await expect(modal).toContainText('Data export')
+    await expect(modal).toContainText('Delete account')
+
+    const downloadPromise = page.waitForEvent('download')
+    await modal.locator('.user-setting-row', { hasText: 'Data export' }).getByRole('button', { name: /Export/ }).click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toMatch(/^voxpery-data-export-\d{4}-\d{2}-\d{2}\.json$/)
+    await expect(page.locator('.toast-item', { hasText: 'Data export ready' })).toBeVisible()
+    expect(state.dataExportRequestCount).toBe(1)
+
+    await modal.locator('.user-setting-row', { hasText: 'Delete account' }).getByRole('button', { name: 'Manage' }).click()
+    const deleteModal = page.locator('.delete-account-modal')
+    await expect(deleteModal).toBeVisible()
+    const deleteButton = deleteModal.getByRole('button', { name: 'Delete account' })
+    await expect(deleteButton).toBeDisabled()
+
+    await deleteModal.locator('#delete-password').fill('current-password-123')
+    await deleteModal.locator('#delete-confirm').fill('DELETE')
+    await expect(deleteModal.getByText('Confirmation text is valid.')).toBeVisible()
+    await expect(deleteButton).toBeEnabled()
+    await deleteButton.click()
+
+    await expect(page).toHaveURL(/\/login/)
+    expect(state.deleteAccountRequestCount).toBe(1)
+    expect(state.lastDeleteAccountConfirm).toBe('DELETE')
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts --project=chromium",
+    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts --project=chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -38,5 +38,9 @@ export default defineConfig({
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
+    env: {
+      ...process.env,
+      VITE_APP_VERSION: process.env.VITE_APP_VERSION ?? '0.2.0-test',
+    },
   },
 })


### PR DESCRIPTION
## Summary

- Add mocked Playwright coverage for release/version and account settings regressions.
- Cover the combined Beta + version brand badge, password modal validation/submission, data export download, and delete-account confirmation guardrails.
- Extend the mocked core API with account export, password change, account deletion, and logout fixtures.
- Include the new release/settings regression spec in the core UI smoke command.
- Set a deterministic `VITE_APP_VERSION` for Playwright webServer runs when no version is provided.

## Validation

- npm run test:e2e -- e2e/release-settings-core-regressions.spec.ts --project=chromium
- npm run test:e2e:ui-smoke
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .