### PR TITLE
test: cover social friend UI regressions

### DIFF
--- a/apps/web/e2e/social-friend-core-regressions.spec.ts
+++ b/apps/web/e2e/social-friend-core-regressions.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test'
+import {
+  buildFriends,
+  buildRequests,
+  createMockCoreState,
+  installMockCoreApi,
+} from './mock-core-api'
+
+test.describe('mocked social friend UI regressions', () => {
+  test('sends a friend request and keeps the outgoing request visible', async ({ page }) => {
+    const state = createMockCoreState({
+      friends: [],
+      incomingRequests: [],
+      outgoingRequests: [],
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: /Requests/ }).click()
+    await page.getByPlaceholder('Enter username').fill('newfriend')
+    await page.getByRole('button', { name: 'Send Request' }).click()
+
+    await expect(page.getByText('Friend request sent.')).toBeVisible()
+    await expect(page.getByText('Pending to')).toBeVisible()
+    await expect(page.getByText('newfriend')).toBeVisible()
+    expect(state.outgoingRequests[0]?.receiver_username).toBe('newfriend')
+  })
+
+  test('accepts and rejects incoming friend requests from the Requests tab', async ({ page }) => {
+    const state = createMockCoreState({
+      friends: [],
+      incomingRequests: buildRequests(2, 'incoming'),
+      outgoingRequests: [],
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: /Requests/ }).click()
+
+    await page.getByRole('button', { name: 'Accept friend request from Request In 01' }).click()
+    await expect(page.getByText('Request In 01')).toBeHidden()
+    expect(state.friends.some((friend) => friend.username === 'Request In 01')).toBe(true)
+
+    await page.getByRole('button', { name: 'Reject friend request from Request In 02' }).click()
+    await expect(page.getByText('Request In 02')).toBeHidden()
+    expect(state.incomingRequests).toHaveLength(0)
+
+    await page.getByRole('button', { name: /All/ }).click()
+    await expect(page.getByText('All Friends — 1')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Message Request In 01' })).toBeVisible()
+  })
+
+  test('cancels an outgoing friend request without clearing incoming requests', async ({ page }) => {
+    const state = createMockCoreState({
+      friends: [],
+      incomingRequests: buildRequests(1, 'incoming'),
+      outgoingRequests: buildRequests(2, 'outgoing'),
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: /Requests/ }).click()
+    await page.getByRole('button', { name: 'Cancel request to Request Out 01' }).click()
+
+    await expect(page.getByText('Request Out 01')).toBeHidden()
+    await expect(page.getByText('Request Out 02')).toBeVisible()
+    await expect(page.getByText('Request In 01')).toBeVisible()
+    expect(state.outgoingRequests.map((request) => request.receiver_username)).toEqual(['Request Out 02'])
+    expect(state.incomingRequests).toHaveLength(1)
+  })
+
+  test('removes a friend only after confirmation', async ({ page }) => {
+    const state = createMockCoreState({
+      friends: buildFriends(2),
+      incomingRequests: [],
+      outgoingRequests: [],
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: /All/ }).click()
+    await page.getByRole('button', { name: 'Remove Friend 01 as friend' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Remove friend?' })).toBeVisible()
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByRole('button', { name: 'Message Friend 01' })).toBeVisible()
+    expect(state.friends.some((friend) => friend.id === 'friend-01')).toBe(true)
+
+    await page.getByRole('button', { name: 'Remove Friend 01 as friend' }).click()
+    await page.getByRole('button', { name: 'Remove', exact: true }).click()
+
+    await expect(page.getByRole('button', { name: 'Message Friend 01' })).toBeHidden()
+    await expect(page.getByRole('button', { name: 'Message Friend 02' })).toBeVisible()
+    expect(state.friends.some((friend) => friend.id === 'friend-01')).toBe(false)
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts --project=chromium",
+    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts e2e/social-friend-core-regressions.spec.ts --project=chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1091,10 +1091,20 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                         <div key={r.id} className="home-request-row">
                           <span>{r.requester_username}</span>
                           <div className="home-request-actions">
-                            <button type="button" className="home-request-btn accept" onClick={() => acceptRequest(r.id)}>
+                            <button
+                              type="button"
+                              className="home-request-btn accept"
+                              aria-label={`Accept friend request from ${r.requester_username}`}
+                              onClick={() => acceptRequest(r.id)}
+                            >
                               <Check size={14} />
                             </button>
-                            <button type="button" className="home-request-btn reject" onClick={() => rejectRequest(r.id)}>
+                            <button
+                              type="button"
+                              className="home-request-btn reject"
+                              aria-label={`Reject friend request from ${r.requester_username}`}
+                              onClick={() => rejectRequest(r.id)}
+                            >
                               <X size={14} />
                             </button>
                           </div>
@@ -1220,6 +1230,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                                 type="button"
                                 className="home-member-action danger"
                                 title="Remove friend"
+                                aria-label={`Remove ${friend.username} as friend`}
                                 disabled={openingDmPeerId === friend.id}
                                 onClick={(e) => {
                                   e.stopPropagation()


### PR DESCRIPTION
## Summary
- Add mocked Playwright regressions for social friend flows.
- Cover sending friend requests, accepting/rejecting incoming requests, canceling outgoing requests, and remove-friend confirmation.
- Add accessible labels to friend request and remove-friend icon actions.
- Include the new social/friend spec in the core UI smoke command.

## Validation
- npm run test:e2e -- e2e/social-friend-core-regressions.spec.ts --project=chromium
- npm run test:e2e:ui-smoke
- npm run lint
- npm run test:run
- npm run build
- git diff --check
- graphify update .