### PR TITLE
fix: smooth chat media loading

### DIFF
--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -381,8 +381,35 @@ describe('ChatArea regressions', () => {
     })
 
     expect(screen.getByAltText('Sticker preview')).toHaveAttribute('src')
+    expect(screen.getByAltText('Sticker preview')).toHaveAttribute('loading', 'eager')
+    expect(screen.getByAltText('Sticker preview')).toHaveAttribute('width', '120')
     expect(screen.getByAltText('GIF preview')).toHaveAttribute('src')
+    expect(screen.getByAltText('GIF preview')).toHaveAttribute('loading', 'eager')
+    expect(screen.getByAltText('GIF preview')).toHaveAttribute('width', '320')
     expect(container.querySelector(`a[href="${stickerUrl}"]`)).toBeNull()
     expect(container.querySelector(`a[href="${gifUrl}"]`)).toBeNull()
+  })
+
+  it('renders image attachments with stable eager preview sizing', () => {
+    renderChatArea({
+      messages: [
+        {
+          ...message('message-image', 'screenshot', 0),
+          attachments: [
+            {
+              url: 'https://cdn.example.test/screenshot.png',
+              type: 'image/png',
+              name: 'screenshot.png',
+            },
+          ],
+        },
+      ],
+    })
+
+    const preview = screen.getByAltText('screenshot.png')
+    expect(preview).toHaveAttribute('loading', 'eager')
+    expect(preview).toHaveAttribute('decoding', 'async')
+    expect(preview).toHaveAttribute('width', '320')
+    expect(preview).toHaveAttribute('height', '180')
   })
 })

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -197,6 +197,45 @@ function estimateAttachmentHeight(attachments?: Attachment[]) {
     return ESTIMATED_ATTACHMENT_ROW_PX * Math.ceil(attachments.length / 2)
 }
 
+type AttachmentResolutionState = {
+    sourceUrl: string
+    resolvedUrl: string
+    loadFailed: boolean
+    triedDirectFallback: boolean
+}
+
+const MAX_ATTACHMENT_RESOLUTION_CACHE_ENTRIES = 160
+const attachmentResolutionCache = new Map<string, AttachmentResolutionState>()
+
+function defaultAttachmentResolution(sourceUrl: string): AttachmentResolutionState {
+    return {
+        sourceUrl,
+        resolvedUrl: sourceUrl,
+        loadFailed: false,
+        triedDirectFallback: false,
+    }
+}
+
+function getAttachmentResolutionCacheKey(attachment: Attachment, token: string | null) {
+    return [attachment.url, attachment.type ?? '', token ?? 'cookie-auth'].join('\n')
+}
+
+function rememberAttachmentResolution(cacheKey: string, resolution: AttachmentResolutionState) {
+    const previous = attachmentResolutionCache.get(cacheKey)
+    if (previous?.resolvedUrl.startsWith('blob:') && previous.resolvedUrl !== resolution.resolvedUrl) {
+        URL.revokeObjectURL(previous.resolvedUrl)
+    }
+    attachmentResolutionCache.delete(cacheKey)
+    attachmentResolutionCache.set(cacheKey, resolution)
+    while (attachmentResolutionCache.size > MAX_ATTACHMENT_RESOLUTION_CACHE_ENTRIES) {
+        const oldestKey = attachmentResolutionCache.keys().next().value
+        if (!oldestKey) break
+        const oldest = attachmentResolutionCache.get(oldestKey)
+        if (oldest?.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(oldest.resolvedUrl)
+        attachmentResolutionCache.delete(oldestKey)
+    }
+}
+
 /** Parses "> @username: quote\n\nreply" into { replyUsername, replyQuote, replyBody } or null. */
 function parseReplyContent(content: string): { replyUsername: string; replyQuote: string; replyBody: string } | null {
     if (!content.startsWith('> @')) return null
@@ -229,26 +268,24 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
     const token = useAuthStore((s) => s.token)
     const [previewOpen, setPreviewOpen] = useState(false)
     const fallbackInFlightRef = useRef(false)
-    const fallbackObjectUrlRef = useRef<string | null>(null)
     const isImage = isImageAttachment(attachment)
-    const [resolution, setResolution] = useState(() => ({
-        sourceUrl: attachment.url,
-        resolvedUrl: attachment.url,
-        loadFailed: false,
-        triedDirectFallback: false,
-    }))
+    const cacheKey = getAttachmentResolutionCacheKey(attachment, token ?? null)
+    const [resolution, setResolution] = useState<AttachmentResolutionState>(() => (
+        attachmentResolutionCache.get(cacheKey) ?? defaultAttachmentResolution(attachment.url)
+    ))
     const currentResolution = resolution.sourceUrl === attachment.url
         ? resolution
-        : {
-            sourceUrl: attachment.url,
-            resolvedUrl: attachment.url,
-            loadFailed: false,
-            triedDirectFallback: false,
-        }
+        : attachmentResolutionCache.get(cacheKey) ?? defaultAttachmentResolution(attachment.url)
 
     useEffect(() => {
         let cancelled = false
-        let objectUrl: string | null = null
+        const cached = attachmentResolutionCache.get(cacheKey)
+        if (cached) {
+            setResolution(cached)
+            return () => {
+                cancelled = true
+            }
+        }
 
         resolveAttachmentUrl(attachment.url, token ?? null, {
             fallbackMimeType: attachment.type,
@@ -258,43 +295,35 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
                     if (nextUrl.startsWith('blob:')) URL.revokeObjectURL(nextUrl)
                     return
                 }
-                if (nextUrl.startsWith('blob:')) objectUrl = nextUrl
-                setResolution({
+                const nextResolution = {
                     sourceUrl: attachment.url,
                     resolvedUrl: nextUrl,
                     loadFailed: false,
                     triedDirectFallback: false,
-                })
+                }
+                rememberAttachmentResolution(cacheKey, nextResolution)
+                setResolution(nextResolution)
             })
             .catch(() => {
                 if (!cancelled) {
-                    setResolution({
+                    const nextResolution = {
                         sourceUrl: attachment.url,
                         resolvedUrl: attachment.url,
                         loadFailed: isImage,
                         triedDirectFallback: true,
-                    })
+                    }
+                    rememberAttachmentResolution(cacheKey, nextResolution)
+                    setResolution(nextResolution)
                 }
             })
 
         return () => {
             cancelled = true
-            if (objectUrl) URL.revokeObjectURL(objectUrl)
         }
-    }, [attachment.type, attachment.url, isImage, token])
-
-    useEffect(() => {
-        return () => {
-            if (fallbackObjectUrlRef.current) URL.revokeObjectURL(fallbackObjectUrlRef.current)
-        }
-    }, [])
+    }, [attachment.type, attachment.url, cacheKey, isImage, token])
 
     useEffect(() => {
         fallbackInFlightRef.current = false
-        if (fallbackObjectUrlRef.current) {
-            URL.revokeObjectURL(fallbackObjectUrlRef.current)
-            fallbackObjectUrlRef.current = null
-        }
     }, [attachment.url])
 
     if (isImage) {
@@ -319,35 +348,31 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
                     fallbackMimeType: attachment.type,
                 })
                     .then((nextUrl) => {
-                        if (nextUrl.startsWith('blob:')) {
-                            if (fallbackObjectUrlRef.current) URL.revokeObjectURL(fallbackObjectUrlRef.current)
-                            fallbackObjectUrlRef.current = nextUrl
-                        }
                         setResolution((current) => {
                             if (current.sourceUrl !== attachment.url) {
                                 if (nextUrl.startsWith('blob:')) URL.revokeObjectURL(nextUrl)
-                                if (fallbackObjectUrlRef.current === nextUrl) fallbackObjectUrlRef.current = null
                                 return current
                             }
-                            if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
-                            return {
+                            const nextResolution = {
                                 sourceUrl: attachment.url,
                                 resolvedUrl: nextUrl,
                                 loadFailed: false,
                                 triedDirectFallback: true,
                             }
+                            rememberAttachmentResolution(cacheKey, nextResolution)
+                            return nextResolution
                         })
                     })
                     .catch(() => {
                         setResolution((current) => {
                             if (current.sourceUrl !== attachment.url) return current
-                            if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
-                            if (fallbackObjectUrlRef.current === current.resolvedUrl) fallbackObjectUrlRef.current = null
-                            return {
+                            const nextResolution = {
                                 ...current,
                                 loadFailed: true,
                                 triedDirectFallback: true,
                             }
+                            rememberAttachmentResolution(cacheKey, nextResolution)
+                            return nextResolution
                         })
                     })
                     .finally(() => {
@@ -358,13 +383,13 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
 
             setResolution((current) => {
                 if (current.sourceUrl !== attachment.url) return current
-                if (current.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(current.resolvedUrl)
-                if (fallbackObjectUrlRef.current === current.resolvedUrl) fallbackObjectUrlRef.current = null
-                return {
+                const nextResolution = {
                     ...current,
                     loadFailed: true,
                     triedDirectFallback: true,
                 }
+                rememberAttachmentResolution(cacheKey, nextResolution)
+                return nextResolution
             })
         }
         if (currentResolution.loadFailed) {
@@ -386,6 +411,10 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
                         src={currentResolution.resolvedUrl}
                         alt={alt}
                         className="chat-image-attachment"
+                        loading="eager"
+                        decoding="async"
+                        width={320}
+                        height={180}
                         onError={handleImageLoadError}
                     />
                 </button>

--- a/apps/web/src/components/InlineMediaImage.tsx
+++ b/apps/web/src/components/InlineMediaImage.tsx
@@ -8,21 +8,29 @@ type InlineMediaImageProps = {
   className?: string
 }
 
+type InlineMediaState = {
+  useFallback: boolean
+  loadFailed: boolean
+}
+
+const inlineMediaStateCache = new Map<string, InlineMediaState>()
+
 export default function InlineMediaImage({ src, alt, className }: InlineMediaImageProps) {
-  const [useFallback, setUseFallback] = useState(false)
-  const [loadFailed, setLoadFailed] = useState(false)
+  const [state, setState] = useState<InlineMediaState>(() => (
+    inlineMediaStateCache.get(src) ?? { useFallback: false, loadFailed: false }
+  ))
   const trustedDirectUrl = useMemo(() => trustedInlineMediaFallbackUrl(src), [src])
   const proxiedUrl = resolveInlineMediaUrl(src) ?? src
   const primaryUrl = trustedDirectUrl ?? proxiedUrl
   const fallbackUrl = trustedDirectUrl && trustedDirectUrl !== primaryUrl ? trustedDirectUrl : null
-  const activeUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl
+  const activeUrl = state.useFallback && fallbackUrl ? fallbackUrl : primaryUrl
+  const isSticker = className?.includes('sticker') ?? false
 
   useEffect(() => {
-    setUseFallback(false)
-    setLoadFailed(false)
+    setState(inlineMediaStateCache.get(src) ?? { useFallback: false, loadFailed: false })
   }, [src])
 
-  if (loadFailed) {
+  if (state.loadFailed) {
     return (
       <span
         className={`${className ?? ''} inline-media-unavailable`.trim()}
@@ -38,13 +46,25 @@ export default function InlineMediaImage({ src, alt, className }: InlineMediaIma
       alt={alt}
       className={className}
       draggable={false}
-      loading="lazy"
+      loading="eager"
+      decoding="async"
+      width={isSticker ? 120 : 320}
+      height={isSticker ? 120 : 180}
+      onLoad={() => {
+        const nextState = { useFallback: state.useFallback, loadFailed: false }
+        inlineMediaStateCache.set(src, nextState)
+        setState(nextState)
+      }}
       onError={() => {
-        if (!useFallback && fallbackUrl && activeUrl !== fallbackUrl) {
-          setUseFallback(true)
+        if (!state.useFallback && fallbackUrl && activeUrl !== fallbackUrl) {
+          const nextState = { useFallback: true, loadFailed: false }
+          inlineMediaStateCache.set(src, nextState)
+          setState(nextState)
           return
         }
-        setLoadFailed(true)
+        const nextState = { useFallback: state.useFallback, loadFailed: true }
+        inlineMediaStateCache.set(src, nextState)
+        setState(nextState)
       }}
     />
   )

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5434,6 +5434,7 @@ body {
 
 .chat-inline-gif-link {
   display: inline-flex;
+  width: min(320px, 100%);
   border-radius: 10px;
   overflow: hidden;
   border: none;
@@ -5445,12 +5446,15 @@ body {
 
 .chat-inline-gif {
   width: 100%;
+  aspect-ratio: 16 / 9;
   max-height: 220px;
+  height: auto;
   object-fit: cover;
   display: block;
 }
 
 .chat-inline-sticker-link {
+  width: 120px;
   max-width: 120px;
   border: none;
   border-radius: 0;
@@ -5461,7 +5465,9 @@ body {
 
 .chat-inline-sticker {
   width: 100%;
+  aspect-ratio: 1;
   max-height: 120px;
+  height: auto;
   object-fit: contain;
   display: block;
   filter: drop-shadow(0 8px 18px rgba(7, 11, 24, 0.18));
@@ -8238,8 +8244,11 @@ a.community-open-btn:hover {
 
 .chat-image-attachment {
   display: block;
+  width: min(320px, 52vw);
+  aspect-ratio: 16 / 9;
   max-width: min(320px, 52vw);
   max-height: 220px;
+  height: auto;
   object-fit: cover;
   background: #0b0d14;
 }


### PR DESCRIPTION
## Summary
- Cache resolved chat attachment URLs during the session to avoid remount flicker.
- Cache inline GIF/sticker load state across virtualized row remounts.
- Render chat media eagerly with stable width/height hints.
- Reserve stable media boxes in CSS so images do not collapse before decode.
- Add regression coverage for inline media and image attachment preview attributes.

## Validation
- `npm run test:run`
- `npm run lint`
- `npm run build`
- `graphify update .`