### PR TITLE
fix: reduce background media bandwidth

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -106,6 +106,7 @@ function renderActiveCallBar(overrides?: Record<string, unknown>) {
     startCamera: vi.fn(),
     stopCamera: vi.fn(),
     setVoiceControls: vi.fn(),
+    setRemoteMediaSubscribed: vi.fn(),
     playVoiceCue: vi.fn(),
   }
 
@@ -155,18 +156,20 @@ describe('ActiveCallBar regressions', () => {
     const screenTrack = mediaTrack('video', 'screen-track')
     const remoteStream = new MediaStream([screenTrack])
 
-    renderActiveCallBar({
+    const { voice } = renderActiveCallBar({
       remoteStreams: new Map([['peer-1', remoteStream]]),
       remoteScreenTrackIds: new Set(['screen-track']),
     })
 
     fireEvent.click(screen.getByTitle('Stop watching screen'))
 
+    expect(voice.setRemoteMediaSubscribed).toHaveBeenCalledWith('peer-1', 'screen', false)
     expect(screen.getByText('Screen share hidden')).not.toBeNull()
     expect(screen.getAllByText('admin')).toHaveLength(2)
 
     fireEvent.click(screen.getByRole('button', { name: /show/i }))
 
+    expect(voice.setRemoteMediaSubscribed).toHaveBeenLastCalledWith('peer-1', 'screen', true)
     expect(screen.getByTitle('Stop watching screen')).not.toBeNull()
     expect(screen.queryByText('Screen share hidden')).toBeNull()
   })

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -54,15 +54,26 @@ function readScreenShareQuality(): ScreenShareQuality {
 }
 
 function screenShareQualitySummary(mode: ScreenShareQuality) {
-  if (mode === 'presentation') return '1080p30 · 5 Mbps · detail'
-  if (mode === 'video') return '1080p60 · 7 Mbps · motion'
-  if (mode === 'gaming') return '1080p60 · 9 Mbps · high motion'
-  return 'Auto picks 30/60fps by share source.'
+  if (mode === 'presentation') return '1080p30 · 4 Mbps · detail'
+  if (mode === 'video') return '1080p60 · 6 Mbps · motion'
+  if (mode === 'gaming') return '1080p60 · 8 Mbps · high motion'
+  return 'Auto uses a balanced profile up to 1080p60 · 6 Mbps.'
 }
 
 export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId }: ActiveCallBarProps) {
   const navigate = useNavigate()
-  const { state, joinVoice, leaveVoice, startScreenShare, stopScreenShare, startCamera, stopCamera, setVoiceControls, playVoiceCue } = useLiveKitVoice()
+  const {
+    state,
+    joinVoice,
+    leaveVoice,
+    startScreenShare,
+    stopScreenShare,
+    startCamera,
+    stopCamera,
+    setVoiceControls,
+    setRemoteMediaSubscribed,
+    playVoiceCue,
+  } = useLiveKitVoice()
   const { user } = useAuthStore()
   const { members, voiceStates, channels, channelsByServerId, servers, setActiveServer, setActiveChannel, voiceSpeakingUserIds, voiceLocalSpeaking, voiceControls } = useAppStore(
     useShallow((s) => ({
@@ -461,13 +472,14 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const setRemoteMediaHidden = useCallback((peerId: string, kind: RemoteMediaKind, hidden: boolean) => {
     const key = getRemoteMediaKey(peerId, kind)
     if (!key) return
+    setRemoteMediaSubscribed(peerId, kind, !hidden)
     setHiddenRemoteMediaKeys((current) => {
       const next = new Set(current)
       if (hidden) next.add(key)
       else next.delete(key)
       return next
     })
-  }, [getRemoteMediaKey])
+  }, [getRemoteMediaKey, setRemoteMediaSubscribed])
 
   // Track total audio track count so we re-trigger playback when screen share audio arrives
   const remoteAudioTrackCount = useMemo(() => {

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -20,28 +20,28 @@ describe('screen share quality profiles', () => {
     expect(resolveScreenShareProfileForMode('presentation')).toEqual({
       resolution: '1080p',
       framerate: 30,
-      bitrate: 5_000_000,
+      bitrate: 4_000_000,
       contentHint: 'detail',
       degradationPreference: 'maintain-resolution',
     })
     expect(resolveScreenShareProfileForMode('video')).toEqual({
       resolution: '1080p',
       framerate: 60,
-      bitrate: 7_000_000,
+      bitrate: 6_000_000,
       contentHint: 'motion',
       degradationPreference: 'maintain-framerate',
     })
     expect(resolveScreenShareProfileForMode('gaming')).toEqual({
       resolution: '1080p',
       framerate: 60,
-      bitrate: 9_000_000,
+      bitrate: 8_000_000,
       contentHint: 'motion',
       degradationPreference: 'maintain-framerate',
     })
   })
 
   it('selects auto profile by shared surface', () => {
-    expect(resolveScreenShareProfileForMode('auto', 'monitor')).toEqual(SCREEN_SHARE_PRESET_PROFILE.gaming)
+    expect(resolveScreenShareProfileForMode('auto', 'monitor')).toEqual(SCREEN_SHARE_PRESET_PROFILE.video)
     expect(resolveScreenShareProfileForMode('auto', 'browser')).toEqual(SCREEN_SHARE_PRESET_PROFILE.video)
     expect(resolveScreenShareProfileForMode('auto', 'window')).toEqual(SCREEN_SHARE_PRESET_PROFILE.presentation)
     expect(resolveScreenShareProfileForMode('auto')).toEqual(SCREEN_SHARE_PRESET_PROFILE.presentation)

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -27,21 +27,21 @@ export const SCREEN_SHARE_PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'au
     presentation: {
         resolution: '1080p',
         framerate: 30,
-        bitrate: 5_000_000,
+        bitrate: 4_000_000,
         contentHint: 'detail',
         degradationPreference: 'maintain-resolution',
     },
     video: {
         resolution: '1080p',
         framerate: 60,
-        bitrate: 7_000_000,
+        bitrate: 6_000_000,
         contentHint: 'motion',
         degradationPreference: 'maintain-framerate',
     },
     gaming: {
         resolution: '1080p',
         framerate: 60,
-        bitrate: 9_000_000,
+        bitrate: 8_000_000,
         contentHint: 'motion',
         degradationPreference: 'maintain-framerate',
     },
@@ -60,7 +60,7 @@ export function resolveScreenShareProfileForMode(
         return SCREEN_SHARE_PRESET_PROFILE[mode]
     }
 
-    if (displaySurface === 'monitor') return SCREEN_SHARE_PRESET_PROFILE.gaming
+    if (displaySurface === 'monitor') return SCREEN_SHARE_PRESET_PROFILE.video
     if (displaySurface === 'browser') return SCREEN_SHARE_PRESET_PROFILE.video
     return SCREEN_SHARE_PRESET_PROFILE.presentation
 }

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   clearRemoteMediaStartCue,
   getMicrophonePublishOptions,
+  remoteMediaKindForSource,
   remoteMediaStartCueKey,
   resyncVoiceStateAfterReconnect,
+  shouldSubscribeRemoteTrack,
   shouldPlayRemoteMediaStartCue,
 } from './useLiveKitVoice'
 import { AudioPresets, Track } from 'livekit-client'
@@ -17,6 +19,29 @@ describe('microphone publish options', () => {
       red: true,
       forceStereo: false,
     })
+  })
+})
+
+describe('remote media subscriptions', () => {
+  it('keeps remote audio subscribed while the app is hidden', () => {
+    expect(shouldSubscribeRemoteTrack(Track.Kind.Audio, false)).toBe(true)
+  })
+
+  it('pauses remote video while hidden and restores it while visible', () => {
+    expect(shouldSubscribeRemoteTrack(Track.Kind.Video, false)).toBe(false)
+    expect(shouldSubscribeRemoteTrack(Track.Kind.Video, true)).toBe(true)
+  })
+
+  it('keeps user-hidden media unsubscribed even while the app is visible', () => {
+    expect(shouldSubscribeRemoteTrack(Track.Kind.Video, true, true)).toBe(false)
+    expect(shouldSubscribeRemoteTrack(Track.Kind.Audio, true, true)).toBe(false)
+  })
+
+  it('maps camera and screen publications to viewer controls', () => {
+    expect(remoteMediaKindForSource(Track.Source.Camera)).toBe('camera')
+    expect(remoteMediaKindForSource(Track.Source.ScreenShare)).toBe('screen')
+    expect(remoteMediaKindForSource(Track.Source.ScreenShareAudio)).toBe('screen')
+    expect(remoteMediaKindForSource(Track.Source.Microphone)).toBeNull()
   })
 })
 

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -6,6 +6,7 @@ import {
   Room,
   RoomEvent,
   Track,
+  type RemoteTrackPublication,
   type TrackPublishOptions,
 } from 'livekit-client'
 import { webrtcApi } from '../api'
@@ -24,6 +25,7 @@ import {
   shouldRebuildSuppressionPipeline,
 } from './voiceInputProfile'
 import { updateVoiceDiagnostics } from './voiceDiagnostics'
+import type { RemoteMediaKind } from './remoteMediaControls'
 
 type PeerId = string
 type RemoteMediaStartCueKind = 'camera' | 'screen'
@@ -43,6 +45,21 @@ export function getMicrophonePublishOptions(): TrackPublishOptions {
     red: true,
     forceStereo: false,
   }
+}
+
+export function shouldSubscribeRemoteTrack(
+  kind: Track.Kind,
+  appVisible: boolean,
+  userHidden = false,
+): boolean {
+  if (userHidden) return false
+  return kind === Track.Kind.Audio || appVisible
+}
+
+export function remoteMediaKindForSource(source: Track.Source): RemoteMediaKind | null {
+  if (source === Track.Source.Camera) return 'camera'
+  if (source === Track.Source.ScreenShare || source === Track.Source.ScreenShareAudio) return 'screen'
+  return null
 }
 
 interface VoiceReconnectResyncOptions {
@@ -145,6 +162,9 @@ export function useLiveKitVoice() {
   const remoteMonitorCleanupsRef = useRef<Map<PeerId, () => void>>(new Map())
   const remoteMediaStartCueKeysRef = useRef<Set<string>>(new Set())
   const remoteMediaStartCueReadyRef = useRef(false)
+  const visibilitySuppressedTrackSidsRef = useRef<Set<string>>(new Set())
+  const userHiddenRemoteMediaKeysRef = useRef<Set<string>>(new Set())
+  const resumedTrackSidsRef = useRef<Set<string>>(new Set())
   const joinedChannelIdRef = useRef<string | null>(null)
   const desiredMicMutedRef = useRef(false)
   const activeInputDeviceIdRef = useRef(getStoredVoiceInputDeviceId())
@@ -168,6 +188,73 @@ export function useLiveKitVoice() {
   const [roomState, setRoomState] = useState('disconnected')
   const [participantCount, setParticipantCount] = useState(0)
   const [lastError, setLastError] = useState<string | null>(null)
+
+  const remoteMediaSubscriptionKey = useCallback((peerId: string, kind: RemoteMediaKind) => (
+    `${peerId}:${kind}`
+  ), [])
+
+  const syncRemotePublicationSubscription = useCallback((publication: RemoteTrackPublication, peerId: string) => {
+    const appVisible = typeof document === 'undefined' || document.visibilityState !== 'hidden'
+    const mediaKind = remoteMediaKindForSource(publication.source)
+    const userHidden = mediaKind
+      ? userHiddenRemoteMediaKeysRef.current.has(remoteMediaSubscriptionKey(peerId, mediaKind))
+      : false
+    const shouldSubscribe = shouldSubscribeRemoteTrack(publication.kind, appVisible, userHidden)
+
+    if (!shouldSubscribe && !userHidden && publication.kind === Track.Kind.Video) {
+      visibilitySuppressedTrackSidsRef.current.add(publication.trackSid)
+    } else if (shouldSubscribe && visibilitySuppressedTrackSidsRef.current.delete(publication.trackSid)) {
+      resumedTrackSidsRef.current.add(publication.trackSid)
+    }
+    if (publication.isSubscribed !== shouldSubscribe) {
+      publication.setSubscribed(shouldSubscribe)
+    }
+  }, [remoteMediaSubscriptionKey])
+
+  const syncRemoteSubscriptions = useCallback((room: Room) => {
+    room.remoteParticipants.forEach((participant) => {
+      participant.trackPublications.forEach((publication) => {
+        syncRemotePublicationSubscription(publication, participant.identity)
+      })
+    })
+  }, [syncRemotePublicationSubscription])
+
+  const setRemoteMediaSubscribed = useCallback((
+    peerId: string,
+    kind: RemoteMediaKind,
+    subscribed: boolean,
+  ) => {
+    const key = remoteMediaSubscriptionKey(peerId, kind)
+    if (subscribed) userHiddenRemoteMediaKeysRef.current.delete(key)
+    else userHiddenRemoteMediaKeysRef.current.add(key)
+
+    const participant = roomRef.current?.remoteParticipants.get(peerId)
+    participant?.trackPublications.forEach((publication) => {
+      if (remoteMediaKindForSource(publication.source) !== kind) return
+
+      if (!subscribed) {
+        visibilitySuppressedTrackSidsRef.current.delete(publication.trackSid)
+        if (publication.isSubscribed) publication.setSubscribed(false)
+        return
+      }
+
+      const appVisible = typeof document === 'undefined' || document.visibilityState !== 'hidden'
+      const shouldSubscribe = shouldSubscribeRemoteTrack(publication.kind, appVisible)
+      if (shouldSubscribe && !publication.isSubscribed) {
+        resumedTrackSidsRef.current.add(publication.trackSid)
+        publication.setSubscribed(true)
+      }
+    })
+  }, [remoteMediaSubscriptionKey])
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const room = roomRef.current
+      if (room) syncRemoteSubscriptions(room)
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [syncRemoteSubscriptions])
 
   const remoteStreams = useMemo(() => {
     void remoteStreamsVersion
@@ -532,13 +619,15 @@ export function useLiveKitVoice() {
         // Ignore TURN errors in dev
       }
 
-      room.on(RoomEvent.TrackPublished, (publication) => {
-        if (!publication.isSubscribed) publication.setSubscribed(true)
+      room.on(RoomEvent.TrackPublished, (publication, participant) => {
+        syncRemotePublicationSubscription(publication, participant.identity)
       })
 
       room
         .on(RoomEvent.TrackSubscribed, (track, pub, participant) => {
           const peerId = participant.identity
+          visibilitySuppressedTrackSidsRef.current.delete(pub.trackSid)
+          const resumedAfterPause = resumedTrackSidsRef.current.delete(pub.trackSid)
 
           const combined = remoteStreamsRef.current.get(peerId) ?? new MediaStream()
           const mediaTrack = track.mediaStreamTrack
@@ -546,13 +635,13 @@ export function useLiveKitVoice() {
           if (pub.source === Track.Source.ScreenShare) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShare', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.add(mediaTrack.id)
-            playRemoteMediaStartCue(participant, 'screen')
+            if (!resumedAfterPause) playRemoteMediaStartCue(participant, 'screen')
           } else if (pub.source === Track.Source.ScreenShareAudio) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShareAudio', { value: true, writable: true, configurable: true })
           } else if (pub.source === Track.Source.Camera) {
             Object.defineProperty(mediaTrack, '__voxpery_isCamera', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.delete(mediaTrack.id)
-            playRemoteMediaStartCue(participant, 'camera')
+            if (!resumedAfterPause) playRemoteMediaStartCue(participant, 'camera')
           }
 
           mediaTrack.onmute = () => { syncParticipantMediaState(participant); bumpRemote() }
@@ -585,6 +674,12 @@ export function useLiveKitVoice() {
         })
         .on(RoomEvent.TrackUnsubscribed, (track, _pub, participant) => {
           const peerId = participant.identity
+          const mediaKind = remoteMediaKindForSource(_pub.source)
+          const pausedForVisibility = visibilitySuppressedTrackSidsRef.current.has(_pub.trackSid)
+          const pausedByUser = mediaKind
+            ? userHiddenRemoteMediaKeysRef.current.has(remoteMediaSubscriptionKey(peerId, mediaKind))
+            : false
+          const pausedIntentionally = pausedForVisibility || pausedByUser
           const stream = remoteStreamsRef.current.get(peerId)
           if (!stream) return
           const mediaTrack = track.mediaStreamTrack
@@ -593,8 +688,12 @@ export function useLiveKitVoice() {
             stream.removeTrack(existing)
             remoteScreenTrackIdsRef.current.delete(existing.id)
           }
-          if (_pub.source === Track.Source.Camera) clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'camera')
-          if (_pub.source === Track.Source.ScreenShare) clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'screen')
+          if (!pausedIntentionally && _pub.source === Track.Source.Camera) {
+            clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'camera')
+          }
+          if (!pausedIntentionally && _pub.source === Track.Source.ScreenShare) {
+            clearRemoteMediaStartCue(remoteMediaStartCueKeysRef.current, peerId, 'screen')
+          }
           if (stream.getTracks().length === 0) closePeer(peerId)
           else bumpRemote()
 
@@ -602,13 +701,19 @@ export function useLiveKitVoice() {
           updateRoomStats()
         })
         .on(RoomEvent.ParticipantDisconnected, (participant) => {
+          participant.trackPublications.forEach((publication) => {
+            visibilitySuppressedTrackSidsRef.current.delete(publication.trackSid)
+            resumedTrackSidsRef.current.delete(publication.trackSid)
+          })
+          userHiddenRemoteMediaKeysRef.current.delete(remoteMediaSubscriptionKey(participant.identity, 'camera'))
+          userHiddenRemoteMediaKeysRef.current.delete(remoteMediaSubscriptionKey(participant.identity, 'screen'))
           closePeer(participant.identity)
           updateRoomStats()
           playVoiceCue('leave')
         })
         .on(RoomEvent.ParticipantConnected, (participant) => {
           participant.trackPublications.forEach((publication) => {
-            if (!publication.isSubscribed) publication.setSubscribed(true)
+            syncRemotePublicationSubscription(publication, participant.identity)
           })
           syncParticipantMediaState(participant)
           updateRoomStats()
@@ -624,12 +729,8 @@ export function useLiveKitVoice() {
           // Re-subscribe to all existing remote participants' tracks
           const currentRoom = roomRef.current
           if (currentRoom) {
-            currentRoom.remoteParticipants.forEach((participant) => {
-              participant.trackPublications.forEach((publication) => {
-                if (!publication.isSubscribed) publication.setSubscribed(true)
-              })
-              syncParticipantMediaState(participant)
-            })
+            syncRemoteSubscriptions(currentRoom)
+            currentRoom.remoteParticipants.forEach(syncParticipantMediaState)
           }
         })
         .on(RoomEvent.Disconnected, (reason) => {
@@ -641,7 +742,10 @@ export function useLiveKitVoice() {
           // but do NOT call leaveVoice() — the WS resync effect handles re-join
         })
 
-      const connectPromise = room.connect(ws_url, lkToken, { rtcConfig: { iceServers } })
+      const connectPromise = room.connect(ws_url, lkToken, {
+        autoSubscribe: false,
+        rtcConfig: { iceServers },
+      })
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('LiveKit connection timeout after 15 seconds')), 15000)
       )
@@ -651,7 +755,7 @@ export function useLiveKitVoice() {
       room.remoteParticipants.forEach((participant) => {
         rememberExistingRemoteMedia(participant)
         participant.trackPublications.forEach((publication) => {
-          if (!publication.isSubscribed) publication.setSubscribed(true)
+          syncRemotePublicationSubscription(publication, participant.identity)
         })
         syncParticipantMediaState(participant)
       })
@@ -707,7 +811,7 @@ export function useLiveKitVoice() {
       isJoiningRef.current = false
       setIsJoining(false)
     }
-    }, [applyLocalMicSettings, buildMicSendTrack, cleanupLocalMedia, closePeer, getAudioContext, getMicrophoneStream, getScreenShareEncoding, getInputVolumeFactor, isConnected, playRemoteMediaStartCue, playVoiceCue, refreshLocalStreams, rememberExistingRemoteMedia, send, setLocalMicMuted, startLocalSpeakingMonitor, syncParticipantMediaState, token, updateRoomStats, userId, voiceMode])
+    }, [applyLocalMicSettings, buildMicSendTrack, cleanupLocalMedia, closePeer, getAudioContext, getMicrophoneStream, getScreenShareEncoding, getInputVolumeFactor, isConnected, playRemoteMediaStartCue, playVoiceCue, refreshLocalStreams, rememberExistingRemoteMedia, remoteMediaSubscriptionKey, send, setLocalMicMuted, startLocalSpeakingMonitor, syncParticipantMediaState, syncRemotePublicationSubscription, syncRemoteSubscriptions, token, updateRoomStats, userId, voiceMode])
 
     const leaveVoice = useCallback((options?: { skipLeaveSound?: boolean }) => {
     isJoiningRef.current = false
@@ -717,6 +821,9 @@ export function useLiveKitVoice() {
     joinedChannelIdRef.current = null
     remoteMediaStartCueReadyRef.current = false
     remoteMediaStartCueKeysRef.current.clear()
+    visibilitySuppressedTrackSidsRef.current.clear()
+    userHiddenRemoteMediaKeysRef.current.clear()
+    resumedTrackSidsRef.current.clear()
     setJoinedChannelId(null)
     useAppStore.getState().setJoinedVoiceChannelId(null)
     if (userId) useAppStore.getState().setVoiceCamera(userId, false)
@@ -1044,6 +1151,7 @@ export function useLiveKitVoice() {
     stopCamera,
     setVoiceControls,
     setMemberVoiceControls,
+    setRemoteMediaSubscribed,
     playVoiceCue,
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Reduced default screen-share bandwidth, unsubscribe viewer-hidden remote media, and pause incoming remote video while the app is hidden or minimized, keeping microphone audio connected.
+
 ### Security
 - Updated the frontend Babel toolchain to patched `@babel/core` releases that prevent arbitrary file reads through crafted `sourceMappingURL` comments.
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -57,8 +57,9 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] `docs/VOICE_QUALITY_BENCHMARK.md` completed and recorded as `GO` when the release changes codec, bitrate, capture constraints, suppression tuning, VAD/gate thresholds, input gain, or LiveKit publish options.
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
-- [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding a screen share or changing screen-share volume affects only screen-share audio while normal microphone audio continues.
-- [ ] Screen share quality presets match the UI summary: Presentation uses 1080p30, Video/Gaming use 1080p60, and Auto selects the profile by shared surface without excessive bandwidth.
+- [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding media unsubscribes its remote publications for that viewer while normal microphone audio continues.
+- [ ] Screen share quality presets match the UI summary: Presentation uses 1080p30 at 4 Mbps, Video uses 1080p60 at 6 Mbps, Gaming uses 1080p60 at 8 Mbps, and Auto does not promote monitor sharing to Gaming.
+- [ ] Hiding or minimizing the app pauses incoming remote video subscriptions while voice audio continues, and restoring visibility resumes video without replaying media-start cues.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.
 - [ ] Timed-out members cannot send/edit server-channel messages or add new reactions until cleared or expired.
 - [ ] Mobile server chat shows one visible message after send, including after the API response and WebSocket echo both arrive.

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -41,15 +41,17 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] `Presentation` profile publishes at the UI-described 1080p30 behavior.
 - [ ] `Video` profile publishes at the UI-described 1080p60 behavior.
 - [ ] `Gaming` profile publishes at the UI-described 1080p60 behavior with the higher bitrate profile.
-- [ ] `Auto` chooses by shared surface: monitor -> gaming, browser/tab -> video, window/unknown -> presentation.
+- [ ] `Auto` chooses a balanced profile by shared surface: monitor/browser -> video, window/unknown -> presentation.
 - [ ] Monitor/game and browser/video shares stay motion-first under load: frame pacing remains smooth before sharpness is preserved.
 - [ ] User A starts screen share; User B sees the screen tile.
 - [ ] User B hears the screen-start cue only once for the screen video track.
 - [ ] Sharing screen audio does not play a duplicate start cue.
-- [ ] User B hides the screen share; the screen tile collapses and only screen-share audio is muted.
+- [ ] User B hides the screen share; the screen tile collapses and its screen video/audio publications stop for that viewer.
+- [ ] While hidden by User B, the remote screen video and screen-share audio publications are unsubscribed; selecting `Show` restores them without replaying the start cue.
 - [ ] User A's normal microphone audio continues while the screen share is hidden.
 - [ ] User B mutes or lowers the screen-share volume; only screen-share audio changes and User A's normal microphone audio remains audible.
 - [ ] User B shows the screen share again and audio behavior returns with the visible media.
+- [ ] Minimizing or hiding User B's Voxpery window pauses incoming camera/screen video traffic while microphone and screen-share audio continue; restoring the window resumes video without replaying start cues.
 - [ ] User A stops screen share; User B does not hear a stop cue.
 
 ## 5. Noise Suppression

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -183,10 +183,10 @@ Speaker
 
 | Preset        | Resolution | FPS | Bitrate (Mbps) | Use Case         |
 |---------------|------------|-----|----------------|------------------|
-| Auto          | 1080p      | 30/60 | 5-9          | Picks by shared surface |
-| Presentation  | 1080p      | 30  | 5.0            | Slides, docs, IDEs |
-| Video         | 1080p      | 60  | 7.0            | Browser tabs and video |
-| Gaming        | 1080p      | 60  | 9.0            | Full-screen motion |
+| Auto          | 1080p      | 30/60 | 4-6          | Balanced selection by shared surface |
+| Presentation  | 1080p      | 30  | 4.0            | Slides, docs, IDEs |
+| Video         | 1080p      | 60  | 6.0            | Browser tabs, monitors, and video |
+| Gaming        | 1080p      | 60  | 8.0            | Explicit high-motion mode |
 
 ### Implementation
 
@@ -206,16 +206,18 @@ await room.localParticipant.publishTrack(videoTrack, {
 
 - **Auto screen share**: Starts with a 1080p60 capture envelope, then reapplies the selected surface profile after `displaySurface` is known.
 - **Presentation/window share**: `contentHint = 'detail'` at 1080p30 and `maintain-resolution` degradation to preserve text sharpness while limiting traffic.
-- **Browser tab/video and monitor/gaming share**: `contentHint = 'motion'` at 1080p60 and `maintain-framerate` degradation so motion streams trade resolution before they stall on dropped frames.
+- **Browser tab/video and Auto monitor share**: `contentHint = 'motion'` at 1080p60 with a balanced 6 Mbps cap and `maintain-framerate` degradation.
+- **Gaming share**: Explicit 1080p60 high-motion mode with an 8 Mbps cap for users who prefer quality over bandwidth.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
 
 ### Remote Viewing Controls
 
 - Remote camera and screen-share tiles can be hidden per viewer without leaving the voice channel.
-- Hidden media stays as a compact placeholder with a `Show` action so the user can resume watching.
+- Hidden media stays as a compact placeholder with a `Show` action; its remote camera or screen publications are unsubscribed until the user resumes watching.
 - Hidden preferences are local to the current voice session and reset after leaving, refreshing, or switching voice channels.
-- Hiding a screen share also mutes that screen-share audio track; the participant's microphone audio continues normally.
+- Hiding a screen share unsubscribes both its video and screen-share audio publications; the participant's microphone audio continues normally.
 - The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
+- When the Voxpery window is hidden or minimized, remote video subscriptions pause while microphone and screen-share audio continue. Video subscriptions resume when the app becomes visible, without replaying media-start cues.
 
 ## Camera
 


### PR DESCRIPTION
## Summary

- Reduce default screen-share bandwidth while preserving explicit high-quality options
- Pause incoming remote video subscriptions while the app is hidden or minimized
- Unsubscribe viewer-hidden camera and screen-share publications until they are shown again
- Keep microphone audio connected during background operation
- Update voice documentation and release smoke coverage

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`
- `graphify update .`