### PR TITLE
fix: hide undecoded chat image placeholders

### DIFF
--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -75,6 +75,26 @@ function renderChatArea(overrides?: Partial<React.ComponentProps<typeof ChatArea
   )
 }
 
+function mockDecodedImages() {
+  class MockImage {
+    decoding = 'auto'
+    complete = true
+    naturalWidth = 320
+    onload: ((event: Event) => void) | null = null
+    onerror: ((event: Event) => void) | null = null
+
+    set src(_value: string) {
+      queueMicrotask(() => this.onload?.(new Event('load')))
+    }
+
+    decode() {
+      return Promise.resolve()
+    }
+  }
+
+  vi.stubGlobal('Image', MockImage)
+}
+
 describe('ChatArea regressions', () => {
   beforeEach(() => {
     vi.useRealTimers()
@@ -83,6 +103,7 @@ describe('ChatArea regressions', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('re-anchors switched channels to their latest rendered message', async () => {
@@ -423,7 +444,9 @@ describe('ChatArea regressions', () => {
     expect(container.querySelector(`a[href="${gifUrl}"]`)).toBeNull()
   })
 
-  it('renders image attachments with stable eager preview sizing', () => {
+  it('renders image attachments with stable eager preview sizing', async () => {
+    mockDecodedImages()
+
     renderChatArea({
       messages: [
         {
@@ -439,10 +462,13 @@ describe('ChatArea regressions', () => {
       ],
     })
 
-    const preview = screen.getByAltText('screenshot.png')
+    expect(screen.queryByAltText('screenshot.png')).toBeNull()
+    const previewButton = await screen.findByRole('button', { name: 'Preview screenshot.png' })
+    const preview = previewButton.querySelector('img') as HTMLImageElement
     expect(preview).toHaveAttribute('loading', 'eager')
     expect(preview).toHaveAttribute('decoding', 'async')
     expect(preview).toHaveAttribute('width', '320')
     expect(preview).toHaveAttribute('height', '180')
+    expect(preview).toHaveAttribute('alt', '')
   })
 })

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -206,6 +206,7 @@ type AttachmentResolutionState = {
 
 const MAX_ATTACHMENT_RESOLUTION_CACHE_ENTRIES = 160
 const attachmentResolutionCache = new Map<string, AttachmentResolutionState>()
+const decodedAttachmentImageCache = new Set<string>()
 
 function defaultAttachmentResolution(sourceUrl: string): AttachmentResolutionState {
     return {
@@ -234,6 +235,40 @@ function rememberAttachmentResolution(cacheKey: string, resolution: AttachmentRe
         if (oldest?.resolvedUrl.startsWith('blob:')) URL.revokeObjectURL(oldest.resolvedUrl)
         attachmentResolutionCache.delete(oldestKey)
     }
+}
+
+function decodeAttachmentImage(url: string): Promise<void> {
+    if (decodedAttachmentImageCache.has(url)) return Promise.resolve()
+    if (typeof window === 'undefined' || typeof Image === 'undefined') {
+        decodedAttachmentImageCache.add(url)
+        return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => {
+        const image = new Image()
+        image.decoding = 'async'
+        image.onload = () => {
+            decodedAttachmentImageCache.add(url)
+            resolve()
+        }
+        image.onerror = () => reject(new Error('Image decode failed'))
+        image.src = url
+        const decode = image.decode?.()
+        if (decode) {
+            decode
+                .then(() => {
+                    decodedAttachmentImageCache.add(url)
+                    resolve()
+                })
+                .catch(() => {
+                    if (image.complete && image.naturalWidth > 0) {
+                        decodedAttachmentImageCache.add(url)
+                        resolve()
+                        return
+                    }
+                    reject(new Error('Image decode failed'))
+                })
+        }
+    })
 }
 
 /** Parses "> @username: quote\n\nreply" into { replyUsername, replyQuote, replyBody } or null. */
@@ -276,6 +311,9 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
     const currentResolution = resolution.sourceUrl === attachment.url
         ? resolution
         : attachmentResolutionCache.get(cacheKey) ?? defaultAttachmentResolution(attachment.url)
+    const [imageDecoded, setImageDecoded] = useState(() => (
+        !isImage || decodedAttachmentImageCache.has(currentResolution.resolvedUrl)
+    ))
 
     useEffect(() => {
         let cancelled = false
@@ -325,6 +363,30 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
     useEffect(() => {
         fallbackInFlightRef.current = false
     }, [attachment.url])
+
+    useEffect(() => {
+        if (!isImage || currentResolution.loadFailed) {
+            setImageDecoded(false)
+            return
+        }
+        const imageUrl = currentResolution.resolvedUrl
+        if (decodedAttachmentImageCache.has(imageUrl)) {
+            setImageDecoded(true)
+            return
+        }
+        let cancelled = false
+        setImageDecoded(false)
+        decodeAttachmentImage(imageUrl)
+            .then(() => {
+                if (!cancelled) setImageDecoded(true)
+            })
+            .catch(() => {
+                if (!cancelled) setImageDecoded(true)
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [currentResolution.loadFailed, currentResolution.resolvedUrl, isImage])
 
     if (isImage) {
         const alt = attachment.name || `Attachment ${index + 1}`
@@ -401,23 +463,33 @@ function AttachmentLink({ attachment, index }: { attachment: Attachment; index: 
         }
         return (
             <>
-                <button
-                    type="button"
-                    className="chat-image-link chat-image-preview-trigger"
-                    onClick={() => setPreviewOpen(true)}
-                    aria-label={`Preview ${alt}`}
-                >
-                    <img
-                        src={currentResolution.resolvedUrl}
-                        alt={alt}
-                        className="chat-image-attachment"
-                        loading="eager"
-                        decoding="async"
-                        width={320}
-                        height={180}
-                        onError={handleImageLoadError}
+                {imageDecoded ? (
+                    <button
+                        type="button"
+                        className="chat-image-link chat-image-preview-trigger"
+                        onClick={() => setPreviewOpen(true)}
+                        aria-label={`Preview ${alt}`}
+                    >
+                        <img
+                            src={currentResolution.resolvedUrl}
+                            alt=""
+                            className="chat-image-attachment"
+                            loading="eager"
+                            decoding="async"
+                            width={320}
+                            height={180}
+                            onLoad={() => {
+                                decodedAttachmentImageCache.add(currentResolution.resolvedUrl)
+                            }}
+                            onError={handleImageLoadError}
+                        />
+                    </button>
+                ) : (
+                    <span
+                        className="chat-image-link chat-image-preview-trigger chat-image-preview-trigger--pending"
+                        aria-hidden="true"
                     />
-                </button>
+                )}
                 {previewOpen && (
                     <AttachmentImagePreviewModal
                         src={currentResolution.resolvedUrl}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8161,6 +8161,18 @@ a.community-open-btn:hover {
   cursor: zoom-in;
 }
 
+.chat-image-preview-trigger--pending {
+  width: min(320px, 52vw);
+  aspect-ratio: 16 / 9;
+  max-width: min(320px, 52vw);
+  max-height: 220px;
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  pointer-events: none;
+  visibility: hidden;
+}
+
 .chat-image-preview-backdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- Pre-decode chat attachment images before rendering the visible image element.
- Hide the reserved attachment image shell while decode is pending to avoid black/empty frames.
- Keep decoded image URLs cached so revisiting virtualized chat rows shows images immediately.
- Prevent filename alt text from flashing inside pending image boxes.

## Validation
- `npm run test:run`
- `npm run lint`
- `npm run build`
- `graphify update .`