### PR TITLE
fix: make social loading cache aware

### DIFF
--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -49,6 +49,7 @@ export default function AppShell() {
     setDmChannels,
     setDmUnreadFromChannels,
     setFriends,
+    setSocialDataReady,
     activeDmChannelId,
     setActiveServer,
     setActiveChannel,
@@ -68,6 +69,7 @@ export default function AppShell() {
       setDmChannels: s.setDmChannels,
       setDmUnreadFromChannels: s.setDmUnreadFromChannels,
       setFriends: s.setFriends,
+      setSocialDataReady: s.setSocialDataReady,
       activeDmChannelId: s.activeDmChannelId,
       setActiveServer: s.setActiveServer,
       setActiveChannel: s.setActiveChannel,
@@ -249,14 +251,25 @@ export default function AppShell() {
         setDmChannels(channels)
         setDmUnreadFromChannels(channels)
         setFriends(friendList)
+        setSocialDataReady(true)
       } catch {
         // ignore transient failures
       }
     }
-    syncSocial()
-    const id = window.setInterval(syncSocial, 2000)
-    return () => window.clearInterval(id)
-  }, [setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, token, userId])
+    void syncSocial()
+    const id = window.setInterval(() => {
+      if (document.visibilityState === 'hidden') return
+      void syncSocial()
+    }, 15000)
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') void syncSocial()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setSocialDataReady, token, userId])
 
   useEffect(() => {
     if (!isConnected || dmChannelIds.length === 0) return

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -201,6 +201,30 @@ describe('HomePage friends list', () => {
     expect(screen.queryByRole('button', { name: 'Hide DM with cilo' })).toBeNull()
   })
 
+  it('shows cached social data without waiting for the server list refresh', async () => {
+    const cachedFriend = friend('friend-cached', 'cachedfriend', 'online')
+    const cachedDm = dmChannel('dm-cached', cachedFriend.id, cachedFriend.username)
+    apiMocks.listServers.mockReturnValue(new Promise(() => {}))
+    apiMocks.listFriends.mockResolvedValue([cachedFriend])
+    apiMocks.listDmChannels.mockResolvedValue([cachedDm])
+    useAppStore.setState({
+      friends: [cachedFriend],
+      dmChannels: [cachedDm],
+      dmChannelIds: [cachedDm.id],
+      socialDataReady: true,
+    })
+
+    renderHomePage()
+
+    expect(screen.getByRole('button', { name: 'Message cachedfriend' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Hide DM with cachedfriend' })).toBeInTheDocument()
+    expect(screen.queryByText('Start your social graph')).toBeNull()
+    await waitFor(() => {
+      expect(apiMocks.listFriends).toHaveBeenCalled()
+      expect(apiMocks.listDmChannels).toHaveBeenCalled()
+    })
+  })
+
   it('refreshes the active DM when returning from another app area', async () => {
     const channel = dmChannel('dm-cilo')
     sessionStorage.setItem('voxpery-social-view', 'dm')

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -110,8 +110,10 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     setIncomingRequestCount,
     friends: storeFriends,
     dmChannels: storeDmChannels,
+    socialDataReady,
     setFriends: setStoreFriends,
     setDmChannels: setStoreDmChannels,
+    setSocialDataReady,
     setDmUnreadFromChannels,
     mobileSidebarPanel,
     setMobileSidebarPanel,
@@ -129,8 +131,10 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setIncomingRequestCount: s.setIncomingRequestCount,
       friends: s.friends,
       dmChannels: s.dmChannels,
+      socialDataReady: s.socialDataReady,
       setFriends: s.setFriends,
       setDmChannels: s.setDmChannels,
+      setSocialDataReady: s.setSocialDataReady,
       setDmUnreadFromChannels: s.setDmUnreadFromChannels,
       mobileSidebarPanel: s.mobileSidebarPanel,
       setMobileSidebarPanel: s.setMobileSidebarPanel,
@@ -143,7 +147,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [view, setView] = useState<SocialView>('friends')
   const isDmConversationVisible = isMessagesView && location.pathname === ROUTES.dm && view === 'dm'
   const [friendsFilter, setFriendsFilter] = useState<FriendsFilter>('online')
-  const [socialBootstrapLoading, setSocialBootstrapLoading] = useState(true)
+  const [socialBootstrapLoading, setSocialBootstrapLoading] = useState(() => !useAppStore.getState().socialDataReady)
   const [incomingRequests, setIncomingRequests] = useState<FriendRequest[]>([])
   const [outgoingRequests, setOutgoingRequests] = useState<FriendRequest[]>([])
   const [addFriendUsername, setAddFriendUsername] = useState('')
@@ -154,6 +158,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const isMobileSocialSidebarOpen = mobileSidebarPanel === 'social'
   const friends = storeFriends
   const dmChannels = storeDmChannels
+  const showSocialBootstrapLoading = socialBootstrapLoading && !socialDataReady
 
   // Social paths (/social and /social/dm): restore last social tab and optional deep-linked DM.
   useEffect(() => {
@@ -214,15 +219,23 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   // Use user so web works: on web token is null, auth is via httpOnly cookie.
   const refreshServersAndFriends = useCallback(async () => {
     if (!userId) return
+    const shouldBlockSocialUi = !useAppStore.getState().socialDataReady
+    if (shouldBlockSocialUi) setSocialBootstrapLoading(true)
+
     setServersLoading(true)
+    void serverApi.list(token)
+      .then(setServers)
+      .catch(console.error)
+      .finally(() => {
+        setServersLoading(false)
+      })
+
     try {
-      const [serverList, friendList, req, dms] = await Promise.all([
-        serverApi.list(token),
+      const [friendList, req, dms] = await Promise.all([
         friendApi.list(token),
         friendApi.requests(token),
         dmApi.listChannels(token),
       ])
-      setServers(serverList)
       setStoreFriends(friendList)
       setIncomingRequests(req.incoming)
       setIncomingRequestCount(req.incoming.length)
@@ -230,15 +243,15 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setStoreDmChannels(dms)
       setDmUnreadFromChannels(dms)
       setDmChannelIds(dms.map((d) => d.id))
+      setSocialDataReady(true)
     } finally {
-      setServersLoading(false)
       setSocialBootstrapLoading(false)
     }
-  }, [setDmChannelIds, setDmUnreadFromChannels, setIncomingRequestCount, setServers, setServersLoading, setStoreFriends, setStoreDmChannels, token, userId])
+  }, [setDmChannelIds, setDmUnreadFromChannels, setIncomingRequestCount, setServers, setServersLoading, setSocialDataReady, setStoreFriends, setStoreDmChannels, token, userId])
 
   useEffect(() => {
     if (!userId) return
-    setSocialBootstrapLoading(true)
+    if (!useAppStore.getState().socialDataReady) setSocialBootstrapLoading(true)
     refreshServersAndFriends().catch(console.error)
   }, [refreshServersAndFriends, userId])
 
@@ -895,7 +908,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         </button>
         <div className="social-sidebar-divider" />
         <div className="social-sidebar-title">Direct Messages</div>
-        {socialBootstrapLoading ? (
+        {showSocialBootstrapLoading ? (
           <div className="home-sidebar-skeleton" aria-hidden="true">
             <div className="home-sidebar-skeleton-row" />
             <div className="home-sidebar-skeleton-row" />
@@ -1112,7 +1125,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                         ? `Online Friends — ${onlineFriends.length}`
                         : `All Friends — ${friends.length}`}
                     </div>
-                    {socialBootstrapLoading ? (
+                    {showSocialBootstrapLoading ? (
                       <div className="home-list-skeleton" aria-hidden="true">
                         <div className="home-list-skeleton-row" />
                         <div className="home-list-skeleton-row" />
@@ -1218,7 +1231,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
 
           {view === 'dm' && (() => {
             const dmChannel = activeDmChannelId ? storeDmChannels.find((c) => c.id === activeDmChannelId) : null
-            if (socialBootstrapLoading) {
+            if (showSocialBootstrapLoading) {
               return (
                 <div className="home-dm-chat">
                   <div className="home-list-skeleton" aria-hidden="true" style={{ padding: 24 }}>

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -43,8 +43,10 @@ interface AppState {
     // Prefetched for Social (friends + DM channel list) so Social loads instantly
     friends: Friend[]
     dmChannels: DmChannel[]
+    socialDataReady: boolean
     setFriends: (friends: Friend[]) => void
     setDmChannels: (channels: DmChannel[]) => void
+    setSocialDataReady: (ready: boolean) => void
     dmUnread: Record<string, number>
     setDmUnreadFromChannels: (channels: DmChannel[]) => void
     incrementDmUnread: (channelId: string) => void
@@ -216,8 +218,10 @@ export const useAppStore = create<AppState>()(
             setActiveDmChannelId: (id) => set({ activeDmChannelId: id }),
             friends: [],
             dmChannels: [],
+            socialDataReady: false,
             setFriends: (friends) => set((s) => JSON.stringify(s.friends) === JSON.stringify(friends) ? s : { friends }),
             setDmChannels: (channels) => set((s) => JSON.stringify(s.dmChannels) === JSON.stringify(channels) ? s : { dmChannels: channels }),
+            setSocialDataReady: (ready) => set({ socialDataReady: ready }),
             dmUnread: {},
             setDmUnreadFromChannels: (channels) =>
                 set((s) => {
@@ -377,6 +381,7 @@ export const useAppStore = create<AppState>()(
                     activeDmChannelId: null,
                     friends: [],
                     dmChannels: [],
+                    socialDataReady: false,
                     dmUnread: {},
                     serverUnreadByChannel: {},
                     serverMentionsByChannel: {},


### PR DESCRIPTION
## Summary
- Make the Social/Friends home loading flow cache-aware so cached friends and DM channels render immediately.
- Decouple server list refresh from the critical Social bootstrap path.
- Reduce aggressive Social polling from every 2 seconds to a lighter interval plus visibility refresh.
- Preserve persistent hidden-DM behavior while refreshing the canonical DM list in the background.
- Add regression coverage for rendering cached Social data without waiting for server list refresh.

## Validation
- npm run test:run -- HomePage.test.tsx
- npm run test:run
- npm run lint
- npm run build
- npm run test:e2e:ui-smoke