### PR TITLE
fix: stabilize chat scroll anchoring

### DIFF
--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -536,6 +536,7 @@ export default function ChatArea({
     const pendingLatestAnchorChannelIdRef = useRef<string | null>(null)
     const latestAnchorCleanupRef = useRef<(() => void) | null>(null)
     const programmaticScrollRef = useRef(0)
+    const resizeAutoScrollRafRef = useRef<number | null>(null)
     const userReadingHistoryRef = useRef(false)
     const lastKnownScrollTopRef = useRef(0)
     const touchStartYRef = useRef<number | null>(null)
@@ -642,12 +643,21 @@ export default function ChatArea({
             fn()
         } finally {
             window.requestAnimationFrame(() => {
-                programmaticScrollRef.current = Math.max(0, programmaticScrollRef.current - 1)
+                window.requestAnimationFrame(() => {
+                    programmaticScrollRef.current = Math.max(0, programmaticScrollRef.current - 1)
+                })
             })
         }
     }, [])
 
     const cancelLatestAnchor = useCallback(() => {
+        latestAnchorCleanupRef.current?.()
+        latestAnchorCleanupRef.current = null
+        pendingLatestAnchorChannelIdRef.current = null
+    }, [])
+
+    const completeLatestAnchor = useCallback((channelId?: string | null) => {
+        if (channelId && pendingLatestAnchorChannelIdRef.current !== channelId) return
         latestAnchorCleanupRef.current?.()
         latestAnchorCleanupRef.current = null
         pendingLatestAnchorChannelIdRef.current = null
@@ -708,7 +718,10 @@ export default function ChatArea({
                 return
             }
         }
-        el.scrollTop = anchor.scrollTop + Math.max(0, el.scrollHeight - anchor.scrollHeight)
+        runProgrammaticScroll(() => {
+            el.scrollTop = anchor.scrollTop + Math.max(0, el.scrollHeight - anchor.scrollHeight)
+            lastKnownScrollTopRef.current = el.scrollTop
+        })
         shouldAutoScrollRef.current = false
         setShowJumpToLatest(true)
     }, [messages, rowVirtualizer, runProgrammaticScroll])
@@ -810,8 +823,8 @@ export default function ChatArea({
             rafIds.push(id)
         }
         snapIfCurrent()
-        queueRaf(5)
-        for (const delay of [48, 120, 260, 520]) {
+        queueRaf(2)
+        for (const delay of [96]) {
             timeoutIds.push(window.setTimeout(snapIfCurrent, delay))
         }
         latestAnchorCleanupRef.current = () => {
@@ -890,8 +903,8 @@ export default function ChatArea({
         touchStartYRef.current = nextY
     }, [markUserReadingHistory])
 
-    /* When switching channel/DM, aggressively re-anchor to the latest visible
-       content so returning to a previously read chat does not keep an older
+    /* When switching channel/DM, anchor to the latest visible content so
+       returning to a previously read chat does not keep an older
        scroll position. Do not run this for pagination prepends; loading older
        messages must preserve the user's scroll anchor. */
     useLayoutEffect(() => {
@@ -918,8 +931,16 @@ export default function ChatArea({
         const pendingLatest = !!activeChannel?.id && pendingLatestAnchorChannelIdRef.current === activeChannel.id
         if (!pendingLatest && !shouldAutoScrollRef.current) return
         shouldAutoScrollRef.current = true
-        snapToBottom(pendingLatest ? activeChannel.id : undefined)
-    }, [activeChannel?.id, messages.length, unreadDividerCount, snapToBottom])
+        const snapped = snapToBottom(pendingLatest ? activeChannel.id : undefined)
+        if (pendingLatest && snapped && activeChannel?.id) {
+            const channelId = activeChannel.id
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    completeLatestAnchor(channelId)
+                })
+            })
+        }
+    }, [activeChannel?.id, completeLatestAnchor, messages.length, unreadDividerCount, snapToBottom])
 
     /* If user sends while reading older messages, force snap to newest after the new row mounts. */
     useLayoutEffect(() => {
@@ -964,10 +985,22 @@ export default function ChatArea({
         if (!spacer || typeof ResizeObserver === 'undefined') return
         const observer = new ResizeObserver(() => {
             if (!shouldAutoScrollRef.current) return
-            snapToBottom()
+            if (preservingOlderMessagesRef.current) return
+            if (resizeAutoScrollRafRef.current != null) return
+            resizeAutoScrollRafRef.current = window.requestAnimationFrame(() => {
+                resizeAutoScrollRafRef.current = null
+                if (!shouldAutoScrollRef.current || preservingOlderMessagesRef.current) return
+                snapToBottom()
+            })
         })
         observer.observe(spacer)
-        return () => observer.disconnect()
+        return () => {
+            observer.disconnect()
+            if (resizeAutoScrollRafRef.current != null) {
+                window.cancelAnimationFrame(resizeAutoScrollRafRef.current)
+                resizeAutoScrollRafRef.current = null
+            }
+        }
     }, [activeChannel?.id, messages.length, snapToBottom])
 
     /* When user switches back from Servers to Messages/DM, scroll to bottom so latest messages are visible */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4367,6 +4367,25 @@ body {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-height: 0;
+  overscroll-behavior: contain;
+  overflow-anchor: none;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(122, 170, 231, 0.36) transparent;
+}
+
+.chat-messages::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(122, 170, 231, 0.32);
+}
+
+.chat-messages::-webkit-scrollbar-thumb:hover {
+  background: rgba(122, 170, 231, 0.48);
 }
 
 /* Virtual list updates transform on scroll (scroll-linked). Firefox warns; containment limits scope. */
@@ -4385,6 +4404,7 @@ body {
 .virtual-list-spacer {
   position: relative;
   width: 100%;
+  overflow-anchor: none;
 }
 
 .virtual-list-item {
@@ -4395,6 +4415,7 @@ body {
   min-width: 0;
   padding-bottom: 1px;
   box-sizing: border-box;
+  overflow-anchor: none;
 }
 
 .virtual-list-item-first .message-day-divider {

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -422,7 +422,6 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [showMobileMemberSheet, setShowMobileMemberSheet] = useState(false)
     const [serverBootstrapLoading, setServerBootstrapLoading] = useState(false)
     const [serverListReady, setServerListReady] = useState(false)
-    const messagesScrollRef = useRef<HTMLDivElement | null>(null)
     const currentServerMember = useMemo(
         () => (user?.id ? members.find((member) => member.user_id === user.id) ?? null : null),
         [members, user?.id],
@@ -911,9 +910,6 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         const current = messagesByChannelRef.current[channelId] ?? []
         const oldestId = current[0]?.id
         if (!oldestId) return
-        const scrollEl = messagesScrollRef.current
-        const previousScrollHeight = scrollEl?.scrollHeight ?? 0
-        const previousScrollTop = scrollEl?.scrollTop ?? 0
         setLoadingOlder(true)
         try {
             const rows = await messageApi.list(channelId, token, oldestId, MESSAGE_PAGE_SIZE)
@@ -923,15 +919,6 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             if (activeChannelIdRef.current !== channelId) return
             setMessages(merged)
             if (rows.length < MESSAGE_PAGE_SIZE) setHasMoreOlder(false)
-            if (scrollEl && rows.length > 0) {
-                const restoreAnchor = () => {
-                    scrollEl.scrollTop = previousScrollTop + Math.max(0, scrollEl.scrollHeight - previousScrollHeight)
-                }
-                requestAnimationFrame(() => {
-                    restoreAnchor()
-                    requestAnimationFrame(restoreAnchor)
-                })
-            }
         } catch (e) {
             console.error('Load older messages failed', e)
         } finally {
@@ -3003,7 +2990,6 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 hasMoreOlder={!channelSearch.trim() && olderMessagesReady && hasMoreOlder}
                 loadingOlder={loadingOlder}
                 onLoadOlder={loadOlderMessages}
-                onScrollRefReady={(ref) => { messagesScrollRef.current = ref }}
                 searchQuery={channelSearch}
                 onSearchChange={setChannelSearch}
                 pinnedMessages={channelPins}


### PR DESCRIPTION
## Summary
- Stabilize chat scroll ownership inside `ChatArea`.
- Preserve position more reliably when older messages are prepended.
- Reduce jitter from resize/virtual-list anchoring and improve scrollbar stability.
- Add chat scrollbar gutter/anchor CSS rules for smoother Discord-like behavior.

## Validation
- `npm run test:run`
- `npm run lint`
- `npm run build`
- `graphify update .`