### PR TITLE
fix: hide voice diagnostics unless enabled

### DIFF
--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -76,6 +76,7 @@ import {
 import {
   formatVoiceDiagnosticsSnapshot,
   getVoiceDiagnosticsSnapshot,
+  isVoiceDiagnosticsEnabled,
 } from '../webrtc/voiceDiagnostics'
 
 const MAX_PROFILE_IMAGE_BYTES = 2 * 1024 * 1024
@@ -1221,6 +1222,7 @@ export default function UserBar() {
     ? desktopMediaPermissionRecoveryMessage('microphone')
     : 'Allow microphone access to unlock full voice controls.'
   const showDesktopMicrophoneRecovery = isTauri() && microphonePermissionState === 'denied'
+  const showVoiceBenchmarkDiagnostics = isVoiceDiagnosticsEnabled()
 
   const voiceDeviceMenu = openDeviceMenu && deviceMenuAnchor && typeof document !== 'undefined'
     ? createPortal(
@@ -1764,19 +1766,21 @@ export default function UserBar() {
                         </button>
                       </div>
                     )}
-                    <div className="user-setting-row user-setting-row--span-two">
-                      <div>
-                        <div className="user-setting-title">Benchmark diagnostics</div>
-                        <div className="user-setting-desc">Copy the active voice diagnostics snapshot for benchmark notes.</div>
+                    {showVoiceBenchmarkDiagnostics && (
+                      <div className="user-setting-row user-setting-row--span-two">
+                        <div>
+                          <div className="user-setting-title">Benchmark diagnostics</div>
+                          <div className="user-setting-desc">Copy the active voice diagnostics snapshot for benchmark notes.</div>
+                        </div>
+                        <button
+                          type="button"
+                          className="user-toggle account-action-btn"
+                          onClick={() => void copyVoiceBenchmarkDiagnostics()}
+                        >
+                          Copy diagnostics
+                        </button>
                       </div>
-                      <button
-                        type="button"
-                        className="user-toggle account-action-btn"
-                        onClick={() => void copyVoiceBenchmarkDiagnostics()}
-                      >
-                        Copy diagnostics
-                      </button>
-                    </div>
+                    )}
                   </div>
                 </div>
               </section>

--- a/docs/VOICE_QUALITY_BENCHMARK.md
+++ b/docs/VOICE_QUALITY_BENCHMARK.md
@@ -83,7 +83,7 @@ After joining voice, capture:
 window.__VOXPERY_VOICE_DIAGNOSTICS__
 ```
 
-You can also open User Settings -> Voice & Audio and click `Copy diagnostics` to copy the same JSON snapshot into the benchmark notes.
+With diagnostics enabled, you can also open User Settings -> Voice & Audio and click `Copy diagnostics` to copy the same JSON snapshot into the benchmark notes. The diagnostics action is hidden during normal app use.
 
 Required diagnostic fields:
 


### PR DESCRIPTION
## Summary
- Hide the Voice & Audio benchmark diagnostics action unless voice diagnostics are explicitly enabled.
- Keep the copy-diagnostics workflow available for benchmark runs via the existing localStorage flag.
- Update the voice benchmark docs to clarify that the settings action is hidden during normal app use.

## Validation
- npm run test:run -- voiceDiagnostics.test.ts
- npm run test:run
- npm run lint
- npm run build
- npm run test:e2e:ui-smoke