### PR TITLE
feat: expose voice benchmark diagnostics

### DIFF
--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -2,6 +2,10 @@ import { useCallback, useRef } from 'react'
 import { createRnnoiseNode, type RnnoiseNode } from '../rnnoise'
 import { getOrCreateAudioContext, playCueStack } from '../../audioCues'
 import {
+    getSliderFromStorage,
+    getStoredSpeakingPreset,
+} from '../sensitivityThreshold'
+import {
     getStoredVoiceInputProfile,
     getStoredVoiceSuppressionTuning,
     shouldUseAggressiveVoiceIsolation,
@@ -21,6 +25,10 @@ function pickSuppressionValue<T>(
     values: { off: T; balanced: T; high: T },
 ): T {
     return values[tuning]
+}
+
+function thresholdDbFromSlider(slider: number): number {
+    return Math.max(-100, Math.min(0, Math.round(slider - 100)))
 }
 
 function getBandAverageDb(
@@ -153,12 +161,17 @@ function buildSuppressionConfig(
     noiseSuppressionEnabled: boolean,
 ): LiveSuppressionConfig {
     const profile = getStoredVoiceInputProfile()
+    const speakingPreset = getStoredSpeakingPreset()
+    const speakingThreshold = getSliderFromStorage()
     const aggressiveIsolation = shouldUseAggressiveVoiceIsolation(profile, noiseSuppressionEnabled)
     const suppressionTuning = getStoredVoiceSuppressionTuning(noiseSuppressionEnabled)
 
     updateVoiceDiagnostics({
         noiseSuppressionEnabled,
         voiceInputProfile: profile,
+        speakingPreset,
+        speakingThreshold,
+        speakingThresholdDb: thresholdDbFromSlider(speakingThreshold),
         suppressionTuning,
         aggressiveIsolation,
     })

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -95,6 +95,9 @@ describe('voiceDiagnostics', () => {
       rnnoiseStatus: 'ready',
       noiseSuppressionEnabled: true,
       voiceInputProfile: 'custom',
+      speakingPreset: 'noisy',
+      speakingThreshold: 60,
+      speakingThresholdDb: -40,
       suppressionTuning: 'high',
       aggressiveIsolation: true,
     })
@@ -103,6 +106,9 @@ describe('voiceDiagnostics', () => {
       rnnoiseStatus: 'ready',
       noiseSuppressionEnabled: true,
       voiceInputProfile: 'custom',
+      speakingPreset: 'noisy',
+      speakingThreshold: 60,
+      speakingThresholdDb: -40,
       suppressionTuning: 'high',
       aggressiveIsolation: true,
     })

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -6,6 +6,9 @@ export interface VoiceRuntimeDiagnostics {
   rnnoiseWorkletUrl?: string
   noiseSuppressionEnabled?: boolean
   voiceInputProfile?: string
+  speakingPreset?: string
+  speakingThreshold?: number
+  speakingThresholdDb?: number
   suppressionTuning?: string
   aggressiveIsolation?: boolean
   updatedAt?: string

--- a/docs/VOICE_QUALITY_BENCHMARK.md
+++ b/docs/VOICE_QUALITY_BENCHMARK.md
@@ -85,6 +85,9 @@ Required diagnostic fields:
 
 - `rnnoiseStatus` is `ready` when suppression is on.
 - `noiseSuppressionEnabled` is `true`.
+- `speakingPreset` is `normal` for the `Balanced` run and `noisy` for the `Noisy room` run.
+- `speakingThreshold` is `42` for the `Balanced` run and `60` for the `Noisy room` run.
+- `speakingThresholdDb` is `-58` for the `Balanced` run and `-40` for the `Noisy room` run.
 - `suppressionTuning` is `balanced` for the `Balanced` run.
 - `suppressionTuning` is `high` for the `Noisy room` run.
 - `aggressiveIsolation` is `true` for noisy-room isolation.


### PR DESCRIPTION
## Summary

- Expose active voice benchmark preset and threshold details in runtime diagnostics.
- Add `speakingPreset`, `speakingThreshold`, and `speakingThresholdDb` to `window.__VOXPERY_VOICE_DIAGNOSTICS__`.
- Update the voice quality benchmark checklist to require those diagnostic fields.
- Extend diagnostics tests to cover the new benchmark fields.

## Validation

- `npm --prefix apps/web run test:run -- src/webrtc/voiceDiagnostics.test.ts src/webrtc/voiceQualityBenchmarkConfig.test.ts`
- `npm --prefix apps/web run test:run`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`
- `git diff --check`
- `graphify update .`