### PR TITLE
perf: make social refresh event driven

### DIFF
--- a/apps/web/src/pages/AppShell.test.tsx
+++ b/apps/web/src/pages/AppShell.test.tsx
@@ -1,0 +1,182 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DmChannel, Friend, User } from '../api'
+import { useAppStore } from '../stores/app'
+import { useAuthStore } from '../stores/auth'
+import { useSocketStore } from '../stores/socket'
+import AppShell from './AppShell'
+
+const apiMocks = vi.hoisted(() => ({
+  createWebSocket: vi.fn(),
+  listDmChannels: vi.fn(),
+  listFriends: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  createWebSocket: apiMocks.createWebSocket,
+  dmApi: {
+    listChannels: apiMocks.listDmChannels,
+    getOrCreateChannel: vi.fn(),
+  },
+  friendApi: {
+    list: apiMocks.listFriends,
+  },
+}))
+
+vi.mock('../components/ActiveCallBar', () => ({
+  default: () => <div data-testid="active-call-bar" />,
+}))
+
+vi.mock('../components/QuickSwitcher', () => ({
+  default: () => null,
+}))
+
+vi.mock('../components/UserBar', () => ({
+  default: () => <div data-testid="user-bar" />,
+}))
+
+vi.mock('../notificationSound', () => ({
+  playMessageNotificationSound: vi.fn(),
+  shouldPlayNotificationSound: vi.fn(() => false),
+}))
+
+vi.mock('../pushNotifications', () => ({
+  shouldShowPushNotification: vi.fn(() => false),
+  showPushNotification: vi.fn(),
+}))
+
+vi.mock('../secureStorage', () => ({
+  isTauri: vi.fn(() => false),
+}))
+
+vi.mock('../updater', () => ({
+  DESKTOP_UPDATE_STATUS_EVENT: 'voxpery-desktop-update-status',
+  checkForUpdates: vi.fn(),
+  downloadAndInstallUpdate: vi.fn(),
+  getDesktopAppVersion: vi.fn(),
+}))
+
+const localUser: User = {
+  id: 'user-local',
+  username: 'admin',
+  email: 'admin@example.test',
+  email_verified: true,
+  status: 'online',
+}
+
+function dmChannel(id: string, peerId = 'friend-1', peerUsername = 'friend'): DmChannel {
+  return {
+    id,
+    peer_id: peerId,
+    peer_username: peerUsername,
+    peer_avatar_url: null,
+    peer_status: 'online',
+    last_message_at: null,
+    unread_count: 0,
+  }
+}
+
+function friend(id: string, username: string): Friend {
+  return {
+    id,
+    username,
+    avatar_url: null,
+    status: 'online',
+  }
+}
+
+function renderAppShell() {
+  return render(
+    <MemoryRouter initialEntries={['/channels/@me']}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/channels/@me" element={<div data-testid="shell-child" />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('AppShell social refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+
+    apiMocks.createWebSocket.mockReturnValue({
+      readyState: WebSocket.CONNECTING,
+      send: vi.fn(),
+      close: vi.fn(),
+      onopen: null,
+      onclose: null,
+      onmessage: null,
+    })
+    apiMocks.listDmChannels.mockResolvedValue([dmChannel('dm-1')])
+    apiMocks.listFriends.mockResolvedValue([friend('friend-1', 'friend')])
+
+    useAuthStore.setState({
+      token: 'token',
+      user: localUser,
+      loggingOut: false,
+    })
+    useAppStore.getState().resetSessionState()
+    useSocketStore.setState({
+      socket: null,
+      isConnected: false,
+      token: null,
+      shouldReconnect: false,
+      listeners: new Set(),
+      reconnectListeners: new Set(),
+      reconnectAttempt: 0,
+      reconnectTimer: null,
+      connectionId: 0,
+      wasConnectedBefore: false,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps social data fresh from events and reconnects instead of aggressive polling', async () => {
+    const setIntervalSpy = vi.spyOn(window, 'setInterval')
+
+    renderAppShell()
+
+    await waitFor(() => {
+      expect(apiMocks.listDmChannels).toHaveBeenCalledTimes(1)
+      expect(apiMocks.listFriends).toHaveBeenCalledTimes(1)
+    })
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000)
+    expect(useAppStore.getState().socialDataReady).toBe(true)
+
+    act(() => {
+      useSocketStore.getState().listeners.forEach((listener) => {
+        listener({ type: 'FriendUpdate', data: { user_id: 'other-user' } })
+      })
+    })
+
+    expect(apiMocks.listDmChannels).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      useSocketStore.getState().listeners.forEach((listener) => {
+        listener({ type: 'FriendUpdate', data: { user_id: localUser.id } })
+      })
+    })
+
+    await waitFor(() => {
+      expect(apiMocks.listDmChannels).toHaveBeenCalledTimes(2)
+      expect(apiMocks.listFriends).toHaveBeenCalledTimes(2)
+    })
+
+    act(() => {
+      useSocketStore.getState().reconnectListeners.forEach((listener) => listener())
+    })
+
+    await waitFor(() => {
+      expect(apiMocks.listDmChannels).toHaveBeenCalledTimes(3)
+      expect(apiMocks.listFriends).toHaveBeenCalledTimes(3)
+    })
+  })
+})

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useNavigate, useLocation } from 'react-router-dom'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowDownToLine, Search } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { useAuthStore } from '../stores/auth'
@@ -38,7 +38,7 @@ export default function AppShell() {
   const userId = user?.id ?? null
   const myStatus = useAuthStore((s) => s.user?.status)
   const token = useAuthStore((s) => s.token)
-  const { connect, subscribe, send, isConnected } = useSocketStore()
+  const { connect, subscribe, send, isConnected, onReconnect } = useSocketStore()
   const {
     setVoiceState,
     setVoiceControl,
@@ -239,37 +239,43 @@ export default function AppShell() {
     return () => unsubscribe()
   }, [])
 
+  const syncSocial = useCallback(async () => {
+    if (!userId) return
+    try {
+      const [channels, friendList] = await Promise.all([
+        dmApi.listChannels(token),
+        friendApi.list(token),
+      ])
+      setDmChannelIds(channels.map((c) => c.id))
+      setDmChannels(channels)
+      setDmUnreadFromChannels(channels)
+      setFriends(friendList)
+      setSocialDataReady(true)
+    } catch {
+      // ignore transient failures
+    }
+  }, [setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setSocialDataReady, token, userId])
+
   useEffect(() => {
     if (!userId) return
-    const syncSocial = async () => {
-      try {
-        const [channels, friendList] = await Promise.all([
-          dmApi.listChannels(token),
-          friendApi.list(token),
-        ])
-        setDmChannelIds(channels.map((c) => c.id))
-        setDmChannels(channels)
-        setDmUnreadFromChannels(channels)
-        setFriends(friendList)
-        setSocialDataReady(true)
-      } catch {
-        // ignore transient failures
-      }
-    }
     void syncSocial()
     const id = window.setInterval(() => {
       if (document.visibilityState === 'hidden') return
       void syncSocial()
-    }, 15000)
+    }, 60000)
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') void syncSocial()
     }
+    const unsubscribeReconnect = onReconnect(() => {
+      void syncSocial()
+    })
     document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
       window.clearInterval(id)
+      unsubscribeReconnect()
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setSocialDataReady, token, userId])
+  }, [onReconnect, syncSocial, userId])
 
   useEffect(() => {
     if (!isConnected || dmChannelIds.length === 0) return
@@ -398,6 +404,12 @@ export default function AppShell() {
             clearDmUnread(payload.channel_id)
           }
         }
+        if (e?.type === 'FriendUpdate') {
+          const payload = e.data as { user_id?: string }
+          if (!payload.user_id || payload.user_id === userId) {
+            void syncSocial()
+          }
+        }
         if (e?.type === 'NewMessage') {
           const payload = e?.data as { channel_id?: string; channel_type?: string; message?: { author?: { user_id?: string; username?: string } } }
           const channelId = payload?.channel_id
@@ -489,7 +501,7 @@ export default function AppShell() {
       }
     })
     return () => unsub()
-  }, [activeDmChannelId, clearDmUnread, dmChannelIds, dmChannels, incrementDmUnread, location.pathname, myStatus, navigate, pushToast, setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setJoinedVoiceChannelId, setVoiceControl, setVoiceState, subscribe, token, userId])
+  }, [activeDmChannelId, clearDmUnread, dmChannelIds, dmChannels, incrementDmUnread, location.pathname, myStatus, navigate, pushToast, setActiveDmChannelId, setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setJoinedVoiceChannelId, setVoiceControl, setVoiceState, subscribe, syncSocial, token, userId])
   const activeChannel = useMemo(() => channels.find((c) => c.id === activeChannelId), [channels, activeChannelId])
   // Prefer the voice channel the user is viewing so switching channels leaves current and joins the new one.
   const selectedVoiceChannelId =


### PR DESCRIPTION
## Summary
- make AppShell social refresh event-driven via FriendUpdate, WebSocket reconnect, and visibility return
- reduce fallback social polling from 15 seconds to 60 seconds
- add an AppShell regression test covering event/reconnect refresh behavior and the polling interval

## Validation
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:ui-smoke