### PR TITLE
tune balanced voice profile for natural speech

### DIFF
--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -183,31 +183,31 @@ export function buildSuppressionFilterConfig(
 ): LiveSuppressionFilterConfig {
     return {
         highPassHz: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 120, balanced: 145, high: 170 })
+            ? pickSuppressionValue(suppressionTuning, { off: 120, balanced: 135, high: 170 })
             : pickSuppressionValue(suppressionTuning, { off: 120, balanced: 125, high: 145 }),
         lowPassHz: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 7200, balanced: 6200, high: 3500 })
+            ? pickSuppressionValue(suppressionTuning, { off: 7200, balanced: 6800, high: 3500 })
             : pickSuppressionValue(suppressionTuning, { off: 7200, balanced: 6200, high: 4400 }),
         deClickGainDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: -3.5, high: -10 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: -2.4, high: -10 })
             : pickSuppressionValue(suppressionTuning, { off: 0, balanced: -1.8, high: -4.2 }),
         speechPresenceGainDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: 1.1, high: 1.9 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: 0.9, high: 1.9 })
             : pickSuppressionValue(suppressionTuning, { off: 0, balanced: 1.1, high: 1.75 }),
         compressorThresholdDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: -30, balanced: -34, high: -44 })
+            ? pickSuppressionValue(suppressionTuning, { off: -30, balanced: -32, high: -44 })
             : pickSuppressionValue(suppressionTuning, { off: -30, balanced: -31, high: -36 }),
         compressorKneeDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 10, balanced: 8, high: 5 })
+            ? pickSuppressionValue(suppressionTuning, { off: 10, balanced: 9, high: 5 })
             : pickSuppressionValue(suppressionTuning, { off: 10, balanced: 10, high: 8 }),
         compressorRatio: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 3.5, balanced: 4.6, high: 8.2 })
+            ? pickSuppressionValue(suppressionTuning, { off: 3.5, balanced: 4, high: 8.2 })
             : pickSuppressionValue(suppressionTuning, { off: 3.5, balanced: 3.8, high: 5.4 }),
         compressorAttackSec: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.003, balanced: 0.0025, high: 0.001 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.003, balanced: 0.0028, high: 0.001 })
             : pickSuppressionValue(suppressionTuning, { off: 0.003, balanced: 0.0024, high: 0.0015 }),
         compressorReleaseSec: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.085, balanced: 0.072, high: 0.038 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.085, balanced: 0.085, high: 0.038 })
             : pickSuppressionValue(suppressionTuning, { off: 0.085, balanced: 0.082, high: 0.065 }),
     }
 }
@@ -236,19 +236,19 @@ export function buildSuppressionConfig(
         aggressiveIsolation,
         suppressionTuning,
         lowFloorThr: dbToLinear(aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: -51, balanced: -49, high: -40 })
+            ? pickSuppressionValue(suppressionTuning, { off: -51, balanced: -51, high: -40 })
             : pickSuppressionValue(suppressionTuning, { off: -51, balanced: -50, high: -46 })),
         openFloorThr: dbToLinear(aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: -40, balanced: -37, high: -29 })
+            ? pickSuppressionValue(suppressionTuning, { off: -40, balanced: -39, high: -29 })
             : pickSuppressionValue(suppressionTuning, { off: -40, balanced: -38, high: -34 })),
         minFloorGain: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.12, balanced: 0.09, high: 0.012 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.12, balanced: 0.12, high: 0.012 })
             : pickSuppressionValue(suppressionTuning, { off: 0.12, balanced: 0.1, high: 0.06 }),
         floorReleaseAlpha: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.08, balanced: 0.08, high: 0.12 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.08, balanced: 0.07, high: 0.12 })
             : pickSuppressionValue(suppressionTuning, { off: 0.08, balanced: 0.075, high: 0.09 }),
         floorReleaseTime: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.065, high: 0.046 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.075, high: 0.046 })
             : pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.066, high: 0.055 }),
     }
 }

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   clearRemoteMediaStartCue,
+  getMicrophonePublishOptions,
   remoteMediaStartCueKey,
   resyncVoiceStateAfterReconnect,
   shouldPlayRemoteMediaStartCue,
 } from './useLiveKitVoice'
+import { AudioPresets, Track } from 'livekit-client'
+
+describe('microphone publish options', () => {
+  it('uses a high-quality mono Opus profile with resilience enabled', () => {
+    expect(getMicrophonePublishOptions()).toMatchObject({
+      source: Track.Source.Microphone,
+      audioPreset: AudioPresets.musicHighQuality,
+      dtx: true,
+      red: true,
+      forceStereo: false,
+    })
+  })
+})
 
 describe('resyncVoiceStateAfterReconnect', () => {
   it('re-sends voice join and control state after WebSocket reconnect', () => {

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  AudioPresets,
   LocalAudioTrack,
   RemoteParticipant,
   Room,
   RoomEvent,
   Track,
+  type TrackPublishOptions,
 } from 'livekit-client'
 import { webrtcApi } from '../api'
 import { useAuthStore } from '../stores/auth'
@@ -32,6 +34,16 @@ type VoiceControlState = {
   screenSharing?: boolean
   cameraOn?: boolean
 } | null | undefined
+
+export function getMicrophonePublishOptions(): TrackPublishOptions {
+  return {
+    source: Track.Source.Microphone,
+    audioPreset: AudioPresets.musicHighQuality,
+    dtx: true,
+    red: true,
+    forceStereo: false,
+  }
+}
 
 interface VoiceReconnectResyncOptions {
   channelId: string | null
@@ -320,7 +332,7 @@ export function useLiveKitVoice() {
       await room.localParticipant.unpublishTrack(previousTrack)
       previousTrack.stop()
 
-      const publication = await room.localParticipant.publishTrack(nextTrack, { source: Track.Source.Microphone })
+      const publication = await room.localParticipant.publishTrack(nextTrack, getMicrophonePublishOptions())
       previousGateCancel?.()
       gateCancelRef.current = nextGateCancel
       localAudioTrackRef.current = publication.track as LocalAudioTrack
@@ -479,6 +491,10 @@ export function useLiveKitVoice() {
         adaptiveStream: true,
         dynacast: true,
         publishDefaults: {
+          audioPreset: AudioPresets.musicHighQuality,
+          dtx: true,
+          red: true,
+          forceStereo: false,
           screenShareEncoding: getScreenShareEncoding(),
           screenShareSimulcastLayers: [],
           videoEncoding: { maxBitrate: 3_000_000, maxFramerate: 30 },
@@ -643,7 +659,7 @@ export function useLiveKitVoice() {
       remoteMediaStartCueReadyRef.current = true
 
       // Publish the track directly to LiveKit.
-      const pub = await room.localParticipant.publishTrack(publishTrack, { source: Track.Source.Microphone })
+      const pub = await room.localParticipant.publishTrack(publishTrack, getMicrophonePublishOptions())
       updateVoiceDiagnostics({
         livekit: {
           roomState: String(room.state),
@@ -653,6 +669,10 @@ export function useLiveKitVoice() {
           dynacast: true,
           microphonePublished: true,
           microphoneSource: 'processed-webaudio',
+          microphoneAudioPreset: 'musicHighQuality',
+          microphoneDtx: true,
+          microphoneRed: true,
+          microphoneForceStereo: false,
         },
       })
 

--- a/apps/web/src/webrtc/voiceDiagnostics.test.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.test.ts
@@ -164,6 +164,14 @@ describe('voiceDiagnostics', () => {
         pingJitterMs: 4,
         pingSource: 'rtc',
       },
+      livekit: {
+        microphonePublished: true,
+        microphoneSource: 'processed-webaudio',
+        microphoneAudioPreset: 'musicHighQuality',
+        microphoneDtx: true,
+        microphoneRed: true,
+        microphoneForceStereo: false,
+      },
     })
 
     const snapshot = getVoiceDiagnosticsSnapshot()
@@ -186,6 +194,14 @@ describe('voiceDiagnostics', () => {
         pingMs: 42,
         rtcPingMs: 42,
         pingSource: 'rtc',
+      },
+      livekit: {
+        microphonePublished: true,
+        microphoneSource: 'processed-webaudio',
+        microphoneAudioPreset: 'musicHighQuality',
+        microphoneDtx: true,
+        microphoneRed: true,
+        microphoneForceStereo: false,
       },
     })
     expect(snapshot).not.toBe(window.__VOXPERY_VOICE_DIAGNOSTICS__)

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -60,6 +60,10 @@ export interface VoiceLivekitDiagnostics {
   dynacast?: boolean
   microphonePublished?: boolean
   microphoneSource?: 'processed-webaudio'
+  microphoneAudioPreset?: 'musicHighQuality'
+  microphoneDtx?: boolean
+  microphoneRed?: boolean
+  microphoneForceStereo?: boolean
 }
 
 export interface VoiceRuntimeDiagnostics {

--- a/apps/web/src/webrtc/voiceQualityBenchmarkConfig.test.ts
+++ b/apps/web/src/webrtc/voiceQualityBenchmarkConfig.test.ts
@@ -87,6 +87,17 @@ describe('voice quality benchmark configuration', () => {
     const balancedFilters = buildSuppressionFilterConfig(true, 'balanced')
     const highFilters = buildSuppressionFilterConfig(true, 'high')
 
+    expect(balancedFilters).toMatchObject({
+      highPassHz: 135,
+      lowPassHz: 6800,
+      deClickGainDb: -2.4,
+      speechPresenceGainDb: 0.9,
+      compressorThresholdDb: -32,
+      compressorKneeDb: 9,
+      compressorRatio: 4,
+      compressorAttackSec: 0.0028,
+      compressorReleaseSec: 0.085,
+    })
     expect(balancedFilters.highPassHz).toBeLessThan(highFilters.highPassHz)
     expect(balancedFilters.lowPassHz).toBeGreaterThan(highFilters.lowPassHz)
     expect(balancedFilters.deClickGainDb).toBeGreaterThan(highFilters.deClickGainDb)
@@ -101,8 +112,11 @@ describe('voice quality benchmark configuration', () => {
     localStorage.setItem('voxpery-settings-speaking-preset', 'noisy')
     const highConfig = buildSuppressionConfig(true)
 
-    expect(dbFromLinear(balancedConfig.lowFloorThr)).toBe(-49)
-    expect(dbFromLinear(balancedConfig.openFloorThr)).toBe(-37)
+    expect(dbFromLinear(balancedConfig.lowFloorThr)).toBe(-51)
+    expect(dbFromLinear(balancedConfig.openFloorThr)).toBe(-39)
+    expect(balancedConfig.minFloorGain).toBe(0.12)
+    expect(balancedConfig.floorReleaseAlpha).toBe(0.07)
+    expect(balancedConfig.floorReleaseTime).toBe(0.075)
     expect(balancedConfig.minFloorGain).toBeGreaterThan(highConfig.minFloorGain)
     expect(balancedConfig.floorReleaseTime).toBeGreaterThan(highConfig.floorReleaseTime)
   })

--- a/docs/VOICE_QUALITY_BENCHMARK.md
+++ b/docs/VOICE_QUALITY_BENCHMARK.md
@@ -102,7 +102,7 @@ Required diagnostic fields:
 - `liveProcessing.rmsDb`, `floorGain`, `isolationGain`, and `likelySpeech` show the current suppression behavior.
 - `voiceActivity` shows gate state, speech state, RMS, thresholds, and frame counters.
 - `network` shows ping, RTC ping, packet loss, jitter, and selected ping source.
-- `livekit` shows room state, participants, remote stream count, and whether the processed microphone track was published.
+- `livekit` shows room state, participants, remote stream count, and whether the processed microphone track was published with `musicHighQuality`, DTX, RED, and mono microphone audio.
 
 Also capture the call bar ping color and visible ping.
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -80,7 +80,7 @@ GainNode (input volume)
     |
 VAD gate (optional, voice_activity mode)
     |
-LiveKit LocalAudioTrack
+LiveKit LocalAudioTrack (high-quality mono Opus with DTX + RED)
     |
 Room.localParticipant.publishTrack
 ```
@@ -120,8 +120,12 @@ Room.localParticipant.publishTrack
     - speech-presence shaping
     - compressor strength
     - residual noise floor attenuation
-  - `Balanced` is the recommended default
+  - `Balanced` is the recommended default and keeps a wider speech band with gentler compression/floor attenuation so everyday voices sound more natural
   - `Noisy room` and stricter custom thresholds trend more aggressive for keyboard and room noise
+- **Microphone publish quality**
+  - The processed microphone track is published with LiveKit's high-quality mono Opus preset.
+  - DTX remains enabled to avoid sending unnecessary silence, and RED remains enabled for packet-loss resilience.
+  - Stereo is forced off for microphone audio so bitrate stays focused on voice clarity rather than duplicate channels.
 - **Why RNNoise?**
   - Browser native `noiseSuppression` is too weak for noisy backgrounds
   - Krisp required LiveKit Cloud (self-hosted setups can't use it)


### PR DESCRIPTION
## Summary
- tune the default Balanced voice isolation profile toward more natural speech
- keep Noisy room / high cleanup behavior unchanged for stronger noise rejection
- publish processed microphone audio with LiveKit high-quality mono Opus settings
- keep DTX and RED enabled for silence efficiency and packet-loss resilience
- expose microphone publish quality in voice diagnostics
- update benchmark regressions and voice docs for the final voice-quality behavior

## Validation
- npm run test:run -- voiceQualityBenchmarkConfig.test.ts voiceGate.test.ts voiceDiagnostics.test.ts voiceInputProfile.test.ts useLiveKitVoice.test.ts
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:ui-smoke