### PR TITLE
feat: expand voice benchmark diagnostics

### DIFF
--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -11,7 +11,15 @@ import {
     shouldUseAggressiveVoiceIsolation,
     type VoiceSuppressionTuning,
 } from '../voiceInputProfile'
-import { updateVoiceDiagnostics } from '../voiceDiagnostics'
+import { buildMicProcessingConstraints } from '../../voiceDevices'
+import {
+    linearToDbDiagnostic,
+    roundVoiceDiagnosticNumber,
+    toVoiceAudioContextDiagnostics,
+    toVoiceProcessingConstraintsDiagnostics,
+    toVoiceTrackSettingsDiagnostics,
+    updateVoiceDiagnostics,
+} from '../voiceDiagnostics'
 
 const SOUND_KEY = 'voxpery-settings-sound-enabled'
 const NOISE_SUPPRESSION_KEY = 'voxpery-settings-noise-suppression'
@@ -167,6 +175,7 @@ function buildSuppressionConfig(
     const suppressionTuning = getStoredVoiceSuppressionTuning(noiseSuppressionEnabled)
 
     updateVoiceDiagnostics({
+        benchmarkSchemaVersion: 1,
         noiseSuppressionEnabled,
         voiceInputProfile: profile,
         speakingPreset,
@@ -365,6 +374,16 @@ export function useAudioEngine() {
             await ctx.resume()
         }
 
+        updateVoiceDiagnostics({
+            benchmarkSchemaVersion: 1,
+            captureConstraints: toVoiceProcessingConstraintsDiagnostics(
+                buildMicProcessingConstraints(noiseSuppressionEnabled),
+            ),
+            rawMicTrackSettings: toVoiceTrackSettingsDiagnostics(rawTrack.getSettings?.()),
+            audioContext: toVoiceAudioContextDiagnostics(ctx),
+            inputVolume: roundVoiceDiagnosticNumber(volumeFactor, 2),
+        })
+
         const source = ctx.createMediaStreamSource(sourceStream)
         const suppressionConfig = buildSuppressionConfig(noiseSuppressionEnabled)
         const { aggressiveIsolation, suppressionTuning } = suppressionConfig
@@ -437,12 +456,17 @@ export function useAudioEngine() {
         const processedTrack = destination.stream.getAudioTracks()[0]
         if (!processedTrack) return { track: rawTrack, vadStream: sourceStream, cancelGate: () => {} }
 
+        updateVoiceDiagnostics({
+            processedMicTrackSettings: toVoiceTrackSettingsDiagnostics(processedTrack.getSettings?.()),
+        })
+
         inputGainNodeRef.current = volumeGainNode
         const analyserBuffer = new Float32Array(Math.max(128, refinementAnalyser.frequencyBinCount, refinementAnalyser.fftSize))
         const frequencyBuffer = new Float32Array(Math.max(32, refinementAnalyser.frequencyBinCount))
         let rafId: number | null = null
         let currentFloorGain = 1
         let currentIsolationGain = 1
+        let lastProcessingDiagnosticsAt = 0
 
         const cancelGate = () => {
             if (rafId != null) {
@@ -549,6 +573,7 @@ export function useAudioEngine() {
                 const liveSuppressionConfig = liveSuppressionConfigRef.current ?? suppressionConfig
                 let targetGain = 1
                 let targetIsolationGain = 1
+                let likelySpeech = false
 
                 if (refinementEnabled) {
                     if (rms <= liveSuppressionConfig.lowFloorThr) {
@@ -567,7 +592,7 @@ export function useAudioEngine() {
                         liveSuppressionConfig.openFloorThr,
                         liveSuppressionConfig.aggressiveIsolation,
                     )
-                    const likelySpeech = isLikelySpeechFrame(
+                    likelySpeech = isLikelySpeechFrame(
                         frequencyBuffer,
                         ctx.sampleRate,
                         refinementAnalyser.fftSize,
@@ -597,6 +622,18 @@ export function useAudioEngine() {
                     ctx.currentTime,
                     targetIsolationGain > currentIsolationGain ? 0.03 : 0.06,
                 )
+                const nowMs = Date.now()
+                if (nowMs - lastProcessingDiagnosticsAt >= 750) {
+                    lastProcessingDiagnosticsAt = nowMs
+                    updateVoiceDiagnostics({
+                        liveProcessing: {
+                            rmsDb: linearToDbDiagnostic(rms),
+                            floorGain: roundVoiceDiagnosticNumber(currentFloorGain, 3),
+                            isolationGain: roundVoiceDiagnosticNumber(currentIsolationGain, 3),
+                            likelySpeech,
+                        },
+                    })
+                }
             } catch {
                 // ignore
             }

--- a/apps/web/src/webrtc/hooks/useVoiceActivity.ts
+++ b/apps/web/src/webrtc/hooks/useVoiceActivity.ts
@@ -4,6 +4,7 @@ import { useAppStore } from '../../stores/app'
 import { getThresholdsFromStorage } from '../sensitivityThreshold'
 import { getStoredVoiceInputProfile, shouldUseAggressiveVoiceIsolation } from '../voiceInputProfile'
 import { evaluateVoiceGateFrame } from '../voiceGate'
+import { linearToDbDiagnostic, updateVoiceDiagnostics } from '../voiceDiagnostics'
 
 const VOICE_MODE_KEY = 'voxpery-settings-voice-mode'
 const PTT_KEY_KEY = 'voxpery-settings-ptt-key'
@@ -32,7 +33,7 @@ export function useVoiceActivity(options: {
     const monitorSourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
     const monitorAnalyserRef = useRef<AnalyserNode | null>(null)
 
-    const getVoiceModeSettings = useCallback(() => {
+    const getVoiceModeSettings = useCallback((): { mode: VoiceMode; key: string } => {
         const modeRaw = localStorage.getItem(VOICE_MODE_KEY)
         const mode = modeRaw === 'push_to_talk' ? 'push_to_talk' : 'voice_activity'
         const keyRaw = localStorage.getItem(PTT_KEY_KEY)
@@ -204,6 +205,7 @@ export function useVoiceActivity(options: {
         let monAboveCount = 0
         let monBelowCount = 0
         let smoothRms = 0
+        let lastVoiceActivityDiagnosticsAt = 0
         // Hold after going quiet so short pauses inside one sentence do not drop the ring.
         // Keep release fairly short so keyboard clicks do not hold the gate open.
         useAppStore.getState().setVoiceSpeaking(useAppStore.getState().voiceSpeakingUserIds, false)
@@ -240,7 +242,8 @@ export function useVoiceActivity(options: {
                     monAboveCount = decision.openFrames
                     monBelowCount = decision.belowFrames
                     smoothRms = decision.smoothedRms
-                    if (decision.speaking !== monLastSpeaking) {
+                    const speakingChanged = decision.speaking !== monLastSpeaking
+                    if (speakingChanged) {
                         monLastSpeaking = decision.speaking
                         voiceActivitySpeakingRef.current = decision.speaking
                         applyVoiceActivityGate(decision.speaking)
@@ -249,6 +252,23 @@ export function useVoiceActivity(options: {
                             decision.speaking,
                         )
                     }
+                    const nowMs = Date.now()
+                    if (nowMs - lastVoiceActivityDiagnosticsAt >= 750 || speakingChanged) {
+                        lastVoiceActivityDiagnosticsAt = nowMs
+                        updateVoiceDiagnostics({
+                            voiceActivity: {
+                                mode: getVoiceModeSettings().mode,
+                                gateOpen: gateOpenRef.current,
+                                speaking: decision.speaking,
+                                rmsDb: linearToDbDiagnostic(rms),
+                                smoothedRmsDb: linearToDbDiagnostic(decision.smoothedRms),
+                                onThresholdDb: linearToDbDiagnostic(onThr),
+                                offThresholdDb: linearToDbDiagnostic(offThr),
+                                openFrames: decision.openFrames,
+                                belowFrames: decision.belowFrames,
+                            },
+                        })
+                    }
                 }
             } catch {
                 // ignore
@@ -256,7 +276,7 @@ export function useVoiceActivity(options: {
             inlineMonitorIntervalRef.current = requestAnimationFrame(tick)
         }
         inlineMonitorIntervalRef.current = requestAnimationFrame(tick)
-    }, [applyVoiceActivityGate, cleanupMonitorNodes, getAudioContext, localStream, resetVoiceActivityGate])
+    }, [applyVoiceActivityGate, cleanupMonitorNodes, getAudioContext, getVoiceModeSettings, localStream, resetVoiceActivityGate])
 
     useEffect(() => {
         if (!joinedChannelId) return

--- a/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.ts
+++ b/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { Room } from 'livekit-client'
+import { updateVoiceDiagnostics } from '../voiceDiagnostics'
 
 const PING_WINDOW_SIZE = 7
 const RTC_BURST_SAMPLE_COUNT = 6
@@ -380,6 +381,17 @@ export function useWebrtcDiagnostics(options: {
     useEffect(() => {
         if (!joinedChannelId) {
             selectedPingSourceRef.current = null
+            updateVoiceDiagnostics({
+                network: {
+                    pingMs: null,
+                    wsPingMs: null,
+                    rtcPingMs: null,
+                    packetLossPct: null,
+                    jitterMs: null,
+                    pingJitterMs: null,
+                    pingSource: null,
+                },
+            })
             return
         }
 
@@ -414,6 +426,21 @@ export function useWebrtcDiagnostics(options: {
         setPingJitterMs(nextSource === 'rtc' ? rtcPingJitterMsRef.current : wsPingJitterMsRef.current)
         selectedPingSourceRef.current = nextSource
     }, [joinedChannelId, roomState, rtcPingMs, wsPingMs])
+
+    useEffect(() => {
+        if (!joinedChannelId) return
+        updateVoiceDiagnostics({
+            network: {
+                pingMs,
+                wsPingMs,
+                rtcPingMs,
+                packetLossPct,
+                jitterMs,
+                pingJitterMs,
+                pingSource: selectedPingSourceRef.current,
+            },
+        })
+    }, [joinedChannelId, jitterMs, packetLossPct, pingJitterMs, pingMs, rtcPingMs, wsPingMs])
 
     const hasActiveVoice = !!joinedChannelId
     const hasDisplaySource = hasActiveVoice && (rtcPingMs != null || wsPingMs != null)

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -21,6 +21,7 @@ import {
   getStoredVoiceSuppressionTuning,
   shouldRebuildSuppressionPipeline,
 } from './voiceInputProfile'
+import { updateVoiceDiagnostics } from './voiceDiagnostics'
 
 type PeerId = string
 type RemoteMediaStartCueKind = 'camera' | 'screen'
@@ -176,10 +177,27 @@ export function useLiveKitVoice() {
     if (!room) {
       setRoomState('disconnected')
       setParticipantCount(0)
+      updateVoiceDiagnostics({
+        livekit: {
+          roomState: 'disconnected',
+          participants: 0,
+          remoteStreams: 0,
+          microphonePublished: false,
+        },
+      })
       return
     }
-    setRoomState(String(room.state))
-    setParticipantCount(room.numParticipants ?? 0)
+    const nextRoomState = String(room.state)
+    const nextParticipantCount = room.numParticipants ?? 0
+    setRoomState(nextRoomState)
+    setParticipantCount(nextParticipantCount)
+    updateVoiceDiagnostics({
+      livekit: {
+        roomState: nextRoomState,
+        participants: nextParticipantCount,
+        remoteStreams: remoteStreamsRef.current.size,
+      },
+    })
   }, [])
 
   const setLocalMicMuted = useCallback(async (muted: boolean) => {
@@ -466,6 +484,15 @@ export function useLiveKitVoice() {
           videoEncoding: { maxBitrate: 3_000_000, maxFramerate: 30 },
         },
       })
+      updateVoiceDiagnostics({
+        livekit: {
+          roomState: 'connecting',
+          adaptiveStream: true,
+          dynacast: true,
+          microphonePublished: false,
+          microphoneSource: 'processed-webaudio',
+        },
+      })
       roomRef.current = room
       remoteMediaStartCueKeysRef.current.clear()
       remoteMediaStartCueReadyRef.current = false
@@ -617,6 +644,17 @@ export function useLiveKitVoice() {
 
       // Publish the track directly to LiveKit.
       const pub = await room.localParticipant.publishTrack(publishTrack, { source: Track.Source.Microphone })
+      updateVoiceDiagnostics({
+        livekit: {
+          roomState: String(room.state),
+          participants: room.numParticipants ?? 0,
+          remoteStreams: remoteStreamsRef.current.size,
+          adaptiveStream: true,
+          dynacast: true,
+          microphonePublished: true,
+          microphoneSource: 'processed-webaudio',
+        },
+      })
 
       micPublished = true
       localAudioTrackRef.current = pub.track as LocalAudioTrack

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -8,6 +8,9 @@ import {
   getVoiceQualityAdvice,
   getVoicePingLevel,
   isVoiceDiagnosticsEnabled,
+  linearToDbDiagnostic,
+  toVoiceProcessingConstraintsDiagnostics,
+  toVoiceTrackSettingsDiagnostics,
   updateVoiceDiagnostics,
   voiceQualityLabel,
 } from './voiceDiagnostics'
@@ -120,6 +123,7 @@ describe('voiceDiagnostics', () => {
   it('returns a copyable runtime diagnostics snapshot', () => {
     window.localStorage.setItem(VOICE_DIAGNOSTICS_STORAGE_KEY, '1')
     updateVoiceDiagnostics({
+      benchmarkSchemaVersion: 1,
       rnnoiseStatus: 'ready',
       noiseSuppressionEnabled: true,
       voiceInputProfile: 'isolation',
@@ -128,6 +132,38 @@ describe('voiceDiagnostics', () => {
       speakingThresholdDb: -58,
       suppressionTuning: 'balanced',
       aggressiveIsolation: true,
+      captureConstraints: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: false,
+      },
+      rawMicTrackSettings: {
+        sampleRate: 48000,
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: false,
+      },
+      voiceActivity: {
+        mode: 'voice_activity',
+        gateOpen: true,
+        speaking: true,
+        rmsDb: -36.5,
+        smoothedRmsDb: -39.2,
+        onThresholdDb: -58,
+        offThresholdDb: -62,
+        openFrames: 2,
+        belowFrames: 0,
+      },
+      network: {
+        pingMs: 42,
+        wsPingMs: 48,
+        rtcPingMs: 42,
+        packetLossPct: 0,
+        jitterMs: 3,
+        pingJitterMs: 4,
+        pingSource: 'rtc',
+      },
     })
 
     const snapshot = getVoiceDiagnosticsSnapshot()
@@ -136,8 +172,65 @@ describe('voiceDiagnostics', () => {
       speakingPreset: 'normal',
       speakingThresholdDb: -58,
       suppressionTuning: 'balanced',
+      captureConstraints: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: false,
+      },
+      voiceActivity: {
+        mode: 'voice_activity',
+        gateOpen: true,
+        speaking: true,
+      },
+      network: {
+        pingMs: 42,
+        rtcPingMs: 42,
+        pingSource: 'rtc',
+      },
     })
     expect(snapshot).not.toBe(window.__VOXPERY_VOICE_DIAGNOSTICS__)
     expect(formatVoiceDiagnosticsSnapshot(snapshot!)).toContain('"speakingThresholdDb": -58')
+  })
+
+  it('sanitizes audio track settings for benchmark diagnostics', () => {
+    const settings = {
+      sampleRate: 48000,
+      sampleSize: 16,
+      channelCount: 1,
+      echoCancellation: true,
+      noiseSuppression: false,
+      autoGainControl: true,
+      latency: 0.015,
+      deviceId: 'private-device-id',
+      groupId: 'private-group-id',
+    } as MediaTrackSettings
+
+    expect(toVoiceTrackSettingsDiagnostics(settings)).toEqual({
+      sampleRate: 48000,
+      sampleSize: 16,
+      channelCount: 1,
+      latency: 0.015,
+      echoCancellation: true,
+      noiseSuppression: false,
+      autoGainControl: true,
+    })
+  })
+
+  it('keeps only boolean capture constraints in benchmark diagnostics', () => {
+    expect(toVoiceProcessingConstraintsDiagnostics({
+      echoCancellation: true,
+      noiseSuppression: false,
+      autoGainControl: { ideal: true },
+    })).toEqual({
+      echoCancellation: true,
+      noiseSuppression: false,
+      autoGainControl: undefined,
+    })
+  })
+
+  it('converts linear audio values to stable diagnostic dB values', () => {
+    expect(linearToDbDiagnostic(1)).toBe(0)
+    expect(linearToDbDiagnostic(0)).toBe(-100)
+    expect(linearToDbDiagnostic(0.001)).toBe(-60)
   })
 })

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -1,6 +1,69 @@
 export type RnnoiseRuntimeStatus = 'disabled' | 'loading' | 'ready' | 'failed'
 
+export interface VoiceTrackSettingsDiagnostics {
+  sampleRate?: number
+  sampleSize?: number
+  channelCount?: number
+  latency?: number
+  echoCancellation?: boolean
+  noiseSuppression?: boolean
+  autoGainControl?: boolean
+}
+
+export interface VoiceProcessingConstraintsDiagnostics {
+  echoCancellation?: boolean
+  noiseSuppression?: boolean
+  autoGainControl?: boolean
+}
+
+export interface VoiceAudioContextDiagnostics {
+  sampleRate?: number
+  state?: string
+  baseLatency?: number
+  outputLatency?: number
+}
+
+export interface VoiceLiveProcessingDiagnostics {
+  rmsDb?: number
+  floorGain?: number
+  isolationGain?: number
+  likelySpeech?: boolean
+}
+
+export interface VoiceActivityDiagnostics {
+  mode?: 'voice_activity' | 'push_to_talk'
+  gateOpen?: boolean
+  speaking?: boolean
+  rmsDb?: number
+  smoothedRmsDb?: number
+  onThresholdDb?: number
+  offThresholdDb?: number
+  openFrames?: number
+  belowFrames?: number
+}
+
+export interface VoiceNetworkDiagnosticsSnapshot {
+  pingMs?: number | null
+  wsPingMs?: number | null
+  rtcPingMs?: number | null
+  packetLossPct?: number | null
+  jitterMs?: number | null
+  pingJitterMs?: number | null
+  pingSource?: 'rtc' | 'ws' | null
+}
+
+export interface VoiceLivekitDiagnostics {
+  roomState?: string
+  participants?: number
+  remoteStreams?: number
+  adaptiveStream?: boolean
+  dynacast?: boolean
+  microphonePublished?: boolean
+  microphoneSource?: 'processed-webaudio'
+}
+
 export interface VoiceRuntimeDiagnostics {
+  benchmarkSchemaVersion?: number
   rnnoiseStatus?: RnnoiseRuntimeStatus
   rnnoiseError?: string
   rnnoiseWorkletUrl?: string
@@ -11,6 +74,15 @@ export interface VoiceRuntimeDiagnostics {
   speakingThresholdDb?: number
   suppressionTuning?: string
   aggressiveIsolation?: boolean
+  inputVolume?: number
+  captureConstraints?: VoiceProcessingConstraintsDiagnostics
+  rawMicTrackSettings?: VoiceTrackSettingsDiagnostics
+  processedMicTrackSettings?: VoiceTrackSettingsDiagnostics
+  audioContext?: VoiceAudioContextDiagnostics
+  liveProcessing?: VoiceLiveProcessingDiagnostics
+  voiceActivity?: VoiceActivityDiagnostics
+  network?: VoiceNetworkDiagnosticsSnapshot
+  livekit?: VoiceLivekitDiagnostics
   updatedAt?: string
 }
 
@@ -54,6 +126,61 @@ export function getVoiceDiagnosticsSnapshot(): VoiceRuntimeDiagnostics | null {
 
 export function formatVoiceDiagnosticsSnapshot(snapshot: VoiceRuntimeDiagnostics): string {
   return JSON.stringify(snapshot, null, 2)
+}
+
+function pickFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function pickBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+export function roundVoiceDiagnosticNumber(value: number, decimals = 1): number {
+  if (!Number.isFinite(value)) return 0
+  const factor = 10 ** decimals
+  return Math.round(value * factor) / factor
+}
+
+export function linearToDbDiagnostic(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return -100
+  return Math.max(-100, roundVoiceDiagnosticNumber(20 * Math.log10(value), 1))
+}
+
+export function toVoiceTrackSettingsDiagnostics(
+  settings: MediaTrackSettings | null | undefined,
+): VoiceTrackSettingsDiagnostics | undefined {
+  if (!settings) return undefined
+  const settingsWithLatency = settings as MediaTrackSettings & { latency?: number }
+  return {
+    sampleRate: pickFiniteNumber(settings.sampleRate),
+    sampleSize: pickFiniteNumber(settings.sampleSize),
+    channelCount: pickFiniteNumber(settings.channelCount),
+    latency: pickFiniteNumber(settingsWithLatency.latency),
+    echoCancellation: pickBoolean(settings.echoCancellation),
+    noiseSuppression: pickBoolean(settings.noiseSuppression),
+    autoGainControl: pickBoolean(settings.autoGainControl),
+  }
+}
+
+export function toVoiceProcessingConstraintsDiagnostics(
+  constraints: MediaTrackConstraints,
+): VoiceProcessingConstraintsDiagnostics {
+  return {
+    echoCancellation: pickBoolean(constraints.echoCancellation),
+    noiseSuppression: pickBoolean(constraints.noiseSuppression),
+    autoGainControl: pickBoolean(constraints.autoGainControl),
+  }
+}
+
+export function toVoiceAudioContextDiagnostics(ctx: AudioContext): VoiceAudioContextDiagnostics {
+  const ctxWithOutputLatency = ctx as AudioContext & { outputLatency?: number }
+  return {
+    sampleRate: pickFiniteNumber(ctx.sampleRate),
+    state: ctx.state,
+    baseLatency: pickFiniteNumber(ctx.baseLatency),
+    outputLatency: pickFiniteNumber(ctxWithOutputLatency.outputLatency),
+  }
 }
 
 export type VoiceQualityLevel = 'unknown' | 'good' | 'fair' | 'poor'

--- a/docs/VOICE_QUALITY_BENCHMARK.md
+++ b/docs/VOICE_QUALITY_BENCHMARK.md
@@ -85,6 +85,7 @@ You can also open User Settings -> Voice & Audio and click `Copy diagnostics` to
 
 Required diagnostic fields:
 
+- `benchmarkSchemaVersion` is `1`.
 - `rnnoiseStatus` is `ready` when suppression is on.
 - `noiseSuppressionEnabled` is `true`.
 - `speakingPreset` is `normal` for the `Balanced` run and `noisy` for the `Noisy room` run.
@@ -93,6 +94,13 @@ Required diagnostic fields:
 - `suppressionTuning` is `balanced` for the `Balanced` run.
 - `suppressionTuning` is `high` for the `Noisy room` run.
 - `aggressiveIsolation` is `true` for noisy-room isolation.
+- `captureConstraints` shows browser echo cancellation, noise suppression, and automatic gain control.
+- `rawMicTrackSettings` and `processedMicTrackSettings` show sanitized audio settings without device ids or labels.
+- `audioContext.sampleRate` confirms the processing graph sample rate.
+- `liveProcessing.rmsDb`, `floorGain`, `isolationGain`, and `likelySpeech` show the current suppression behavior.
+- `voiceActivity` shows gate state, speech state, RMS, thresholds, and frame counters.
+- `network` shows ping, RTC ping, packet loss, jitter, and selected ping source.
+- `livekit` shows room state, participants, remote stream count, and whether the processed microphone track was published.
 
 Also capture the call bar ping color and visible ping.
 


### PR DESCRIPTION
## Summary

- Expand voice benchmark diagnostics with sanitized mic constraints, raw/processed track settings, audio context details, live processing metrics, VAD gate state, network quality, and LiveKit publish state.
- Keep copied diagnostics free of device ids, group ids, labels, and other private device identifiers.
- Update the voice quality benchmark checklist with the new required diagnostic fields.
- Extend diagnostics unit tests for sanitized settings, capture constraints, and dB conversion helpers.

## Validation

- `npm --prefix apps/web run test:run -- src/webrtc/voiceDiagnostics.test.ts`
- `npm --prefix apps/web run test:run`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`
- `git diff --check`
- `graphify update .`