### PR TITLE
chore: harden ops scripts

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -252,10 +252,22 @@ image tag.
 ./scripts/ops/db_backup.sh
 ```
 
+Dry-run backup preflight:
+
+```bash
+BACKUP_DRY_RUN=1 ./scripts/ops/db_backup.sh
+```
+
 Restore (explicit confirmation required):
 
 ```bash
 RESTORE_CONFIRM=YES ./scripts/ops/db_restore.sh backups/postgres/<backup-file>.sql.gz
+```
+
+Dry-run restore validation:
+
+```bash
+RESTORE_DRY_RUN=1 ./scripts/ops/db_restore.sh backups/postgres/<backup-file>.sql.gz
 ```
 
 Healthcheck:

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -8,6 +8,18 @@ Before first use:
 chmod +x scripts/ops/*.sh
 ```
 
+All scripts are intended to run from the repository root on the Docker Compose
+host. They auto-detect the current compose service names, but every service can
+be overridden when production uses a non-default compose layout:
+
+```bash
+POSTGRES_SERVICE=postgres
+REDIS_SERVICE=redis
+LIVEKIT_SERVICE=livekit
+SERVER_SERVICE=server
+WEB_SERVICE=web
+```
+
 ## 1) Backup Automation (PostgreSQL)
 
 Backup script:
@@ -16,10 +28,37 @@ Backup script:
 ./scripts/ops/db_backup.sh
 ```
 
+Validate backup prerequisites without writing a dump:
+
+```bash
+BACKUP_DRY_RUN=1 ./scripts/ops/db_backup.sh
+```
+
+Backups are written with owner/privilege metadata stripped, include `DROP IF
+EXISTS` statements for repeatable restore drills, are compressed atomically, and
+use restrictive file permissions by default. Optional knobs:
+
+- `BACKUP_DIR=/secure/path`
+- `BACKUP_LABEL=pre_release`
+- `POSTGRES_SERVICE=postgres`
+
 Restore script:
 
 ```bash
 RESTORE_CONFIRM=YES ./scripts/ops/db_restore.sh backups/postgres/<file>.sql.gz
+```
+
+Validate a backup file and database connectivity without applying it:
+
+```bash
+RESTORE_DRY_RUN=1 ./scripts/ops/db_restore.sh backups/postgres/<file>.sql.gz
+```
+
+Restores create a fresh pre-restore backup by default before applying SQL. Skip
+that only when an external backup has already been captured:
+
+```bash
+RESTORE_CONFIRM=YES RESTORE_SKIP_PRE_BACKUP=YES ./scripts/ops/db_restore.sh backups/postgres/<file>.sql.gz
 ```
 
 Recommended cron (daily backup at 02:15 UTC):
@@ -56,12 +95,13 @@ This script verifies:
 - PostgreSQL responds through `pg_isready` inside the database container
 - Redis responds through `redis-cli ping` inside the Redis container
 - Attachment storage exists and is writable inside the server container
-- Web endpoint responds
+- Web `/healthz` endpoint responds
 
 Manual health check:
 
 ```bash
 curl -fsS http://127.0.0.1:3001/health
+curl -fsS http://127.0.0.1:${WEB_PORT:-5173}/healthz
 ```
 
 Expected shape:
@@ -81,6 +121,15 @@ Recommended alert cron (every 5 minutes):
 ```
 
 Connect this failure path to your alerting channel (PagerDuty, Opsgenie, Slack webhook, etc.).
+
+`critical_log_scan.sh` redacts emails, tokens, secrets, and bearer values before
+printing matching log lines. Authentication-abuse noise such as CAPTCHA failures
+is not considered stack-critical by default; include it only when investigating
+abuse:
+
+```bash
+LOG_SCAN_INCLUDE_AUTH_ABUSE=1 ./scripts/ops/critical_log_scan.sh
+```
 
 ## 4) Auth Abuse Hardening Knobs
 
@@ -136,8 +185,8 @@ docker compose logs --since 15m server | grep -Ei 'panic|panicked|Failed to run 
 Database and Redis connectivity:
 
 ```bash
-docker exec voxpery-db pg_isready -U "${POSTGRES_USER:-voxpery}" -d "${POSTGRES_DB:-voxpery}"
-docker exec voxpery-redis redis-cli ping
+docker compose exec -T postgres pg_isready -U "${POSTGRES_USER:-voxpery}" -d "${POSTGRES_DB:-voxpery}"
+docker compose exec -T redis redis-cli ping
 curl -fsS http://127.0.0.1:3001/health
 ```
 

--- a/scripts/ops/critical_log_scan.sh
+++ b/scripts/ops/critical_log_scan.sh
@@ -2,19 +2,25 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-cd "$ROOT_DIR"
+source "$SCRIPT_DIR/lib.sh"
+cd_ops_root
+require_ops_runtime
 
 WINDOW="${LOG_SCAN_WINDOW:-10m}"
+SERVER_SERVICE="$(resolve_service SERVER_SERVICE server)"
+LIVEKIT_SERVICE="$(resolve_service LIVEKIT_SERVICE livekit)"
 
-server_logs="$(docker compose logs --since "$WINDOW" server 2>/dev/null || true)"
-livekit_logs="$(docker compose logs --since "$WINDOW" livekit 2>/dev/null || true)"
+server_logs="$(compose logs --since "$WINDOW" "$SERVER_SERVICE" 2>/dev/null || true)"
+livekit_logs="$(compose logs --since "$WINDOW" "$LIVEKIT_SERVICE" 2>/dev/null || true)"
 
-critical_pattern='(ERROR|panic|panicked|Failed to run migrations|VersionMismatch|ParseIntError|must be a number|database.*disconnected|Failed to connect to database|Failed to connect to Redis|Redis connection failed|Redis JWT blacklist check failed|Attachment service initialization failed|Failed to create attachment directory|Failed to read attachment|Failed to write attachment|WebSocket.*failed|Broadcast receiver lagged|LiveKit.*failed|Failed to sign LiveKit token|oauth.*failed|turnstile.*failed)'
+critical_pattern='(ERROR|panic|panicked|Failed to run migrations|VersionMismatch|ParseIntError|must be a number|database.*disconnected|Failed to connect to database|Failed to connect to Redis|Redis connection failed|Redis JWT blacklist check failed|Attachment service initialization failed|Failed to create attachment directory|Failed to read attachment|Failed to write attachment|WebSocket.*failed|Broadcast receiver lagged|LiveKit.*failed|Failed to sign LiveKit token|oauth.*failed)'
+if [[ "${LOG_SCAN_INCLUDE_AUTH_ABUSE:-}" == "1" ]]; then
+  critical_pattern="${critical_pattern}|(turnstile.*failed|rate limit|too many.*requests)"
+fi
 
 if grep -Eiq "$critical_pattern" <<<"$server_logs"$'\n'"$livekit_logs"; then
   echo "Critical log pattern detected in last $WINDOW"
-  grep -Ein "$critical_pattern" <<<"$server_logs"$'\n'"$livekit_logs" | tail -50
+  grep -Ein "$critical_pattern" <<<"$server_logs"$'\n'"$livekit_logs" | tail -50 | redact_logs
   exit 1
 fi
 

--- a/scripts/ops/db_backup.sh
+++ b/scripts/ops/db_backup.sh
@@ -2,17 +2,49 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-cd "$ROOT_DIR"
+source "$SCRIPT_DIR/lib.sh"
+cd_ops_root
+require_ops_runtime
 
-BACKUP_DIR="${BACKUP_DIR:-$ROOT_DIR/backups/postgres}"
+umask 077
+
+BACKUP_DIR="${BACKUP_DIR:-$ops_root_dir/backups/postgres}"
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 DB_NAME="${POSTGRES_DB:-voxpery}"
 DB_USER="${POSTGRES_USER:-voxpery}"
-OUT_FILE="$BACKUP_DIR/${DB_NAME}_${TIMESTAMP}.sql.gz"
+BACKUP_LABEL="${BACKUP_LABEL:-}"
+SAFE_LABEL=""
+if [[ -n "$BACKUP_LABEL" ]]; then
+  SAFE_LABEL="_$(tr -cd '[:alnum:]_.-' <<<"$BACKUP_LABEL" | cut -c1-48)"
+fi
+OUT_FILE="$BACKUP_DIR/${DB_NAME}_${TIMESTAMP}${SAFE_LABEL}.sql.gz"
+TMP_FILE="$OUT_FILE.tmp"
+POSTGRES_SERVICE="$(resolve_service POSTGRES_SERVICE postgres db)"
+
+cleanup() {
+  rm -f "$TMP_FILE"
+}
+trap cleanup EXIT
 
 mkdir -p "$BACKUP_DIR"
 
-docker compose exec -T postgres pg_dump -U "$DB_USER" "$DB_NAME" | gzip -9 > "$OUT_FILE"
+require_running_service "$POSTGRES_SERVICE"
+compose_exec "$POSTGRES_SERVICE" pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null
+
+if [[ "${BACKUP_DRY_RUN:-}" == "1" ]]; then
+  info "Dry run passed. Backup would be written to: $OUT_FILE"
+  exit 0
+fi
+
+compose_exec "$POSTGRES_SERVICE" pg_dump \
+  --format=plain \
+  --clean \
+  --if-exists \
+  --no-owner \
+  --no-privileges \
+  -U "$DB_USER" "$DB_NAME" | gzip -9 > "$TMP_FILE"
+
+gzip -t "$TMP_FILE"
+mv "$TMP_FILE" "$OUT_FILE"
 
 echo "Backup created: $OUT_FILE"

--- a/scripts/ops/db_restore.sh
+++ b/scripts/ops/db_restore.sh
@@ -7,28 +7,47 @@ if [[ $# -lt 1 ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-cd "$ROOT_DIR"
+source "$SCRIPT_DIR/lib.sh"
+cd_ops_root
+require_ops_runtime
 
 INPUT_FILE="$1"
 if [[ ! -f "$INPUT_FILE" ]]; then
-  echo "Backup file not found: $INPUT_FILE"
-  exit 1
+  die "Backup file not found: $INPUT_FILE"
 fi
 
 DB_NAME="${POSTGRES_DB:-voxpery}"
 DB_USER="${POSTGRES_USER:-voxpery}"
+POSTGRES_SERVICE="$(resolve_service POSTGRES_SERVICE postgres db)"
+
+require_running_service "$POSTGRES_SERVICE"
+compose_exec "$POSTGRES_SERVICE" pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null
+
+if [[ "$INPUT_FILE" == *.gz ]]; then
+  gzip -t "$INPUT_FILE"
+fi
+
+if [[ "${RESTORE_DRY_RUN:-}" == "1" ]]; then
+  info "Dry run passed. Restore source is readable and database is reachable: $INPUT_FILE -> $DB_NAME"
+  exit 0
+fi
 
 if [[ "${RESTORE_CONFIRM:-}" != "YES" ]]; then
   echo "Refusing restore without explicit confirmation."
   echo "Run with: RESTORE_CONFIRM=YES $0 $INPUT_FILE"
+  echo "Optional validation only: RESTORE_DRY_RUN=1 $0 $INPUT_FILE"
   exit 1
 fi
 
+if [[ "${RESTORE_SKIP_PRE_BACKUP:-}" != "YES" ]]; then
+  info "Creating a pre-restore backup. Set RESTORE_SKIP_PRE_BACKUP=YES only if an external backup already exists."
+  BACKUP_LABEL="pre_restore" "$SCRIPT_DIR/db_backup.sh"
+fi
+
 if [[ "$INPUT_FILE" == *.gz ]]; then
-  gzip -dc "$INPUT_FILE" | docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME"
+  gzip -dc "$INPUT_FILE" | compose_exec "$POSTGRES_SERVICE" psql -v ON_ERROR_STOP=1 -U "$DB_USER" -d "$DB_NAME"
 else
-  cat "$INPUT_FILE" | docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME"
+  compose_exec "$POSTGRES_SERVICE" psql -v ON_ERROR_STOP=1 -U "$DB_USER" -d "$DB_NAME" < "$INPUT_FILE"
 fi
 
 echo "Restore completed: $INPUT_FILE -> $DB_NAME"

--- a/scripts/ops/lib.sh
+++ b/scripts/ops/lib.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+ops_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ops_root_dir="$(cd "$ops_script_dir/../.." && pwd)"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "==> $*"
+}
+
+cd_ops_root() {
+  cd "$ops_root_dir"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+compose() {
+  docker compose "$@"
+}
+
+compose_exec() {
+  local service="$1"
+  shift
+  compose exec -T "$service" "$@"
+}
+
+service_exists() {
+  local service="$1"
+  compose config --services 2>/dev/null | grep -qx "$service"
+}
+
+resolve_service() {
+  local env_name="$1"
+  shift
+  local configured="${!env_name:-}"
+
+  if [[ -n "$configured" ]]; then
+    service_exists "$configured" || die "$env_name is set to '$configured', but that compose service does not exist"
+    echo "$configured"
+    return
+  fi
+
+  local candidate
+  for candidate in "$@"; do
+    if service_exists "$candidate"; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  die "Could not resolve compose service for $env_name. Tried: $*"
+}
+
+require_running_service() {
+  local service="$1"
+  if ! compose ps --services --filter "status=running" | grep -qx "$service"; then
+    die "Service not running: $service"
+  fi
+}
+
+redact_logs() {
+  sed -E \
+    -e 's/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/[redacted-email]/g' \
+    -e 's/(password|passwd|pwd|secret|token|jwt|authorization|api[_-]?key)([=: ]+)[^[:space:]"'"'"']+/\1\2[redacted]/Ig' \
+    -e 's/(Bearer )[A-Za-z0-9._~+\/=-]+/\1[redacted]/g'
+}
+
+require_ops_runtime() {
+  require_command docker
+  compose version >/dev/null 2>&1 || die "Docker Compose is not available"
+}

--- a/scripts/ops/stack_healthcheck.sh
+++ b/scripts/ops/stack_healthcheck.sh
@@ -2,41 +2,43 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-cd "$ROOT_DIR"
+source "$SCRIPT_DIR/lib.sh"
+cd_ops_root
+require_ops_runtime
+require_command curl
 
 API_URL="${API_HEALTH_URL:-http://127.0.0.1:3001/health}"
-WEB_URL="${WEB_HEALTH_URL:-http://127.0.0.1:${WEB_PORT:-5173}}"
+WEB_URL="${WEB_HEALTH_URL:-http://127.0.0.1:${WEB_PORT:-5173}/healthz}"
+TIMEOUT_SECS="${HEALTHCHECK_TIMEOUT_SECS:-5}"
 
-services=(postgres redis livekit server web)
+POSTGRES_SERVICE="$(resolve_service POSTGRES_SERVICE postgres db)"
+REDIS_SERVICE="$(resolve_service REDIS_SERVICE redis)"
+LIVEKIT_SERVICE="$(resolve_service LIVEKIT_SERVICE livekit)"
+SERVER_SERVICE="$(resolve_service SERVER_SERVICE server)"
+WEB_SERVICE="$(resolve_service WEB_SERVICE web)"
+
+services=("$POSTGRES_SERVICE" "$REDIS_SERVICE" "$LIVEKIT_SERVICE" "$SERVER_SERVICE" "$WEB_SERVICE")
 for svc in "${services[@]}"; do
-  if ! docker compose ps --services --filter "status=running" | grep -qx "$svc"; then
-    echo "Service not running: $svc"
-    exit 1
-  fi
+  require_running_service "$svc"
 done
 
-api_body="$(curl -fsS "$API_URL")"
-if ! grep -q '"status":"ok"' <<<"$api_body"; then
-  echo "API health is not ok: $api_body"
-  exit 1
+api_body="$(curl -fsS --max-time "$TIMEOUT_SECS" "$API_URL")"
+if ! grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"' <<<"$api_body"; then
+  die "API health is not ok: $api_body"
 fi
 
-if ! docker exec voxpery-db sh -lc 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null; then
-  echo "PostgreSQL readiness check failed"
-  exit 1
+if ! compose_exec "$POSTGRES_SERVICE" sh -lc 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null; then
+  die "PostgreSQL readiness check failed"
 fi
 
-if ! docker exec voxpery-redis redis-cli ping | grep -qx "PONG"; then
-  echo "Redis readiness check failed"
-  exit 1
+if ! compose_exec "$REDIS_SERVICE" redis-cli ping | grep -qx "PONG"; then
+  die "Redis readiness check failed"
 fi
 
-if ! docker exec voxpery-server sh -lc 'test -d "${ATTACHMENTS_LOCAL_DIR:-/home/voxpery/attachments}" && test -w "${ATTACHMENTS_LOCAL_DIR:-/home/voxpery/attachments}"'; then
-  echo "Attachment storage directory is missing or not writable"
-  exit 1
+if ! compose_exec "$SERVER_SERVICE" sh -lc 'test -d "${ATTACHMENTS_LOCAL_DIR:-/home/voxpery/attachments}" && test -w "${ATTACHMENTS_LOCAL_DIR:-/home/voxpery/attachments}"'; then
+  die "Attachment storage directory is missing or not writable"
 fi
 
-curl -fsSI "$WEB_URL" >/dev/null
+curl -fsS --max-time "$TIMEOUT_SECS" "$WEB_URL" >/dev/null
 
 echo "Stack healthcheck passed"


### PR DESCRIPTION
## Summary

- Harden `scripts/ops` with shared runtime helpers, compose service auto-detection, and safer defaults.
- Make backups atomic, compressed, permission-restricted, dry-run capable, and restore-drill friendly.
- Add restore dry-run, gzip validation, `psql ON_ERROR_STOP`, and automatic pre-restore backup.
- Improve stack health checks to use compose services and the web `/healthz` endpoint.
- Redact sensitive log values in critical log scans and make auth-abuse noise opt-in.
- Update operations and deployment docs with the new knobs and workflows.

## Validation

- `bash -n scripts/ops/lib.sh scripts/ops/db_backup.sh scripts/ops/db_restore.sh scripts/ops/stack_healthcheck.sh scripts/ops/critical_log_scan.sh`
- `git diff --cached --check`
- `graphify update .`
