### PR TITLE
fix: fall back to default voice devices

### DIFF
--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -7,7 +7,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores/app'
 import { useAuthStore } from '../stores/auth'
 import { useToastStore } from '../stores/toast'
-import { applyPreferredAudioOutputDevice, buildPreferredMicrophoneConstraints, VOICE_SETTINGS_CHANGED_EVENT } from '../voiceDevices'
+import { applyPreferredAudioOutputDevice, getPreferredMicrophoneStream, VOICE_SETTINGS_CHANGED_EVENT } from '../voiceDevices'
 import {
   desktopMediaPermissionRecoveryMessage,
   isMediaPermissionDeniedError,
@@ -652,7 +652,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       }
       let micStream: MediaStream | null = null
       try {
-        micStream = await navigator.mediaDevices.getUserMedia({ audio: buildPreferredMicrophoneConstraints(), video: false })
+        micStream = await getPreferredMicrophoneStream()
         await joinVoice(channelId, { preflightStream: micStream })
       } catch (err: unknown) {
         micStream?.getTracks().forEach((t) => t.stop())
@@ -749,7 +749,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
     let stream: MediaStream | null = null
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: buildPreferredMicrophoneConstraints(), video: false })
+      stream = await getPreferredMicrophoneStream()
       await joinVoice(channelId, { preflightStream: stream })
     } catch (err: unknown) {
       stream?.getTracks().forEach((t) => t.stop())

--- a/apps/web/src/components/SensitivityBar.tsx
+++ b/apps/web/src/components/SensitivityBar.tsx
@@ -9,7 +9,7 @@ import {
 import {
     VOICE_SETTINGS_CHANGED_EVENT,
     applyPreferredAudioOutputDevice,
-    buildPreferredMicrophoneConstraints,
+    getPreferredMicrophoneStream,
 } from '../voiceDevices'
 import { evaluateVoiceGateFrame } from '../webrtc/voiceGate'
 import {
@@ -31,7 +31,6 @@ const MIC_TEST_PRESET_SWITCH_MUTE_MS = 180
 
 function buildMicTestConstraints(): MediaTrackConstraints {
     return {
-        ...buildPreferredMicrophoneConstraints(),
         channelCount: 1,
         // Mic test replays your own voice locally; browser AEC/AGC can
         // over-suppress syllables in this self-monitor loop.
@@ -193,10 +192,7 @@ export default function SensitivityBar({
                     return
                 }
 
-                const stream = await navigator.mediaDevices.getUserMedia({
-                    audio: buildMicTestConstraints(),
-                    video: false,
-                })
+                const stream = await getPreferredMicrophoneStream(buildMicTestConstraints())
                 if (cancelled) {
                     stream.getTracks().forEach((track) => track.stop())
                     return

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -69,6 +69,7 @@ import {
   supportsAudioOutputSelection,
   VOICE_INPUT_DEVICE_KEY,
   VOICE_OUTPUT_DEVICE_KEY,
+  VOICE_DEVICE_PREFERENCES_CHANGED_EVENT,
   VOICE_SETTINGS_CHANGED_EVENT,
   type MicrophonePermissionState,
   type VoiceDeviceOption,
@@ -456,13 +457,21 @@ export default function UserBar() {
   useEffect(() => {
     void refreshVoiceDevices()
     const mediaDevices = navigator.mediaDevices
-    if (!mediaDevices?.addEventListener) return
     const handleDeviceChange = () => {
       void refreshVoiceDevices()
     }
-    mediaDevices.addEventListener('devicechange', handleDeviceChange)
-    return () => mediaDevices.removeEventListener('devicechange', handleDeviceChange)
+    mediaDevices?.addEventListener?.('devicechange', handleDeviceChange)
+    return () => mediaDevices?.removeEventListener?.('devicechange', handleDeviceChange)
   }, [refreshVoiceDevices])
+
+  useEffect(() => {
+    const handlePreferenceFallback = () => {
+      setSelectedInputDeviceId(getStoredVoiceInputDeviceId())
+      setSelectedOutputDeviceId(getStoredVoiceOutputDeviceId())
+    }
+    window.addEventListener(VOICE_DEVICE_PREFERENCES_CHANGED_EVENT, handlePreferenceFallback)
+    return () => window.removeEventListener(VOICE_DEVICE_PREFERENCES_CHANGED_EVENT, handlePreferenceFallback)
+  }, [])
 
   useEffect(() => {
     if (!showSettingsPanel || activeSettingsSection !== 'voice') return

--- a/apps/web/src/voiceDevices.test.ts
+++ b/apps/web/src/voiceDevices.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyPreferredAudioOutputDevice,
+  getPreferredMicrophoneStream,
+  VOICE_DEVICE_PREFERENCES_CHANGED_EVENT,
+  VOICE_INPUT_DEVICE_KEY,
+  VOICE_OUTPUT_DEVICE_KEY,
+} from './voiceDevices'
+
+const originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices')
+const originalSetSinkId = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'setSinkId')
+
+function unavailableDeviceError(): DOMException {
+  return new DOMException('Requested device is unavailable', 'NotFoundError')
+}
+
+describe('voice device preferences', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    if (originalMediaDevices) {
+      Object.defineProperty(navigator, 'mediaDevices', originalMediaDevices)
+    } else {
+      Reflect.deleteProperty(navigator, 'mediaDevices')
+    }
+    if (originalSetSinkId) {
+      Object.defineProperty(HTMLMediaElement.prototype, 'setSinkId', originalSetSinkId)
+    } else {
+      Reflect.deleteProperty(HTMLMediaElement.prototype, 'setSinkId')
+    }
+  })
+
+  it('uses the system default microphone when no custom device is stored', async () => {
+    const stream = {} as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    })
+
+    await expect(getPreferredMicrophoneStream({ channelCount: 1 })).resolves.toBe(stream)
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: expect.objectContaining({
+        deviceId: undefined,
+        channelCount: 1,
+      }),
+      video: false,
+    })
+  })
+
+  it('preserves and uses an available custom microphone', async () => {
+    const stream = {} as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    })
+    localStorage.setItem(VOICE_INPUT_DEVICE_KEY, 'custom-mic')
+
+    await expect(getPreferredMicrophoneStream()).resolves.toBe(stream)
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: expect.objectContaining({
+        deviceId: { exact: 'custom-mic' },
+      }),
+      video: false,
+    })
+    expect(localStorage.getItem(VOICE_INPUT_DEVICE_KEY)).toBe('custom-mic')
+  })
+
+  it('silently falls back to the system microphone when a saved device disappears', async () => {
+    const fallbackStream = {} as MediaStream
+    const getUserMedia = vi.fn()
+      .mockRejectedValueOnce(unavailableDeviceError())
+      .mockResolvedValueOnce(fallbackStream)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    })
+    localStorage.setItem(VOICE_INPUT_DEVICE_KEY, 'removed-mic')
+    const preferenceChanged = vi.fn()
+    window.addEventListener(VOICE_DEVICE_PREFERENCES_CHANGED_EVENT, preferenceChanged)
+
+    await expect(getPreferredMicrophoneStream()).resolves.toBe(fallbackStream)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(getUserMedia.mock.calls[0][0]).toEqual({
+      audio: expect.objectContaining({
+        deviceId: { exact: 'removed-mic' },
+      }),
+      video: false,
+    })
+    expect(getUserMedia.mock.calls[1][0]).toEqual({
+      audio: expect.objectContaining({
+        deviceId: undefined,
+      }),
+      video: false,
+    })
+    expect(localStorage.getItem(VOICE_INPUT_DEVICE_KEY)).toBeNull()
+    expect(preferenceChanged).toHaveBeenCalledOnce()
+    window.removeEventListener(VOICE_DEVICE_PREFERENCES_CHANGED_EVENT, preferenceChanged)
+  })
+
+  it('does not replace a custom microphone when access fails for another reason', async () => {
+    const permissionError = new DOMException('Permission denied', 'NotAllowedError')
+    const getUserMedia = vi.fn().mockRejectedValue(permissionError)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    })
+    localStorage.setItem(VOICE_INPUT_DEVICE_KEY, 'custom-mic')
+
+    await expect(getPreferredMicrophoneStream()).rejects.toBe(permissionError)
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    expect(localStorage.getItem(VOICE_INPUT_DEVICE_KEY)).toBe('custom-mic')
+  })
+
+  it('preserves a custom microphone when another capture constraint is unsupported', async () => {
+    const constraintError = Object.assign(
+      new DOMException('Unsupported channel count', 'OverconstrainedError'),
+      { constraint: 'channelCount' },
+    )
+    const getUserMedia = vi.fn().mockRejectedValue(constraintError)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    })
+    localStorage.setItem(VOICE_INPUT_DEVICE_KEY, 'custom-mic')
+
+    await expect(getPreferredMicrophoneStream({ channelCount: 1 })).rejects.toBe(constraintError)
+    expect(getUserMedia).toHaveBeenCalledOnce()
+    expect(localStorage.getItem(VOICE_INPUT_DEVICE_KEY)).toBe('custom-mic')
+  })
+
+  it('silently falls back to the system speaker when a saved output disappears', async () => {
+    Object.defineProperty(HTMLMediaElement.prototype, 'setSinkId', {
+      configurable: true,
+      value: vi.fn(),
+    })
+    const element = document.createElement('audio') as HTMLAudioElement & {
+      sinkId?: string
+      setSinkId: (sinkId: string) => Promise<void>
+    }
+    const setSinkId = vi.fn()
+      .mockRejectedValueOnce(unavailableDeviceError())
+      .mockResolvedValueOnce(undefined)
+    Object.defineProperty(element, 'setSinkId', {
+      configurable: true,
+      value: setSinkId,
+    })
+    localStorage.setItem(VOICE_OUTPUT_DEVICE_KEY, 'removed-speaker')
+
+    await expect(applyPreferredAudioOutputDevice(element)).resolves.toBe(true)
+    expect(setSinkId).toHaveBeenNthCalledWith(1, 'removed-speaker')
+    expect(setSinkId).toHaveBeenNthCalledWith(2, 'default')
+    expect(localStorage.getItem(VOICE_OUTPUT_DEVICE_KEY)).toBeNull()
+  })
+
+  it('preserves a custom speaker when output switching is blocked rather than unavailable', async () => {
+    Object.defineProperty(HTMLMediaElement.prototype, 'setSinkId', {
+      configurable: true,
+      value: vi.fn(),
+    })
+    const element = document.createElement('audio') as HTMLAudioElement & {
+      sinkId?: string
+      setSinkId: (sinkId: string) => Promise<void>
+    }
+    const permissionError = new DOMException('Output selection is blocked', 'NotAllowedError')
+    const setSinkId = vi.fn().mockRejectedValue(permissionError)
+    Object.defineProperty(element, 'setSinkId', {
+      configurable: true,
+      value: setSinkId,
+    })
+    localStorage.setItem(VOICE_OUTPUT_DEVICE_KEY, 'custom-speaker')
+
+    await expect(applyPreferredAudioOutputDevice(element)).resolves.toBe(false)
+    expect(setSinkId).toHaveBeenCalledOnce()
+    expect(localStorage.getItem(VOICE_OUTPUT_DEVICE_KEY)).toBe('custom-speaker')
+  })
+})

--- a/apps/web/src/voiceDevices.ts
+++ b/apps/web/src/voiceDevices.ts
@@ -1,4 +1,5 @@
 export const VOICE_SETTINGS_CHANGED_EVENT = 'voxpery-voice-settings-changed'
+export const VOICE_DEVICE_PREFERENCES_CHANGED_EVENT = 'voxpery-voice-device-preferences-changed'
 export const VOICE_INPUT_DEVICE_KEY = 'voxpery-settings-input-device-id'
 export const VOICE_OUTPUT_DEVICE_KEY = 'voxpery-settings-output-device-id'
 export const DEFAULT_INPUT_DEVICE_LABEL = 'Windows Default'
@@ -26,6 +27,31 @@ function readStoredDeviceId(key: string): string {
   } catch {
     return ''
   }
+}
+
+function clearStoredDeviceId(key: string): void {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // The current capture/playback fallback still succeeds for this session.
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(VOICE_DEVICE_PREFERENCES_CHANGED_EVENT))
+  }
+}
+
+function isUnavailableDeviceError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const typedError = error as {
+    name?: unknown
+    constraint?: unknown
+    constraintName?: unknown
+  }
+  const name = String(typedError.name ?? '')
+  if (name === 'NotFoundError' || name === 'DevicesNotFoundError') return true
+  if (name !== 'OverconstrainedError' && name !== 'ConstraintNotSatisfiedError') return false
+  const constraint = String(typedError.constraint ?? typedError.constraintName ?? '')
+  return constraint === '' || constraint === 'deviceId'
 }
 
 export function isStoredNoiseSuppressionEnabled(): boolean {
@@ -60,6 +86,39 @@ export function buildPreferredMicrophoneConstraints(): MediaTrackConstraints {
   return {
     deviceId: deviceId ? { exact: deviceId } : undefined,
     ...buildMicProcessingConstraints(noiseSuppressionEnabled),
+  }
+}
+
+export async function getPreferredMicrophoneStream(
+  overrides: MediaTrackConstraints = {},
+): Promise<MediaStream> {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new Error('Microphone access is not supported in this browser')
+  }
+
+  const preferredDeviceId = getStoredVoiceInputDeviceId()
+  const preferredConstraints = {
+    ...buildPreferredMicrophoneConstraints(),
+    ...overrides,
+  }
+
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: preferredConstraints,
+      video: false,
+    })
+  } catch (error) {
+    if (!preferredDeviceId || !isUnavailableDeviceError(error)) throw error
+
+    clearStoredDeviceId(VOICE_INPUT_DEVICE_KEY)
+    return navigator.mediaDevices.getUserMedia({
+      audio: {
+        ...buildPreferredMicrophoneConstraints(),
+        ...overrides,
+        deviceId: undefined,
+      },
+      video: false,
+    })
   }
 }
 
@@ -181,10 +240,12 @@ export async function applyPreferredAudioOutputDevice(element: HTMLAudioElement)
       await sinkElement.setSinkId(preferredSinkId)
     }
     return true
-  } catch {
-    if (preferredSinkId !== 'default') {
+  } catch (error) {
+    if (preferredSinkId !== 'default' && isUnavailableDeviceError(error)) {
+      clearStoredDeviceId(VOICE_OUTPUT_DEVICE_KEY)
       try {
         await sinkElement.setSinkId('default')
+        return true
       } catch {
         // ignore fallback failures
       }

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react'
 import {
     applyMicTrackProcessingConstraints,
-    buildPreferredMicrophoneConstraints,
+    getPreferredMicrophoneStream,
     getStoredVoiceInputDeviceId,
 } from '../../voiceDevices'
 
@@ -137,16 +137,10 @@ export function useLocalMedia() {
         }
         cachedMicStreamRef.current?.getTracks().forEach((track) => track.stop())
         cachedMicStreamRef.current = null
-        if (!navigator.mediaDevices?.getUserMedia) {
-            throw new Error('Microphone access is not supported in this browser')
-        }
         try {
-            const stream = await navigator.mediaDevices.getUserMedia({
-                audio: buildPreferredMicrophoneConstraints(),
-                video: false,
-            })
+            const stream = await getPreferredMicrophoneStream()
             cachedMicStreamRef.current = stream
-            cachedMicDeviceIdRef.current = preferredDeviceId
+            cachedMicDeviceIdRef.current = getStoredVoiceInputDeviceId()
             return stream
         } catch (err: unknown) {
             const name = (err as { name?: string })?.name ?? ''

--- a/apps/web/src/webrtc/useWebRTCVoice.ts
+++ b/apps/web/src/webrtc/useWebRTCVoice.ts
@@ -5,6 +5,7 @@ import { useAppStore } from '../stores/app'
 import { useSocketStore } from '../stores/socket'
 import type { SignalingMessage } from '../types'
 import { startAudioLevelMonitor } from './audioLevelMonitor'
+import { getPreferredMicrophoneStream } from '../voiceDevices'
 
 type PeerId = string
 /** getStats() forEach callback: each entry is a map of stat properties. */
@@ -674,15 +675,12 @@ export function useWebRTCVoice() {
 
       // Acquire mic with basic noise suppression / echo cancellation so peer connections can attach tracks.
       const noiseSuppressionEnabled = localStorage.getItem(NOISE_SUPPRESSION_KEY) !== '0'
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: noiseSuppressionEnabled,
-          autoGainControl: true,
-          sampleRate: 48000,
-          channelCount: 1,
-        },
-        video: false,
+      const stream = await getPreferredMicrophoneStream({
+        echoCancellation: true,
+        noiseSuppression: noiseSuppressionEnabled,
+        autoGainControl: true,
+        sampleRate: 48000,
+        channelCount: 1,
       })
       // Store in ref immediately to avoid races with offer creation.
       localStreamRef.current = stream

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Made direct-message history open without a false empty state by reusing recent conversations, prefetching on sidebar intent, and deduplicating concurrent history requests.
+- Made saved microphone and speaker preferences fall back silently to the system default when a selected device is removed, while preserving available custom devices.
 
 ### Security
 - Updated the frontend Babel toolchain to patched `@babel/core` releases that prevent arbitrary file reads through crafted `sourceMappingURL` comments.

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -17,6 +17,9 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] User B joins the same voice channel and both users hear the join cue.
 - [ ] Mute/unmute changes local mic state and does not disconnect the room.
 - [ ] The configured mute shortcut toggles the microphone while the web tab is focused.
+- [ ] A new/default user joins with the operating system's current default microphone and speaker.
+- [ ] A valid custom microphone and speaker remain selected after reload and voice rejoin.
+- [ ] After a selected custom microphone or speaker is disconnected, the next capture/playback attempt silently uses the system default and Voice Settings shows `Windows Default`.
 - [ ] In desktop builds, the configured mute shortcut also works while Voxpery is unfocused, minimized, or running in the tray.
 - [ ] Rebinding or clearing the mute shortcut takes effect immediately; a conflicting desktop shortcut shows an error without losing the previous working binding.
 - [ ] Deafen stops remote audio playback and restores it when disabled.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -186,6 +186,14 @@ Speaker
 - **Deafen**: Sets `audio.muted = true` on all remote elements
 - **Stop watching screen**: Hiding a remote screen share removes its screen-share audio track from playback while keeping the peer's normal microphone audio active.
 
+### Input and Output Device Selection
+
+- New users and users who leave device selection on `Windows Default` follow the current system default microphone and speaker.
+- Explicit microphone and speaker selections remain stored and are reused while those devices are available.
+- If a stored custom device is unplugged, removed, or no longer exposed by the browser, Voxpery clears only that stale preference and silently retries with the system default.
+- Permission failures, devices that are temporarily busy, and output-selection policy failures do not overwrite a valid custom preference.
+- The same microphone fallback is used by call preflight, LiveKit capture, the microphone test, and the legacy WebRTC path.
+
 ## Screen Sharing
 
 ### Resolutions & Bitrates


### PR DESCRIPTION
## Summary
- silently fall back to system-default audio devices when saved devices disappear
- preserve valid custom microphone and speaker preferences
- apply microphone fallback across call preflight, capture, mic test, and legacy WebRTC paths
- add regression coverage and update voice documentation

## Validation
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:ui-smoke