### PR TITLE
ci: add v0.2.2 release guardrails

### DIFF
--- a/.github/scripts/check-release-version-sync.mjs
+++ b/.github/scripts/check-release-version-sync.mjs
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs'
+
+function fail(message) {
+  console.error(`[release-version-sync] ${message}`)
+  process.exitCode = 1
+}
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function normalizeVersion(rawVersion) {
+  const version = rawVersion?.trim().replace(/^v/, '')
+  if (!version || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid semantic version: ${rawVersion || '<empty>'}`)
+  }
+  return version
+}
+
+function packageVersion(path) {
+  return JSON.parse(read(path)).version
+}
+
+function cargoPackageVersion(path) {
+  const match = read(path).match(/\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m)
+  if (!match) throw new Error(`Could not read package version from ${path}`)
+  return match[1]
+}
+
+function lockPackageVersion(path, packageName) {
+  const lock = read(path)
+  const packageNameLine = `name = "${packageName}"`
+  const packageIndex = lock.indexOf(packageNameLine)
+  if (packageIndex === -1) throw new Error(`Could not find ${packageName} in ${path}`)
+
+  const packageStart = lock.lastIndexOf('[[package]]', packageIndex)
+  const nextPackageStart = lock.indexOf('[[package]]', packageIndex + packageNameLine.length)
+  const packageEnd = nextPackageStart === -1 ? lock.length : nextPackageStart
+  const packageBlock = lock.slice(packageStart, packageEnd)
+  const versionMatch = packageBlock.match(/^version\s*=\s*"([^"]+)"/m)
+  if (!versionMatch) throw new Error(`Could not read ${packageName} version from ${path}`)
+  return versionMatch[1]
+}
+
+function expectVersion(label, actual, expected) {
+  if (actual !== expected) {
+    fail(`${label} is ${actual}, expected ${expected}`)
+  } else {
+    console.log(`[release-version-sync] ${label}: ${actual}`)
+  }
+}
+
+const expected = normalizeVersion(
+  process.env.EXPECTED_RELEASE_VERSION || packageVersion('apps/web/package.json')
+)
+
+expectVersion('web package.json', packageVersion('apps/web/package.json'), expected)
+expectVersion('web package-lock root', packageVersion('apps/web/package-lock.json'), expected)
+expectVersion(
+  'web package-lock package',
+  JSON.parse(read('apps/web/package-lock.json')).packages?.['']?.version,
+  expected
+)
+expectVersion('server Cargo.toml', cargoPackageVersion('apps/server/Cargo.toml'), expected)
+expectVersion(
+  'server Cargo.lock',
+  lockPackageVersion('apps/server/Cargo.lock', 'voxpery-server'),
+  expected
+)
+expectVersion('desktop Cargo.toml', cargoPackageVersion('apps/desktop/src-tauri/Cargo.toml'), expected)
+expectVersion(
+  'desktop Cargo.lock',
+  lockPackageVersion('apps/desktop/src-tauri/Cargo.lock', 'voxpery-desktop'),
+  expected
+)
+expectVersion(
+  'desktop tauri.conf.json',
+  JSON.parse(read('apps/desktop/src-tauri/tauri.conf.json')).version,
+  expected
+)
+
+const changelog = read('docs/CHANGELOG.md')
+if (!changelog.includes(`## [${expected}]`)) {
+  fail(`docs/CHANGELOG.md does not contain a ${expected} release entry`)
+} else {
+  console.log(`[release-version-sync] changelog entry: ${expected}`)
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode)
+}
+
+console.log(`[release-version-sync] OK: ${expected}`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,26 @@ jobs:
             ghcr.io/gitleaks/gitleaks:v8.24.3 \
             git --redact --verbose --exit-code 1
 
+  release_metadata:
+    name: Release / Metadata
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Check release version sync
+        run: node .github/scripts/check-release-version-sync.mjs
+
   backend:
     name: Checks / Backend
     runs-on: ubuntu-latest
@@ -120,6 +140,7 @@ jobs:
     name: ${{ matrix.component == 'backend' && 'Publish / Docker Backend' || 'Publish / Docker Frontend' }}
     needs:
       - security
+      - release_metadata
       - backend
       - frontend
     if: >-

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -7,6 +7,18 @@ on:
         description: Release candidate API base URL, for example https://api.example.com
         required: true
         type: string
+      web_url:
+        description: Release candidate web base URL, for example https://voxpery.com
+        required: true
+        type: string
+      expected_version:
+        description: Expected semantic release version, for example 0.2.2 or v0.2.2
+        required: false
+        type: string
+      expected_image_tag:
+        description: Expected immutable Docker image tag, for example v0.2.2 or sha-abc123def456
+        required: false
+        type: string
       require_security_headers:
         description: Fail API smoke when production security headers are missing or invalid
         required: true
@@ -63,6 +75,15 @@ jobs:
           SMOKE_API_URL: ${{ inputs.api_url }}
           SMOKE_REQUIRE_SECURITY_HEADERS: ${{ inputs.require_security_headers == 'yes' && '1' || '0' }}
         run: npm run smoke:e2e
+
+      - name: Run release deploy guardrails
+        working-directory: apps/web
+        env:
+          SMOKE_API_URL: ${{ inputs.api_url }}
+          SMOKE_WEB_URL: ${{ inputs.web_url }}
+          SMOKE_EXPECTED_VERSION: ${{ inputs.expected_version }}
+          SMOKE_EXPECTED_IMAGE_TAG: ${{ inputs.expected_image_tag }}
+        run: npm run smoke:release-deploy
 
   web-e2e:
     name: Release / Web E2E (${{ inputs.web_e2e_mode }})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "smoke:e2e": "node scripts/smoke-e2e.mjs",
+    "smoke:release-deploy": "node scripts/release-deploy-smoke.mjs",
     "chaos:reconnect": "node scripts/chaos-reconnect.mjs",
     "regression:multi-user": "node scripts/regression-multi-user.mjs",
     "load:realtime": "node scripts/realtime-load-smoke.mjs",

--- a/apps/web/scripts/release-deploy-smoke.mjs
+++ b/apps/web/scripts/release-deploy-smoke.mjs
@@ -1,0 +1,111 @@
+const API_BASE = requiredUrl('SMOKE_API_URL')
+const WEB_BASE = requiredUrl('SMOKE_WEB_URL')
+const RAW_EXPECTED_VERSION = process.env.SMOKE_EXPECTED_VERSION?.trim()
+const EXPECTED_VERSION = RAW_EXPECTED_VERSION
+  ? normalizeVersion(RAW_EXPECTED_VERSION)
+  : normalizeVersion(process.env.npm_package_version)
+const EXPECTED_IMAGE_TAG = (process.env.SMOKE_EXPECTED_IMAGE_TAG || `v${EXPECTED_VERSION}`).trim()
+const EXPECTED_BADGE = formatAppVersionBadge(EXPECTED_IMAGE_TAG)
+
+function requiredUrl(name) {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value.replace(/\/+$/, '')
+}
+
+function normalizeVersion(rawVersion) {
+  const version = rawVersion?.trim().replace(/^v/, '')
+  if (!version || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid release version: ${rawVersion || '<empty>'}`)
+  }
+  return version
+}
+
+function formatAppVersionBadge(rawVersion) {
+  const version = rawVersion?.trim()
+  if (!version) return null
+  if (/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) return `v${version}`
+  const shortSha = version.match(/^sha-([0-9a-f]{7})[0-9a-f]+$/i)
+  if (shortSha?.[1]) return `sha-${shortSha[1]}`
+  return version
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function validateImmutableImageTag(tag) {
+  assert(tag, 'Expected image tag is required')
+  assert(tag !== 'latest', 'Expected image tag must not be latest')
+  assert(/^[A-Za-z0-9_.-]+$/.test(tag), `Expected image tag contains unsupported characters: ${tag}`)
+  assert(
+    /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(tag) || /^sha-[0-9a-f]{7,40}$/i.test(tag),
+    `Expected image tag must be a release tag or sha tag: ${tag}`
+  )
+}
+
+async function getOk(url, label) {
+  const res = await fetch(url, { redirect: 'manual' })
+  assert(res.ok, `${label} failed (${res.status}) at ${url}`)
+  return res
+}
+
+function assetUrls(html, webBase) {
+  const urls = new Set()
+  const pattern = /<(?:script|link)\b[^>]+(?:src|href)="([^"]+)"/g
+  for (const match of html.matchAll(pattern)) {
+    const raw = match[1]
+    if (!/\.(?:js|css)(?:\?|$)/.test(raw)) continue
+    urls.add(new URL(raw, `${webBase}/`).toString())
+  }
+  return [...urls]
+}
+
+async function checkVersionInDeployedAssets() {
+  const rootRes = await getOk(`${WEB_BASE}/`, 'web root')
+  const html = await rootRes.text()
+  const assets = assetUrls(html, WEB_BASE)
+  assert(assets.length > 0, 'No JS/CSS assets found in deployed web root')
+
+  const needles = [EXPECTED_BADGE, EXPECTED_IMAGE_TAG].filter(Boolean)
+  const seen = new Set()
+
+  for (const asset of assets) {
+    const res = await getOk(asset, `asset ${asset}`)
+    const text = await res.text()
+    for (const needle of needles) {
+      if (text.includes(needle)) seen.add(needle)
+    }
+  }
+
+  for (const needle of needles) {
+    assert(seen.has(needle), `Expected deployed web assets to contain ${needle}`)
+  }
+}
+
+async function main() {
+  console.log(`[release-smoke] API: ${API_BASE}`)
+  console.log(`[release-smoke] Web: ${WEB_BASE}`)
+  console.log(`[release-smoke] Expected version badge: ${EXPECTED_BADGE}`)
+  console.log(`[release-smoke] Expected image tag: ${EXPECTED_IMAGE_TAG}`)
+
+  validateImmutableImageTag(EXPECTED_IMAGE_TAG)
+
+  const apiHealth = await getOk(`${API_BASE}/health`, 'API health')
+  const apiHealthJson = await apiHealth.json().catch(() => null)
+  assert(apiHealthJson?.status === 'ok', 'API health response must be {"status":"ok"}')
+  console.log('[release-smoke] API health OK')
+
+  await getOk(`${WEB_BASE}/healthz`, 'web health')
+  console.log('[release-smoke] web health OK')
+
+  await checkVersionInDeployedAssets()
+  console.log('[release-smoke] deployed version assets OK')
+  console.log('[release-smoke] deploy guardrails OK')
+}
+
+main().catch((err) => {
+  console.error('[release-smoke] FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped web, server, and desktop package metadata to `0.2.2`.
+- Added tag-publish metadata guardrails plus release-smoke checks for public health, immutable deploy tags, and deployed web version tags.
 - Documented the release-bump checklist so future public releases keep package metadata, changelog entries, desktop updater metadata, and visible app version tags in sync.
 
 ## [0.2.1] - 2026-06-07

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -61,7 +61,7 @@ Voxpery follows Semantic Versioning:
 
 - **Required PR gates**: `Checks / Secret Scan`, `Checks / Backend`, and `Checks / Frontend`. Keep these fast and deterministic so branch protection can require them on every PR.
 - **Security monitoring gates**: CodeQL and dependency security audit workflows run on PRs, schedules, or manually. Review their output before release; an upstream-blocked advisory needs an explicit release decision rather than being silently ignored.
-- **Release smoke gates**: run the manual `Release / Smoke` workflow against the release candidate API before tagging or publishing. Use strict security headers for production candidates and enable browser E2E only when the candidate environment is ready for it.
+- **Release smoke gates**: release metadata sync runs automatically before Docker publishing on `v*` tag builds. The manual `Release / Smoke` workflow can be run against release candidate API and web URLs for post-deploy confidence; it verifies public health endpoints, immutable image-tag format, and the deployed web version tag.
 - **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish runs automatically for `v*` tag pushes; the manual deploy workflow builds and publishes immutable `sha-<commit>` images before deploying a `main-candidate`. Docker publish jobs must produce immutable `sha-<commit>` tags for manually deployed main-candidate builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
 
 ### Release Checklist

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -11,6 +11,8 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - Git ref / tag:
 - Deploy channel:
 - Docker image tag:
+- Web URL:
+- API URL:
 - Release type: `web-only` / `desktop` / `voice` / `security` / `hotfix`
 - Tester:
 - Date (UTC):
@@ -31,12 +33,15 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Web container health responds through the host mapping (`curl -f http://localhost:${WEB_PORT:-5173}/healthz`) while the container uses unprivileged nginx on internal port `8080`.
 - [ ] Remote avatar/server icon/inline media proxy rejects localhost/private targets and still loads normal public HTTPS images.
 - [ ] Manual `Release / Smoke` workflow completed successfully against the release candidate API.
+- [ ] Manual `Release / Smoke` workflow completed successfully against the release candidate web URL.
 - [ ] Manual `Release / Smoke` workflow run URL is recorded in Release Candidate Info.
+- [ ] Tag-triggered `Release / Metadata` check passed for web, server, desktop, and changelog version-bearing files before Docker publishing.
 - [ ] `Release / Smoke` ran with strict security headers enabled for production candidates.
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
 - [ ] Manual deploy workflow resolved the expected deploy channel and exact Docker image tag recorded in Release Candidate Info.
+- [ ] Release deploy guardrails verified API `/health`, web `/healthz`, immutable image tag format, and the deployed web bundle version tag.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
 ## 3) Web Smoke Tests (mandatory)


### PR DESCRIPTION
## Summary

- Add tag-triggered release metadata guardrails before Docker publishing
- Add optional release deploy smoke checks for API/web health, immutable deploy tags, and deployed web version tags
- Update release checklist, project operations, and changelog for the v0.2.2 release flow

## Validation

- `node .github/scripts/check-release-version-sync.mjs`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run smoke:release-deploy` against local mock API/web servers
- `git diff --check`