### PR TITLE
fix: keep version badge compact

### DIFF
--- a/apps/web/src/appVersion.test.ts
+++ b/apps/web/src/appVersion.test.ts
@@ -9,7 +9,12 @@ describe('formatAppVersionBadge', () => {
 
   it('keeps explicit release and candidate tags unchanged', () => {
     expect(formatAppVersionBadge('v0.2.0')).toBe('v0.2.0')
-    expect(formatAppVersionBadge('sha-8da8941dbb1a')).toBe('sha-8da8941dbb1a')
+    expect(formatAppVersionBadge('sha-8da8941')).toBe('sha-8da8941')
+  })
+
+  it('shortens long immutable sha tags for the topbar badge', () => {
+    expect(formatAppVersionBadge('sha-8da8941dbb1a')).toBe('sha-8da8941')
+    expect(formatAppVersionBadge('sha-F49AA10BEF')).toBe('sha-F49AA10')
   })
 
   it('hides empty versions', () => {

--- a/apps/web/src/appVersion.ts
+++ b/apps/web/src/appVersion.ts
@@ -6,5 +6,10 @@ export function formatAppVersionBadge(rawVersion: string | null | undefined): st
     return `v${version}`
   }
 
+  const shortSha = version.match(/^sha-([0-9a-f]{7})[0-9a-f]+$/i)
+  if (shortSha?.[1]) {
+    return `sha-${shortSha[1]}`
+  }
+
   return version
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -348,6 +348,8 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+  max-width: 100%;
   font-size: 16px;
   font-weight: 700;
   cursor: pointer;
@@ -360,6 +362,7 @@ body {
   height: 20px;
   max-width: 164px;
   padding: 0 9px;
+  overflow: hidden;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.04);
@@ -369,6 +372,10 @@ body {
   letter-spacing: 0.02em;
   line-height: 1;
   white-space: nowrap;
+}
+
+.shell-brand-release > span:first-child {
+  flex: 0 0 auto;
 }
 
 .shell-brand-release::before {
@@ -382,6 +389,7 @@ body {
 }
 
 .shell-brand-release-separator {
+  flex: 0 0 auto;
   color: rgba(200, 212, 238, 0.52);
 }
 


### PR DESCRIPTION
## Summary

- Shorten long `sha-*` image tags in the topbar version badge.
- Harden the release badge layout so long build labels cannot overflow the capsule.
- Keep semantic release versions unchanged.

## Validation

- `npm --prefix apps/web run test:run -- src/appVersion.test.ts`
- `npm --prefix apps/web run test:run`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run build`
- `git diff --check`
- `graphify update .`