### PR TITLE
chore: sync release version metadata

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5337,7 +5337,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3141,7 +3141,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.2",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-13
+
+### Changed
+- Bumped web, server, and desktop package metadata to `0.2.2`.
+- Documented the release-bump checklist so future public releases keep package metadata, changelog entries, desktop updater metadata, and visible app version tags in sync.
+
+## [0.2.1] - 2026-06-07
+
+### Added
+- Added and expanded voice quality benchmark diagnostics for controlled release validation.
+- Added core UI regression coverage for auth, permissions, social/friend flows, server settings, release/settings, invite, and desktop smoke paths.
+
+### Changed
+- Required Node.js 24 across the web and CI toolchain.
+- Improved manual deploy workflows so main candidates build immutable commit-tagged Docker images before deployment.
+- Tuned balanced voice processing for a more natural default speech profile.
+- Split composer media actions and aligned direct-message sidebar styling with the server-channel selection model.
+
+### Fixed
+- Fixed email verification delivery, duplicate confirmation handling, and consumed-token verified-state rendering.
+- Fixed SMTP delivery reliability by preferring IPv4 and resolving SMTP hosts before sending.
+- Fixed chat scroll anchoring, media placeholder stability, and compact version badge rendering.
+- Persisted hidden direct-message sidebar state and made the social loading path cache-aware/event-driven.
+- Hid voice diagnostics unless explicitly enabled for benchmark/debug work.
+
+### Security
+- Updated dependency security paths for web and desktop, including esbuild and Tauri desktop transitive dependencies.
+- Removed hardcoded crypto-like test fixtures that CodeQL reported.
+
 ## [0.2.0] - 2026-06-01
 
 ### Added

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -68,16 +68,17 @@ Voxpery follows Semantic Versioning:
 
 1. Prepare the candidate from updated `main` and keep the final release commit SHA recorded.
 2. Update docs for behavior changes and update the changelog entry before creating the tag.
-3. Ensure required PR gates are green on the release branch and no security monitoring gate is ignored without a recorded decision.
-4. Run the manual `Release / Smoke` workflow against the release candidate API and record the workflow run URL in [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md).
-5. Complete and sign off [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md) (required).
-6. Validate [DESKTOP_RELEASE_HARDENING.md](DESKTOP_RELEASE_HARDENING.md) if desktop artifacts are part of the release.
-7. Validate critical paths: auth, messaging+websocket, voice join/leave.
-8. Create and push the Git tag (for example `v0.1.5`) from the exact signed-off commit.
-9. Confirm tag-triggered release jobs, Docker publish jobs, and desktop artifact jobs ran against that exact tag/ref.
-10. Record the exact Docker image tag selected for production deploy and verify the manual deploy workflow used that tag.
-11. Verify release assets and updater metadata before publishing or announcing the release.
-12. Publish GitHub Release notes only after artifacts, signatures, and smoke sign-off are complete.
+3. Keep all version-bearing artifacts in sync in the same change: web `package.json` and `package-lock.json`, server `Cargo.toml` and `Cargo.lock` when present, desktop `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, release/checklist docs that name the version, Docker image tags, the web top-bar version badge, desktop app version, and updater metadata.
+4. Ensure required PR gates are green on the release branch and no security monitoring gate is ignored without a recorded decision.
+5. Run the manual `Release / Smoke` workflow against the release candidate API and record the workflow run URL in [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md).
+6. Complete and sign off [RELEASE_SMOKE_TEST_CHECKLIST.md](RELEASE_SMOKE_TEST_CHECKLIST.md) (required).
+7. Validate [DESKTOP_RELEASE_HARDENING.md](DESKTOP_RELEASE_HARDENING.md) if desktop artifacts are part of the release.
+8. Validate critical paths: auth, messaging+websocket, voice join/leave.
+9. Create and push the Git tag (for example `v0.1.5`) from the exact signed-off commit.
+10. Confirm tag-triggered release jobs, Docker publish jobs, and desktop artifact jobs ran against that exact tag/ref.
+11. Record the exact Docker image tag selected for production deploy and verify the manual deploy workflow used that tag.
+12. Verify release assets and updater metadata before publishing or announcing the release.
+13. Publish GitHub Release notes only after artifacts, signatures, and smoke sign-off are complete.
 
 ### Release Workflow Rules
 


### PR DESCRIPTION
## Summary
- Bump Voxpery web, server, and desktop package metadata to `0.2.2`
- Add missing `0.2.1` changelog notes and the new `0.2.2` changelog entry
- Document release version-sync requirements in the project release checklist

## Validation
- `cargo test --locked`
- `cargo check --locked` in `apps/desktop/src-tauri`
- `npm run lint`
- `npm run test:run`
- `npm run build`