### PR TITLE
fix: polish chat media and scrollbar behavior

### DIFF
--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -366,6 +366,39 @@ describe('ChatArea regressions', () => {
     expect(screen.getByRole('button', { name: 'Jump to latest messages' })).toBeInTheDocument()
   })
 
+  it('does not re-lock to latest when scrollbar movement scrolls upward during latest anchoring', () => {
+    const { container, rerender } = renderChatArea()
+
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'end' })
+    scrollToIndex.mockClear()
+
+    const scroller = container.querySelector('.chat-messages') as HTMLDivElement
+    scroller.scrollTop = 1060
+    fireEvent.scroll(scroller)
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('general', 'general')}
+        messages={[
+          message('message-1', 'hello', 0),
+          message('message-2', 'latest', 1),
+          message('message-3', 'new arrival', 2),
+        ]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+      />
+    )
+
+    expect(scrollToIndex).not.toHaveBeenCalledWith(2, { align: 'end' })
+    expect(screen.getByRole('button', { name: 'Jump to latest messages' })).toBeInTheDocument()
+  })
+
   it('renders inline stickers and GIFs as chat media instead of text links', () => {
     const stickerUrl = 'https://media.example.test/sticker.png'
     const gifUrl = 'https://media.example.test/reaction.gif'

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -900,12 +900,22 @@ export default function ChatArea({
             const previousScrollTop = lastKnownScrollTopRef.current
             const currentScrollTop = el.scrollTop
             const hasRecentUserScrollIntent = Date.now() <= userScrollIntentUntilRef.current
-            const isUserInitiatedScroll = programmaticScrollRef.current === 0 || hasRecentUserScrollIntent
             const movedUp = currentScrollTop < previousScrollTop - 1
+            const pendingLatestForActiveChannel =
+                !!activeChannel?.id && pendingLatestAnchorChannelIdRef.current === activeChannel.id
+            const likelyScrollbarDragUp =
+                movedUp &&
+                messages.length > 0 &&
+                !preservingOlderMessagesRef.current &&
+                currentScrollTop < Math.max(0, el.scrollHeight - el.clientHeight - 4)
+            const isUserInitiatedScroll =
+                programmaticScrollRef.current === 0 ||
+                hasRecentUserScrollIntent ||
+                (likelyScrollbarDragUp && (!pendingLatestForActiveChannel || currentScrollTop < previousScrollTop - 4))
             if (currentScrollTop <= TOP_AUTO_LOAD_THRESHOLD_PX) {
                 startOlderMessagesLoad()
             }
-            if (activeChannel?.id && pendingLatestAnchorChannelIdRef.current === activeChannel.id && !isUserInitiatedScroll) {
+            if (pendingLatestForActiveChannel && !isUserInitiatedScroll) {
                 lastKnownScrollTopRef.current = currentScrollTop
                 syncAutoScrollState()
                 return
@@ -916,7 +926,7 @@ export default function ChatArea({
             lastKnownScrollTopRef.current = currentScrollTop
         }
         syncAutoScrollState()
-    }, [activeChannel?.id, markUserReadingHistory, startOlderMessagesLoad, syncAutoScrollState])
+    }, [activeChannel?.id, markUserReadingHistory, messages.length, startOlderMessagesLoad, syncAutoScrollState])
 
     const handleWheelScrollIntent = useCallback((event: WheelEvent<HTMLDivElement>) => {
         noteUserScrollIntent()

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8250,7 +8250,7 @@ a.community-open-btn:hover {
   max-height: 220px;
   height: auto;
   object-fit: cover;
-  background: #0b0d14;
+  background: transparent;
 }
 
 .dm-seen {


### PR DESCRIPTION
## Summary
- Remove the black loading frame from chat image attachments while preserving stable media sizing.
- Treat scrollbar-only upward movement as user history scrolling, even during latest anchoring.
- Add regression coverage for scrollbar upward movement so new messages do not re-lock to latest.

## Validation
- `npm run test:run`
- `npm run lint`
- `npm run build`
- `graphify update .`