### PR TITLE
test: add mobile and desktop release smoke guards

### DIFF
--- a/.github/scripts/validate-desktop-artifacts.mjs
+++ b/.github/scripts/validate-desktop-artifacts.mjs
@@ -1,0 +1,128 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { basename, extname, join, relative, resolve } from 'node:path'
+
+const repoRoot = process.cwd()
+const bundleRoot = resolve(
+  repoRoot,
+  process.env.DESKTOP_BUNDLE_DIR || 'apps/desktop/src-tauri/target/release/bundle',
+)
+const platform = normalizePlatform(
+  process.argv.find((arg) => arg.startsWith('--platform='))?.split('=')[1] || process.env.RUNNER_OS,
+)
+const failures = []
+
+function normalizePlatform(value) {
+  const normalized = String(value || '').toLowerCase()
+  if (normalized.includes('windows')) return 'windows'
+  if (normalized.includes('mac')) return 'macos'
+  if (normalized.includes('linux')) return 'linux'
+  return 'unknown'
+}
+
+function fail(message) {
+  failures.push(message)
+}
+
+function walk(dir, entries = []) {
+  if (!existsSync(dir)) return entries
+  for (const name of readdirSync(dir)) {
+    const fullPath = join(dir, name)
+    const stat = statSync(fullPath)
+    entries.push({ fullPath, stat })
+    if (stat.isDirectory()) walk(fullPath, entries)
+  }
+  return entries
+}
+
+function displayPath(entry) {
+  return relative(repoRoot, entry.fullPath).replaceAll('\\', '/')
+}
+
+function fileEntries(entries) {
+  return entries.filter((entry) => entry.stat.isFile())
+}
+
+function findFiles(entries, predicate) {
+  return fileEntries(entries).filter((entry) => predicate(entry.fullPath, entry))
+}
+
+function requireFiles(label, entries, predicate, minBytes = 1) {
+  const matches = findFiles(entries, predicate)
+  if (matches.length === 0) {
+    fail(`Missing desktop artifact: ${label}`)
+    return []
+  }
+  for (const entry of matches) {
+    if (entry.stat.size < minBytes) {
+      fail(`Desktop artifact is too small: ${displayPath(entry)} (${entry.stat.size} bytes)`)
+    }
+  }
+  return matches
+}
+
+function requireDirectory(label, entries, predicate) {
+  const matches = entries.filter((entry) => entry.stat.isDirectory() && predicate(entry.fullPath, entry))
+  if (matches.length === 0) {
+    fail(`Missing desktop artifact directory: ${label}`)
+  }
+  return matches
+}
+
+function requireUpdaterMetadata(entries) {
+  const latestJson = requireFiles(
+    'updater latest.json',
+    entries,
+    (fullPath) => basename(fullPath) === 'latest.json',
+    32,
+  )
+  for (const entry of latestJson) {
+    try {
+      const metadata = JSON.parse(readFileSync(entry.fullPath, 'utf8').replace(/^\uFEFF/, ''))
+      if (!metadata.version || typeof metadata.version !== 'string') {
+        fail(`${displayPath(entry)} must include a string version`)
+      }
+      const platforms = metadata.platforms && typeof metadata.platforms === 'object'
+        ? Object.keys(metadata.platforms)
+        : []
+      if (platforms.length === 0) {
+        fail(`${displayPath(entry)} must include updater platforms`)
+      }
+    } catch (err) {
+      fail(`${displayPath(entry)} must be valid updater JSON: ${String(err)}`)
+    }
+  }
+}
+
+if (platform === 'unknown') {
+  fail('RUNNER_OS is missing or unsupported for desktop artifact validation')
+}
+
+if (!existsSync(bundleRoot)) {
+  fail(`Desktop bundle directory does not exist: ${relative(repoRoot, bundleRoot)}`)
+} else {
+  const entries = walk(bundleRoot)
+
+  if (platform === 'windows') {
+    requireFiles('Windows MSI installer', entries, (fullPath) => extname(fullPath).toLowerCase() === '.msi', 1_000_000)
+    requireFiles('Windows NSIS installer', entries, (fullPath) => extname(fullPath).toLowerCase() === '.exe', 1_000_000)
+  } else if (platform === 'macos') {
+    requireDirectory('macOS .app bundle', entries, (fullPath) => fullPath.endsWith('.app'))
+    requireFiles('macOS DMG installer', entries, (fullPath) => extname(fullPath).toLowerCase() === '.dmg', 1_000_000)
+  } else if (platform === 'linux') {
+    requireFiles('Linux DEB package', entries, (fullPath) => extname(fullPath).toLowerCase() === '.deb', 1_000_000)
+    requireFiles('Linux RPM package', entries, (fullPath) => extname(fullPath).toLowerCase() === '.rpm', 1_000_000)
+  }
+
+  requireUpdaterMetadata(entries)
+  requireFiles('updater signature files', entries, (fullPath) => fullPath.endsWith('.sig'), 16)
+}
+
+if (failures.length > 0) {
+  console.error('Desktop artifact validation failed:')
+  for (const entry of failures) {
+    console.error(`- ${entry}`)
+  }
+  process.exit(1)
+}
+
+console.log(`Desktop artifact validation passed for ${platform}.`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
         working-directory: apps/web
         run: npm run test:e2e:ui-smoke
 
+      - name: Mobile web smoke
+        working-directory: apps/web
+        run: npm run test:e2e:mobile-smoke
+
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -157,3 +157,6 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+      - name: Validate desktop artifacts
+        run: node .github/scripts/validate-desktop-artifacts.mjs

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -23,6 +23,7 @@ on:
         options:
           - disabled
           - chromium
+          - mobile
           - all
 
 permissions:
@@ -89,7 +90,7 @@ jobs:
         working-directory: apps/web
         shell: bash
         run: |
-          if [[ "${{ inputs.web_e2e_mode }}" == "chromium" ]]; then
+          if [[ "${{ inputs.web_e2e_mode }}" == "chromium" || "${{ inputs.web_e2e_mode }}" == "mobile" ]]; then
             npx playwright install --with-deps chromium
           else
             npx playwright install --with-deps
@@ -103,6 +104,8 @@ jobs:
         run: |
           if [[ "${{ inputs.web_e2e_mode }}" == "chromium" ]]; then
             npm run test:e2e -- --project=chromium
+          elif [[ "${{ inputs.web_e2e_mode }}" == "mobile" ]]; then
+            npm run test:e2e:mobile-smoke
           else
             npm run test:e2e
           fi

--- a/apps/web/TESTING.md
+++ b/apps/web/TESTING.md
@@ -23,6 +23,7 @@ E2E (Playwright):
 ```bash
 npm run test:e2e
 npm run test:e2e:ui-smoke
+npm run test:e2e:mobile-smoke
 npm run test:e2e:ui
 npm run test:e2e:headed
 ```
@@ -37,6 +38,17 @@ This Playwright suite runs against the real Vite UI with mocked API and WebSocke
 responses, so it does not require a backend. Use it as the fast PR guard for
 Friends, Requests, DM, server chat, channel creation, quick switcher, message
 actions, voice settings, voice error recovery, and responsive shell regressions.
+
+Mocked mobile web smoke:
+
+```bash
+npm run test:e2e:mobile-smoke
+```
+
+This suite runs the core Social, DM, server chat, mobile composer actions, and
+mobile member sheet flows with the `mobile-chromium` Playwright project. It is
+kept separate from the broader desktop smoke so mobile regressions can be run
+explicitly in CI and release candidate checks without requiring a real phone.
 
 ## Backend (`apps/server`)
 
@@ -73,10 +85,17 @@ Current workflows:
 - `.github/workflows/ci.yml`
   - Secret scan
   - Backend check/tests
-  - Frontend lint/unit tests/core UI smoke/build
+  - Frontend lint/unit tests/core UI smoke/mobile web smoke/build
+- `.github/workflows/release-smoke.yml`
+  - API smoke
+  - Optional web E2E scope: desktop Chromium, mobile Chromium, or all browser projects
+- `.github/workflows/release-desktop.yml`
+  - Desktop release preflight
+  - Tauri build
+  - Platform artifact guard for installer packages, updater metadata, and signatures
 - `.github/workflows/dependency-security.yml`
   - Rust and npm dependency audits
 
 ---
 
-Last verified against code on 2026-06-01.
+Last verified against code on 2026-06-12.

--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Locator } from '@playwright/test'
+import {
+  buildCoreChannels,
+  buildCoreMembers,
+  buildCoreServer,
+  buildFriends,
+  buildRequests,
+  buildServerMessage,
+  createMockCoreState,
+  installMockCoreApi,
+} from './mock-core-api'
+
+test.describe('mocked mobile web smoke', () => {
+  test('keeps Social friends, requests, and DM entry usable on a phone viewport', async ({ page }) => {
+    const state = createMockCoreState({
+      friends: buildFriends(24),
+      incomingRequests: buildRequests(18, 'incoming'),
+      outgoingRequests: buildRequests(18, 'outgoing'),
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/social')
+
+    await expect(page.getByRole('button', { name: /Online/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /All/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Requests/ })).toBeVisible()
+    await expectNoHorizontalOverflow(page.locator('.shell-layout'))
+
+    await page.getByRole('button', { name: /All/ }).click()
+    const homeScroller = page.locator('.home-main').first()
+    await expectScrollable(homeScroller)
+    await homeScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
+    await expect(page.getByText('Friend 24')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Open DM with Friend 24' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Open DM with Friend 24' }).click()
+    await expect(page).toHaveURL(/\/social\/dm/)
+    await expect(page.getByPlaceholder('Message @Friend 24')).toBeVisible()
+    await expectNoHorizontalOverflow(page.locator('.shell-layout'))
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: /Requests/ }).click()
+    await expectScrollable(homeScroller)
+    await homeScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
+    await expect(page.getByText('Request Out 18')).toBeVisible()
+    await expectNoHorizontalOverflow(page.locator('.shell-layout'))
+  })
+
+  test('keeps server channel chat, composer, and mobile member sheet usable', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const general = channels.find((channel) => channel.name === 'general')
+    if (!general) throw new Error('Core channel fixture is incomplete.')
+
+    const state = createMockCoreState({
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: {
+        [general.id]: [buildServerMessage(general.id, 'Mobile smoke baseline message')],
+      },
+    })
+    await installMockCoreApi(page, state)
+
+    await page.goto('/servers')
+
+    await expect(page.locator('.chat-header .channel-title')).toHaveText('general')
+    await expect(page.getByText('Mobile smoke baseline message')).toBeVisible()
+    await expect(page.locator('.dm-attach-btn[title="Attach files"]')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Insert emoji' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Browse GIFs' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Browse stickers' })).toBeVisible()
+    await expectNoHorizontalOverflow(page.locator('.shell-layout'))
+
+    const content = `Mobile smoke message ${Date.now()}`
+    const messageInput = page.getByPlaceholder('Message #general')
+    await messageInput.fill(content)
+    await messageInput.press('Enter')
+    await expect(page.getByText(content)).toBeVisible()
+    expect(state.messagesByChannelId[general.id]?.some((message) => message.content === content)).toBe(true)
+
+    await page.getByRole('button', { name: 'View members' }).click()
+    const sheet = page.locator('.mobile-member-sheet')
+    await expect(sheet).toBeVisible()
+    await expect(sheet.getByRole('heading', { name: 'Members' })).toBeVisible()
+    await expect(sheet).toContainText('localuser')
+    await expect(sheet).toContainText('Friend 01')
+    await expectNoHorizontalOverflow(page.locator('.shell-layout'))
+  })
+})
+
+async function expectScrollable(locator: Locator) {
+  await expect.poll(async () => {
+    return locator.evaluate((element) => element.scrollHeight > element.clientHeight)
+  }).toBe(true)
+}
+
+async function expectNoHorizontalOverflow(locator: Locator) {
+  await expect.poll(async () => {
+    return locator.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)
+  }).toBe(true)
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts e2e/social-friend-core-regressions.spec.ts e2e/server-settings-core-regressions.spec.ts e2e/invite-desktop-core-regressions.spec.ts --project=chromium",
+    "test:e2e:mobile-smoke": "playwright test e2e/mobile-web-smoke.spec.ts --project=mobile-chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const mobileSmokeSpec = /.*mobile-web-smoke\.spec\.ts/
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -19,17 +21,26 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: mobileSmokeSpec,
       use: { ...devices['Desktop Chrome'] },
     },
 
     {
       name: 'firefox',
+      testIgnore: mobileSmokeSpec,
       use: { ...devices['Desktop Firefox'] },
     },
 
     {
       name: 'webkit',
+      testIgnore: mobileSmokeSpec,
       use: { ...devices['Desktop Safari'] },
+    },
+
+    {
+      name: 'mobile-chromium',
+      testMatch: mobileSmokeSpec,
+      use: { ...devices['Pixel 7'] },
     },
   ],
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -69,6 +69,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.
 - [ ] Uploaded chat image attachments render inline after channel/server navigation and open only in the in-app preview modal on web and desktop, with no external tab/browser navigation.
 - [ ] Automated core UI smoke includes invite/join, server settings, social/friend, auth/account, release/settings, permission, and desktop-runtime regressions.
+- [ ] Automated mobile web smoke completed for the release candidate or CI run, covering Social, DM, server chat, mobile composer actions, and the mobile member sheet.
 
 ## 4) Desktop Smoke Tests (mandatory)
 
@@ -85,6 +86,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Desktop release workflow ran against the exact release tag/ref, with `smoke_checklist_confirmed=yes`.
 - [ ] Production desktop releases used `platform=all`; single-platform workflow runs are recorded as test/hotfix-only.
 - [ ] GitHub Release assets include `latest.json`, installer artifacts for the intended platforms, and matching `.sig` files for updater assets.
+- [ ] Desktop release workflow artifact validation passed for every built platform.
 - [ ] `latest.json` version matches the release tag and desktop app version.
 - [ ] `latest.json` URLs point to assets on the same GitHub Release, not a draft-only, private, or unrelated artifact URL.
 - [ ] Updater check shows a clear no-update state when no newer version is available.


### PR DESCRIPTION
## Summary

- Add a dedicated Playwright `mobile-chromium` project and mobile web smoke suite.
- Wire mobile smoke into CI and release smoke workflow options.
- Add desktop release artifact validation after Tauri builds to guard installers, updater metadata, and signature outputs.
- Update testing and release smoke documentation for the new automation gates.

## Validation

- `npm run test:e2e:mobile-smoke`
- `npm run test:e2e:ui-smoke`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Desktop artifact validator tested with Windows, macOS, and Linux fixture outputs.