### PR TITLE
fix: persist hidden DM sidebar state

### DIFF
--- a/apps/server/migrations/040_dm_channel_hidden_state.sql
+++ b/apps/server/migrations/040_dm_channel_hidden_state.sql
@@ -1,0 +1,5 @@
+ALTER TABLE dm_channel_members
+    ADD COLUMN IF NOT EXISTS hidden_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dm_channel_members_user_hidden_at
+    ON dm_channel_members(user_id, hidden_at);

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -191,6 +191,7 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
     Router::new()
         .route("/channels", get(list_dm_channels))
         .route("/channels/{peer_id}", post(get_or_create_dm_channel))
+        .route("/channels/{channel_id}/hide", post(hide_dm_channel))
         .route("/channels/{channel_id}/read-state", get(get_dm_read_state))
         .route("/channels/{channel_id}/read", post(mark_dm_channel_read))
         .route(
@@ -233,43 +234,47 @@ async fn list_dm_channels(
     Extension(claims): Extension<Claims>,
 ) -> Result<Json<Vec<DmChannelInfo>>, AppError> {
     let rows = sqlx::query_as::<_, DmChannelInfo>(
-        r#"SELECT c.id,
-                  u.id as peer_id,
-                  u.username as peer_username,
-                  u.avatar_url as peer_avatar_url,
-                  u.status as peer_status,
-                  (
-                    SELECT m.created_at
-                    FROM dm_messages m
-                    WHERE m.channel_id = c.id
-                    ORDER BY m.created_at DESC
-                    LIMIT 1
-                  ) as last_message_at,
-                  (
-                    SELECT COUNT(*)
-                    FROM dm_messages m
-                    LEFT JOIN dm_channel_reads r
-                      ON r.channel_id = c.id AND r.user_id = $1
-                    WHERE m.channel_id = c.id
-                      AND m.user_id <> $1
-                      AND (r.read_at IS NULL OR m.created_at > r.read_at)
-                  ) as unread_count
-           FROM dm_channels c
-           INNER JOIN dm_channel_members self_m
-             ON self_m.channel_id = c.id AND self_m.user_id = $1
-           INNER JOIN dm_channel_members peer_m
-             ON peer_m.channel_id = c.id AND peer_m.user_id <> $1
-           INNER JOIN users u ON u.id = peer_m.user_id
-           ORDER BY COALESCE(
-             (
-               SELECT m.created_at
-               FROM dm_messages m
-               WHERE m.channel_id = c.id
-               ORDER BY m.created_at DESC
-               LIMIT 1
-             ),
-             c.created_at
-           ) DESC"#,
+        r#"WITH channel_rows AS (
+             SELECT c.id,
+                    u.id as peer_id,
+                    u.username as peer_username,
+                    u.avatar_url as peer_avatar_url,
+                    u.status as peer_status,
+                    self_m.hidden_at,
+                    c.created_at,
+                    (
+                      SELECT m.created_at
+                      FROM dm_messages m
+                      WHERE m.channel_id = c.id
+                      ORDER BY m.created_at DESC
+                      LIMIT 1
+                    ) as last_message_at,
+                    (
+                      SELECT COUNT(*)
+                      FROM dm_messages m
+                      LEFT JOIN dm_channel_reads r
+                        ON r.channel_id = c.id AND r.user_id = $1
+                      WHERE m.channel_id = c.id
+                        AND m.user_id <> $1
+                        AND (r.read_at IS NULL OR m.created_at > r.read_at)
+                    ) as unread_count
+             FROM dm_channels c
+             INNER JOIN dm_channel_members self_m
+               ON self_m.channel_id = c.id AND self_m.user_id = $1
+             INNER JOIN dm_channel_members peer_m
+               ON peer_m.channel_id = c.id AND peer_m.user_id <> $1
+             INNER JOIN users u ON u.id = peer_m.user_id
+           )
+           SELECT id,
+                  peer_id,
+                  peer_username,
+                  peer_avatar_url,
+                  peer_status,
+                  last_message_at,
+                  unread_count
+           FROM channel_rows
+           WHERE hidden_at IS NULL OR unread_count > 0
+           ORDER BY COALESCE(last_message_at, created_at) DESC"#,
     )
     .bind(claims.sub)
     .fetch_all(&state.db)
@@ -406,6 +411,14 @@ async fn get_or_create_dm_channel(
         id
     };
 
+    sqlx::query(
+        "UPDATE dm_channel_members SET hidden_at = NULL WHERE channel_id = $1 AND user_id = $2",
+    )
+    .bind(channel_id)
+    .bind(claims.sub)
+    .execute(&state.db)
+    .await?;
+
     let info = sqlx::query_as::<_, DmChannelInfo>(
         r#"SELECT c.id,
                   u.id as peer_id,
@@ -450,6 +463,24 @@ async fn get_or_create_dm_channel(
     };
 
     Ok(Json(info))
+}
+
+async fn hide_dm_channel(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path(channel_id): Path<Uuid>,
+) -> Result<Json<()>, AppError> {
+    check_dm_access(&state, channel_id, claims.sub).await?;
+
+    sqlx::query(
+        "UPDATE dm_channel_members SET hidden_at = NOW() WHERE channel_id = $1 AND user_id = $2",
+    )
+    .bind(channel_id)
+    .bind(claims.sub)
+    .execute(&state.db)
+    .await?;
+
+    Ok(Json(()))
 }
 
 async fn get_dm_messages(

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -1362,6 +1362,158 @@ async fn friend_dm_channel_open_returns_channel_info() {
 }
 
 #[tokio::test]
+async fn hidden_dm_channel_stays_out_of_channel_list_until_reopened() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app().await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    let alice_username = format!("alice{}", &suffix[..8]);
+    let bob_username = format!("bob{}", &suffix[8..16]);
+    let alice_credential = format!("{}-{}", alice_username, Uuid::new_v4().simple());
+    let bob_credential = format!("{}-{}", bob_username, Uuid::new_v4().simple());
+    let (alice_token, _) = register_user(
+        &mut app,
+        &format!("{alice_username}@example.com"),
+        &alice_username,
+        &alice_credential,
+    )
+    .await;
+    let (bob_token, bob_id) = register_user(
+        &mut app,
+        &format!("{bob_username}@example.com"),
+        &bob_username,
+        &bob_credential,
+    )
+    .await;
+
+    let alice_auth = format!("Bearer {alice_token}");
+    let bob_auth = format!("Bearer {bob_token}");
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/friends/requests")
+        .header("Authorization", &alice_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "username": bob_username })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "send friend request failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/friends/requests")
+        .header("Authorization", &bob_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "list friend requests failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let requests: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let request_id = requests["incoming"][0]["id"].as_str().unwrap();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/friends/requests/{request_id}/accept"))
+        .header("Authorization", &bob_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "accept friend request failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/dm/channels/{bob_id}"))
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "open friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let channel: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let channel_id = channel["id"].as_str().unwrap();
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels.as_array().unwrap().len(), 1);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/dm/channels/{channel_id}/hide"))
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "hide friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels.as_array().unwrap().len(), 0);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/dm/channels/{bob_id}"))
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "reopen hidden friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn strict_username_validation_rejects_invalid_usernames() {
     let Some(_) = test_db_url() else {
         eprintln!("SKIP: DATABASE_URL not set");

--- a/apps/web/src/api/dm.ts
+++ b/apps/web/src/api/dm.ts
@@ -12,6 +12,12 @@ export const dmApi = {
             token,
         }),
 
+    hideChannel: (channelId: string, token: AuthToken) =>
+        apiFetch<void>(`/api/dm/channels/${channelId}/hide`, {
+            method: 'POST',
+            token,
+        }),
+
     listMessages: (channelId: string, token: AuthToken, before?: string) =>
         apiFetch<MessageWithAuthor[]>(
             `/api/dm/messages/${channelId}${before ? `?before=${before}` : ''}`,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6903,13 +6903,14 @@ body {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  padding: 0 4px;
+  padding: 0 4px 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .social-dm-item {
   width: 100%;
-  border: none;
-  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.018);
   color: inherit;
   display: flex;
   align-items: center;
@@ -6920,12 +6921,18 @@ body {
   cursor: pointer;
 }
 
+.social-dm-item+.social-dm-item {
+  margin-top: 6px;
+}
+
 .social-dm-item:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.1);
 }
 
 .social-dm-item.active {
   background: rgba(233, 69, 96, 0.16);
+  border-color: rgba(233, 69, 96, 0.26);
 }
 
 .social-content {
@@ -7439,6 +7446,16 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+}
+
+.social-dm-actions .home-member-action {
+  background: rgba(255, 255, 255, 0.045);
+  opacity: 0.78;
+}
+
+.social-dm-item:hover .home-member-action,
+.social-dm-item:focus-within .home-member-action {
+  opacity: 1;
 }
 
 .social-dm-unread {

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -20,6 +20,7 @@ const apiMocks = vi.hoisted(() => ({
   removeFriend: vi.fn(),
   listDmChannels: vi.fn(),
   getOrCreateDmChannel: vi.fn(),
+  hideDmChannel: vi.fn(),
   listDmMessages: vi.fn(),
   markDmRead: vi.fn(),
   listDmPins: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock('../api', () => ({
   dmApi: {
     listChannels: apiMocks.listDmChannels,
     getOrCreateChannel: apiMocks.getOrCreateDmChannel,
+    hideChannel: apiMocks.hideDmChannel,
     listMessages: apiMocks.listDmMessages,
     markRead: apiMocks.markDmRead,
     listPins: apiMocks.listDmPins,
@@ -135,6 +137,7 @@ describe('HomePage friends list', () => {
     apiMocks.listDmMessages.mockResolvedValue([])
     apiMocks.markDmRead.mockResolvedValue(undefined)
     apiMocks.listDmPins.mockResolvedValue([])
+    apiMocks.hideDmChannel.mockResolvedValue(undefined)
   })
 
   it('opens a DM when a friend row is selected', async () => {
@@ -180,6 +183,22 @@ describe('HomePage friends list', () => {
         message: 'Could not create DM',
       })
     })
+  })
+
+  it('hides a DM conversation from the sidebar', async () => {
+    const channel = dmChannel('dm-cilo')
+    apiMocks.listDmChannels.mockResolvedValue([channel])
+
+    renderHomePage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Hide DM with cilo' }))
+
+    await waitFor(() => {
+      expect(apiMocks.hideDmChannel).toHaveBeenCalledWith(channel.id, null)
+      expect(useAppStore.getState().dmChannels).toEqual([])
+      expect(useAppStore.getState().dmChannelIds).toEqual([])
+    })
+    expect(screen.queryByRole('button', { name: 'Hide DM with cilo' })).toBeNull()
   })
 
   it('refreshes the active DM when returning from another app area', async () => {

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -41,8 +41,6 @@ import {
   upsertDmChannel,
 } from '../friendsList'
 
-const HIDDEN_DM_PEERS_KEY = 'voxpery-hidden-dm-peers'
-
 function isDmAccessForbidden(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
   return msg.includes('No access') || msg.includes('403') || msg.includes('Forbidden')
@@ -148,17 +146,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [socialBootstrapLoading, setSocialBootstrapLoading] = useState(true)
   const [incomingRequests, setIncomingRequests] = useState<FriendRequest[]>([])
   const [outgoingRequests, setOutgoingRequests] = useState<FriendRequest[]>([])
-  const [hiddenDmPeerIds, setHiddenDmPeerIds] = useState<string[]>(() => {
-    try {
-      const raw = localStorage.getItem(HIDDEN_DM_PEERS_KEY)
-      if (!raw) return []
-      const parsed = JSON.parse(raw)
-      if (!Array.isArray(parsed)) return []
-      return parsed.filter((x): x is string => typeof x === 'string')
-    } catch {
-      return []
-    }
-  })
   const [addFriendUsername, setAddFriendUsername] = useState('')
   const [addFriendMessage, setAddFriendMessage] = useState<string | null>(null)
   const [removeFriendTarget, setRemoveFriendTarget] = useState<Friend | null>(null)
@@ -166,13 +153,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [openingDmPeerId, setOpeningDmPeerId] = useState<string | null>(null)
   const isMobileSocialSidebarOpen = mobileSidebarPanel === 'social'
   const friends = storeFriends
-  const dmChannels = useMemo(
-    () =>
-      storeDmChannels.filter(
-        (channel) => !hiddenDmPeerIds.includes(channel.peer_id) || (dmUnread[channel.id] ?? 0) > 0,
-      ),
-    [dmUnread, hiddenDmPeerIds, storeDmChannels]
-  )
+  const dmChannels = storeDmChannels
 
   // Social paths (/social and /social/dm): restore last social tab and optional deep-linked DM.
   useEffect(() => {
@@ -184,7 +165,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         ? dmChannels.find((c) => c.peer_id === openDmUserId)
         : dmChannels.find((c) => c.peer_username === decodeURIComponent(openDmUserId))
       if (channel) {
-        setHiddenDmPeerIds((prev) => prev.filter((id) => id !== channel.peer_id))
         setActiveDmChannelId(channel.id)
         setView('dm')
         setPersistedSocialView('dm')
@@ -255,20 +235,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setSocialBootstrapLoading(false)
     }
   }, [setDmChannelIds, setDmUnreadFromChannels, setIncomingRequestCount, setServers, setServersLoading, setStoreFriends, setStoreDmChannels, token, userId])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(HIDDEN_DM_PEERS_KEY, JSON.stringify(hiddenDmPeerIds))
-    } catch {
-      // ignore
-    }
-  }, [hiddenDmPeerIds])
-
-  useEffect(() => {
-    if (storeDmChannels.length === 0) return
-    const existingPeerIds = new Set(storeDmChannels.map((c) => c.peer_id))
-    setHiddenDmPeerIds((prev) => prev.filter((id) => existingPeerIds.has(id)))
-  }, [storeDmChannels])
 
   useEffect(() => {
     if (!userId) return
@@ -565,7 +531,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       const channel = await dmApi.getOrCreateChannel(friendId, token)
       const nextChannels = upsertDmChannel(useAppStore.getState().dmChannels, channel)
 
-      setHiddenDmPeerIds((prev) => prev.filter((id) => id !== channel.peer_id))
       setStoreDmChannels(nextChannels)
       setDmChannelIds(nextChannels.map((dmChannel) => dmChannel.id))
       setActiveDmChannelId(channel.id)
@@ -953,7 +918,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
               className={`social-dm-item ${view === 'dm' && activeDmChannelId === channel.id ? 'active' : ''}`}
               onClick={(e) => {
                 ; (e.currentTarget as HTMLButtonElement).blur()
-                setHiddenDmPeerIds((prev) => prev.filter((id) => id !== channel.peer_id))
                 setView('dm')
                 setActiveDmChannelId(channel.id)
                 setPersistedSocialView('dm')
@@ -980,33 +944,35 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                   className="home-member-action"
                   title="Hide conversation"
                   aria-label={`Hide DM with ${channel.peer_username}`}
-                  onClick={(e) => {
+                  onClick={async (e) => {
                     e.stopPropagation()
-                    setHiddenDmPeerIds((prev) => {
-                      if (prev.includes(channel.peer_id)) return prev
-                      return [...prev, channel.peer_id]
-                    })
+                    const previousChannels = useAppStore.getState().dmChannels
+                    const nextChannels = previousChannels.filter((dmChannel) => dmChannel.id !== channel.id)
+                    setStoreDmChannels(nextChannels)
+                    setDmChannelIds(nextChannels.map((dmChannel) => dmChannel.id))
                     if (activeDmChannelId === channel.id) {
                       setView('friends')
                       setActiveDmChannelId(null)
                       setPersistedSocialView('friends')
                       navigate(ROUTES.home)
                     }
+                    try {
+                      await dmApi.hideChannel(channel.id, token)
+                    } catch (err) {
+                      setStoreDmChannels(previousChannels)
+                      setDmChannelIds(previousChannels.map((dmChannel) => dmChannel.id))
+                      pushToast({
+                        level: 'error',
+                        title: 'DM hide failed',
+                        message: err instanceof Error ? err.message : 'Could not hide this conversation.',
+                      })
+                    }
                   }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault()
                       e.stopPropagation()
-                      setHiddenDmPeerIds((prev) => {
-                        if (prev.includes(channel.peer_id)) return prev
-                        return [...prev, channel.peer_id]
-                      })
-                      if (activeDmChannelId === channel.id) {
-                        setView('friends')
-                        setActiveDmChannelId(null)
-                        setPersistedSocialView('friends')
-                        navigate(ROUTES.home)
-                      }
+                      e.currentTarget.click()
                     }
                   }}
                 >

--- a/docs/API.md
+++ b/docs/API.md
@@ -216,8 +216,12 @@ Notes:
 ## Direct Message Endpoints
 
 - `GET /api/dm/channels`
-  - Returns DM channel metadata including `unread_count`, the server-derived unread count for the current user.
+  - Returns visible DM channel metadata including `unread_count`, the server-derived unread count for the current user.
+  - Channels hidden by the current user are excluded unless they have unread messages.
 - `POST /api/dm/channels/:peer_id`
+  - Opens or creates a DM channel with the peer and restores it if the current user had hidden it.
+- `POST /api/dm/channels/:channel_id/hide`
+  - Hides the channel from the current user's DM list without deleting messages or hiding it for the peer.
 - `GET /api/dm/messages/:channel_id?before=<uuid>&limit=<n>`
 - `GET /api/dm/messages/:channel_id/search?q=<term>&from=<username>&has_attachment=<bool>&limit=<n>`
   - `from` filters by message author username.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -129,7 +129,9 @@ Uniqueness (case-insensitive):
 
 ### `dm_channel_members`
 
-- `channel_id`, `user_id`, `joined_at`
+- `channel_id`, `user_id`, `joined_at`, `hidden_at`
+- `hidden_at` stores whether that specific user has hidden the DM from their sidebar.
+- Hidden DMs remain intact and are shown again when reopened or when unread messages need attention.
 
 ### `dm_messages`
 
@@ -245,6 +247,7 @@ All migrations currently present:
 - `037_member_timeouts_and_raid_events.sql`
 - `038_server_onboarding_guides.sql`
 - `039_default_dm_privacy_everyone.sql`
+- `040_dm_channel_hidden_state.sql`
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Persist hidden DM sidebar conversations per user on the backend
- Hide DM channels from `/api/dm/channels` unless they have unread messages
- Restore hidden DMs when reopened from the friends list
- Improve Direct Messages sidebar row separation and close-button visibility
- Add frontend and backend coverage for hiding DM conversations

## Validation
- npm run test:run
- npm run lint
- npm run build
- cargo check --locked
- cargo test --locked dm_channel --test integration