### PR TITLE
feat: add voice benchmark diagnostics copy

### DIFF
--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -73,6 +73,10 @@ import {
   type MicrophonePermissionState,
   type VoiceDeviceOption,
 } from '../voiceDevices'
+import {
+  formatVoiceDiagnosticsSnapshot,
+  getVoiceDiagnosticsSnapshot,
+} from '../webrtc/voiceDiagnostics'
 
 const MAX_PROFILE_IMAGE_BYTES = 2 * 1024 * 1024
 const SETTINGS_CHANGED_EVENT = VOICE_SETTINGS_CHANGED_EVENT
@@ -1181,6 +1185,33 @@ export default function UserBar() {
     }
   }
 
+  const copyVoiceBenchmarkDiagnostics = async () => {
+    const snapshot = getVoiceDiagnosticsSnapshot()
+    if (!snapshot) {
+      pushToast({
+        level: 'info',
+        title: 'Voice diagnostics unavailable',
+        message: 'Enable voice diagnostics from the benchmark checklist, reload, and join voice before copying.',
+      })
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(formatVoiceDiagnosticsSnapshot(snapshot))
+      pushToast({
+        level: 'info',
+        title: 'Voice diagnostics copied',
+        message: 'Paste this JSON into the voice quality benchmark notes.',
+      })
+    } catch {
+      pushToast({
+        level: 'error',
+        title: 'Could not copy diagnostics',
+        message: 'Clipboard access was blocked by the browser or desktop shell.',
+      })
+    }
+  }
+
   const isGoogleOnlyAccount = user?.google_connected === true && user?.has_password !== true
   const currentInputDevice = inputDevices.find((device) => device.id === selectedInputDeviceId) ?? DEFAULT_INPUT_DEVICE_OPTION
   const currentOutputDevice = outputDevices.find((device) => device.id === selectedOutputDeviceId) ?? DEFAULT_OUTPUT_DEVICE_OPTION
@@ -1733,6 +1764,19 @@ export default function UserBar() {
                         </button>
                       </div>
                     )}
+                    <div className="user-setting-row user-setting-row--span-two">
+                      <div>
+                        <div className="user-setting-title">Benchmark diagnostics</div>
+                        <div className="user-setting-desc">Copy the active voice diagnostics snapshot for benchmark notes.</div>
+                      </div>
+                      <button
+                        type="button"
+                        className="user-toggle account-action-btn"
+                        onClick={() => void copyVoiceBenchmarkDiagnostics()}
+                      >
+                        Copy diagnostics
+                      </button>
+                    </div>
                   </div>
                 </div>
               </section>

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   VOICE_DIAGNOSTICS_STORAGE_KEY,
   classifyVoiceError,
+  formatVoiceDiagnosticsSnapshot,
+  getVoiceDiagnosticsSnapshot,
   getVoiceNetworkQuality,
   getVoiceQualityAdvice,
   getVoicePingLevel,
@@ -113,5 +115,29 @@ describe('voiceDiagnostics', () => {
       aggressiveIsolation: true,
     })
     expect(window.__VOXPERY_VOICE_DIAGNOSTICS__?.updatedAt).toEqual(expect.any(String))
+  })
+
+  it('returns a copyable runtime diagnostics snapshot', () => {
+    window.localStorage.setItem(VOICE_DIAGNOSTICS_STORAGE_KEY, '1')
+    updateVoiceDiagnostics({
+      rnnoiseStatus: 'ready',
+      noiseSuppressionEnabled: true,
+      voiceInputProfile: 'isolation',
+      speakingPreset: 'normal',
+      speakingThreshold: 42,
+      speakingThresholdDb: -58,
+      suppressionTuning: 'balanced',
+      aggressiveIsolation: true,
+    })
+
+    const snapshot = getVoiceDiagnosticsSnapshot()
+    expect(snapshot).toMatchObject({
+      rnnoiseStatus: 'ready',
+      speakingPreset: 'normal',
+      speakingThresholdDb: -58,
+      suppressionTuning: 'balanced',
+    })
+    expect(snapshot).not.toBe(window.__VOXPERY_VOICE_DIAGNOSTICS__)
+    expect(formatVoiceDiagnosticsSnapshot(snapshot!)).toContain('"speakingThresholdDb": -58')
   })
 })

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -46,6 +46,16 @@ export function updateVoiceDiagnostics(patch: VoiceRuntimeDiagnostics): void {
   }
 }
 
+export function getVoiceDiagnosticsSnapshot(): VoiceRuntimeDiagnostics | null {
+  if (typeof window === 'undefined') return null
+  const snapshot = window.__VOXPERY_VOICE_DIAGNOSTICS__
+  return snapshot ? { ...snapshot } : null
+}
+
+export function formatVoiceDiagnosticsSnapshot(snapshot: VoiceRuntimeDiagnostics): string {
+  return JSON.stringify(snapshot, null, 2)
+}
+
 export type VoiceQualityLevel = 'unknown' | 'good' | 'fair' | 'poor'
 
 export interface VoiceNetworkMetrics {

--- a/docs/VOICE_QUALITY_BENCHMARK.md
+++ b/docs/VOICE_QUALITY_BENCHMARK.md
@@ -81,6 +81,8 @@ After joining voice, capture:
 window.__VOXPERY_VOICE_DIAGNOSTICS__
 ```
 
+You can also open User Settings -> Voice & Audio and click `Copy diagnostics` to copy the same JSON snapshot into the benchmark notes.
+
 Required diagnostic fields:
 
 - `rnnoiseStatus` is `ready` when suppression is on.


### PR DESCRIPTION
## Summary

- Add a Voice & Audio settings action to copy the active voice benchmark diagnostics JSON.
- Add diagnostics snapshot/format helpers so benchmark data can be captured without manually reading DevTools globals.
- Update the voice quality benchmark docs with the new Copy diagnostics flow.
- Extend diagnostics unit tests to cover the copyable snapshot.

## Validation

- `npm --prefix apps/web run test:run -- src/webrtc/voiceDiagnostics.test.ts`
- `npm --prefix apps/web run test:run`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`
- `git diff --check`
- `graphify update .`