### PR TITLE
test: cover invite and desktop smoke flows

### DIFF
--- a/apps/web/e2e/invite-desktop-core-regressions.spec.ts
+++ b/apps/web/e2e/invite-desktop-core-regressions.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from '@playwright/test'
+import {
+  buildCoreChannels,
+  buildCoreMembers,
+  buildCoreRules,
+  buildCoreServer,
+  createMockCoreState,
+  installMockCoreApi,
+} from './mock-core-api'
+
+async function installMockTauriRuntime(page: Page) {
+  await page.addInitScript(() => {
+    const tauriInternals = {
+      invoke: async (cmd: string, args?: { payload?: { prefixedKey?: string } }) => {
+        if (cmd === 'plugin:app|version') return '0.2.0-desktop-test'
+        if (cmd === 'plugin:updater|check') return null
+        if (cmd === 'plugin:autostart|is_enabled') return true
+        if (cmd === 'plugin:secure-storage|get_item' && args?.payload?.prefixedKey === 'voxpery-auth-token') {
+          return 'mock-token'
+        }
+        return null
+      },
+      transformCallback: () => 1,
+      unregisterCallback: () => {},
+      convertFileSrc: (filePath: string) => filePath,
+    }
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      value: tauriInternals,
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'userAgent', {
+      value: `${navigator.userAgent} Tauri Windows`,
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'platform', {
+      value: 'Win32',
+      configurable: true,
+    })
+  })
+}
+
+test.describe('mocked invite and desktop runtime regressions', () => {
+  test('redirects unauthenticated invite visitors to login with the invite return path', async ({ page }) => {
+    const state = createMockCoreState({ authenticated: false })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/invite/core-invite')
+
+    await expect(page).toHaveURL(/\/login\?redirect=%2Finvite%2Fcore-invite/)
+  })
+
+  test('requires server rules acceptance before joining from an invite', async ({ page }) => {
+    const inviteServer = buildCoreServer({
+      id: 'server-invite-core',
+      name: 'Invite Guild',
+      description: 'A joinable community for release smoke coverage.',
+      invite_code: 'core-invite',
+    })
+    const channels = buildCoreChannels(inviteServer.id)
+    const state = createMockCoreState({
+      servers: [],
+      inviteServersByCode: { [inviteServer.invite_code]: inviteServer },
+      channelsByServerId: { [inviteServer.id]: channels },
+      membersByServerId: { [inviteServer.id]: buildCoreMembers() },
+      serverRulesByServerId: { [inviteServer.id]: buildCoreRules(inviteServer.id) },
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/invite/core-invite')
+
+    await expect(page.getByRole('heading', { name: 'Join server' })).toBeVisible()
+    await expect(page.getByText('Invite Guild')).toBeVisible()
+    await expect(page.getByText('A joinable community for release smoke coverage.')).toBeVisible()
+    await expect(page.getByText('Server Rules', { exact: true })).toBeVisible()
+    await expect(page.getByText('Be respectful to other members.')).toBeVisible()
+
+    const joinButton = page.getByRole('button', { name: 'Join server' })
+    await expect(joinButton).toBeDisabled()
+
+    await page.getByLabel('I have read and agree to the server rules').check()
+    await expect(joinButton).toBeEnabled()
+    await joinButton.click()
+
+    await expect(page).toHaveURL(/\/servers/)
+    await expect(page.getByText('Invite Guild').first()).toBeVisible()
+    expect(state.serverJoinCount).toBe(1)
+    expect(state.joinedInviteCodes).toEqual(['core-invite'])
+    expect(state.servers.some((server) => server.id === inviteServer.id)).toBe(true)
+  })
+
+  test('keeps desktop-only settings visible when the web shell runs inside Tauri', async ({ page }) => {
+    const state = createMockCoreState()
+    await installMockTauriRuntime(page)
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Desktop' }).click()
+    await expect(page.locator('.user-settings-modal')).toContainText('App updates')
+    await expect(page.locator('.user-settings-modal')).toContainText('Installed version: 0.2.0-desktop-test.')
+    await expect(page.locator('.user-settings-modal')).toContainText('Launch on startup')
+    await expect(page.locator('.user-settings-modal')).toContainText('Keep running in tray on close')
+  })
+})

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -11,6 +11,7 @@ import type {
   RaidEventEntry,
   Server,
   ServerBanEntry,
+  ServerInvitePreview,
   ServerOnboardingGuide,
   ServerReportEntry,
   ServerRole,
@@ -33,6 +34,7 @@ export interface MockCoreState {
   dmChannels: DmChannel[]
   dmMessagesByChannelId: Record<string, MessageWithAuthor[]>
   servers: Server[]
+  inviteServersByCode: Record<string, Server>
   serverPermissionsByServerId: Record<string, number>
   channelsByServerId: Record<string, Channel[]>
   membersByServerId: Record<string, MemberInfo[]>
@@ -48,6 +50,8 @@ export interface MockCoreState {
   messagesByChannelId: Record<string, MessageWithAuthor[]>
   pinnedMessageIdsByChannelId: Record<string, string[]>
   serverUpdateCount: number
+  serverJoinCount: number
+  joinedInviteCodes: string[]
   onboardingUpdateCount: number
   emailVerificationRequestCount: number
   emailVerificationConfirmCountByToken: Record<string, number>
@@ -107,6 +111,17 @@ export function buildCoreServer(overrides: Partial<Server> = {}): Server {
     owner_id: 'user-local',
     invite_code: 'core-guild',
     ...overrides,
+  }
+}
+
+export function buildInvitePreview(server: Server, memberCount = 8): ServerInvitePreview {
+  return {
+    id: server.id,
+    name: server.name,
+    icon_url: server.icon_url,
+    description: server.description,
+    invite_code: server.invite_code,
+    member_count: memberCount,
   }
 }
 
@@ -312,6 +327,7 @@ export function createMockCoreState(overrides: Partial<MockCoreState> = {}): Moc
     dmChannels: [],
     dmMessagesByChannelId: {},
     servers: [],
+    inviteServersByCode: {},
     serverPermissionsByServerId: {},
     channelsByServerId: {},
     membersByServerId: {},
@@ -327,6 +343,8 @@ export function createMockCoreState(overrides: Partial<MockCoreState> = {}): Moc
     messagesByChannelId: {},
     pinnedMessageIdsByChannelId: {},
     serverUpdateCount: 0,
+    serverJoinCount: 0,
+    joinedInviteCodes: [],
     onboardingUpdateCount: 0,
     emailVerificationRequestCount: 0,
     emailVerificationConfirmCountByToken: {},
@@ -584,6 +602,37 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
 
   if (pathname === '/api/servers' && method === 'GET') {
     await json(route, state.servers)
+    return
+  }
+
+  const invitePreviewMatch = pathname.match(/^\/api\/servers\/invite\/([^/]+)$/)
+  if (invitePreviewMatch && method === 'GET') {
+    const inviteCode = decodeURIComponent(invitePreviewMatch[1] ?? '')
+    const server = findInviteServer(state, inviteCode)
+    if (!server) {
+      await json(route, { error: 'Invalid invite code' }, 404)
+      return
+    }
+    await json(route, buildInvitePreview(server, (state.membersByServerId[server.id] ?? buildCoreMembers()).length))
+    return
+  }
+
+  if (pathname === '/api/servers/join' && method === 'POST') {
+    const body = parseJsonBody<{ invite_code?: string }>(request)
+    const inviteCode = body.invite_code?.trim() ?? ''
+    const server = findInviteServer(state, inviteCode)
+    if (!server) {
+      await json(route, { error: 'Invalid invite code' }, 404)
+      return
+    }
+    if (!state.servers.some((item) => item.id === server.id)) {
+      state.servers = [...state.servers, server]
+    }
+    state.channelsByServerId[server.id] = state.channelsByServerId[server.id] ?? buildCoreChannels(server.id)
+    state.membersByServerId[server.id] = state.membersByServerId[server.id] ?? buildCoreMembers()
+    state.serverJoinCount += 1
+    state.joinedInviteCodes = [...state.joinedInviteCodes, inviteCode]
+    await json(route, server)
     return
   }
 
@@ -1209,6 +1258,12 @@ function findServerMessage(state: MockCoreState, messageId: string): MessageWith
     if (message) return message
   }
   return null
+}
+
+function findInviteServer(state: MockCoreState, inviteCode: string): Server | null {
+  return state.inviteServersByCode[inviteCode]
+    ?? state.servers.find((server) => server.invite_code === inviteCode)
+    ?? null
 }
 
 function getServerRoles(state: MockCoreState, serverId: string): ServerRole[] {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts e2e/social-friend-core-regressions.spec.ts e2e/server-settings-core-regressions.spec.ts --project=chromium",
+    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts e2e/social-friend-core-regressions.spec.ts e2e/server-settings-core-regressions.spec.ts e2e/invite-desktop-core-regressions.spec.ts --project=chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -46,6 +46,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Password reset request + reset flow works.
 - [ ] Google OAuth login works.
 - [ ] Server/channel/category permission scenarios work.
+- [ ] Invite links show the target server, enforce community rules acknowledgement when rules exist, and join into the expected server.
 - [ ] Voice join/leave works.
 - [ ] `docs/VOICE_RELEASE_SMOKE_TEST.md` completed and recorded as `GO` for voice behavior when the release touches voice, LiveKit/WebRTC, camera, screen share, audio settings, service worker caching, desktop runtime, or build output.
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
@@ -66,6 +67,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.
 - [ ] Uploaded chat image attachments render inline after channel/server navigation and open only in the in-app preview modal on web and desktop, with no external tab/browser navigation.
+- [ ] Automated core UI smoke includes invite/join, server settings, social/friend, auth/account, release/settings, permission, and desktop-runtime regressions.
 
 ## 4) Desktop Smoke Tests (mandatory)
 
@@ -87,6 +89,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Updater check shows a clear no-update state when no newer version is available.
 - [ ] Updater check shows the available version when a newer signed release is available.
 - [ ] Update availability appears as one calm toast plus a compact install pill; settings still provides manual check/install.
+- [ ] Desktop settings still exposes app updates, launch-on-startup, and tray-on-close controls when the web shell runs inside Tauri.
 - [ ] Updater install path prepares the desktop runtime before install/relaunch.
 - [ ] Failed updater check/install shows recoverable UI and does not leave settings stuck.
 - [ ] Linux desktop test host has `xdg-desktop-portal` + (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` running.


### PR DESCRIPTION
## Summary

- Add Playwright coverage for invite links, server-rule acknowledgement, and successful invite joins.
- Add a mocked Tauri runtime smoke test that verifies desktop-only settings remain visible in the web shell.
- Extend the core E2E mock API with invite preview and join endpoints.
- Include the new regression spec in `test:e2e:ui-smoke`.
- Update the release smoke checklist with invite/join and desktop-runtime coverage.

## Validation

- `npm --prefix apps/web run test:e2e -- e2e/invite-desktop-core-regressions.spec.ts --project=chromium`
- `npm --prefix apps/web run test:e2e:ui-smoke`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test:run`
- `npm --prefix apps/web run build`
- `graphify update .`