### PR TITLE
feat: show voice media presence

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3277,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Channel, MemberInfo, Server } from '../api'
+import { useAppStore } from '../stores/app'
+import { useAuthStore } from '../stores/auth'
+import { useSocketStore } from '../stores/socket'
+import ChannelSidebar from './ChannelSidebar'
+
+const server: Server = {
+    id: 'server-1',
+    name: 'Test Server',
+    owner_id: 'owner-1',
+    invite_code: 'test-server',
+}
+
+const voiceChannel: Channel = {
+    id: 'voice-1',
+    server_id: server.id,
+    name: 'General',
+    channel_type: 'voice',
+    category: 'Voice',
+    position: 0,
+    my_permissions: 1 << 10,
+}
+
+const remoteMember: MemberInfo = {
+    user_id: 'remote-1',
+    username: 'a-very-long-remote-username',
+    avatar_url: null,
+    role: 'member',
+    status: 'online',
+    role_color: null,
+}
+
+describe('ChannelSidebar voice media presence', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        useAppStore.getState().resetSessionState()
+        useAuthStore.setState({
+            token: 'token',
+            user: {
+                id: 'local-1',
+                username: 'local-user',
+                email: 'local@example.test',
+                email_verified: true,
+                status: 'online',
+            },
+            loggingOut: false,
+        })
+        useSocketStore.setState({ send: vi.fn() })
+    })
+
+    it('shows camera and screen-share activity to a member outside the voice channel', () => {
+        const voiceControls = {
+            [remoteMember.user_id]: {
+                muted: false,
+                deafened: false,
+                serverMuted: false,
+                serverDeafened: false,
+                screenSharing: true,
+                cameraOn: true,
+            },
+        }
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            activeChannelId: null,
+            members: [remoteMember],
+            membersByServerId: { [server.id]: [remoteMember] },
+            voiceStates: { [remoteMember.user_id]: voiceChannel.id },
+            voiceStateServerIds: { [remoteMember.user_id]: server.id },
+            voiceControls,
+            joinedVoiceChannelId: null,
+        })
+
+        render(
+            <ChannelSidebar
+                channelCategories={['Voice']}
+                voiceControls={voiceControls}
+            />,
+        )
+
+        expect(screen.getByText(remoteMember.username)).toBeVisible()
+        expect(screen.getByLabelText(`${remoteMember.username} camera on`)).toBeVisible()
+        expect(screen.getByLabelText(`${remoteMember.username} screen sharing`)).toHaveTextContent('LIVE')
+        expect(useAppStore.getState().joinedVoiceChannelId).toBeNull()
+    })
+})

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -1,4 +1,4 @@
-import { Hash, Volume2, ChevronDown, Plus, MicOff, VolumeX, Monitor, Video, Shield, Lock, Settings2, PhoneOff } from 'lucide-react'
+import { Hash, Volume2, ChevronDown, Plus, MicOff, VolumeX, Video, Shield, Lock, Settings2, PhoneOff } from 'lucide-react'
 import { useEffect, useRef, useState, type DragEvent } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAuthStore } from '../stores/auth'
@@ -588,18 +588,30 @@ export default function ChannelSidebar({
                                                             )}
                                                         </div>
                                                         <span className={`voice-participant-name${isSpeaking ? ' is-speaking' : ''}`}>{vm.username}</span>
-                                                        {(isScreenSharing || isCameraOn || isDeafened || isMuted) && (
-                                                            <span className="voice-participant-icons">
+                                                        {(isCameraOn || isScreenSharing) && (
+                                                            <span className="voice-participant-media" aria-label={`${vm.username} live media`}>
                                                                 {isCameraOn && (
-                                                                    <span className="voice-participant-icon-badge is-positive" title="Camera on">
-                                                                        <Video size={11} />
+                                                                    <span
+                                                                        className="voice-participant-camera"
+                                                                        title="Camera on"
+                                                                        aria-label={`${vm.username} camera on`}
+                                                                    >
+                                                                        <Video size={13} />
                                                                     </span>
                                                                 )}
                                                                 {isScreenSharing && (
-                                                                    <span className="voice-participant-icon-badge is-positive" title="Screen sharing">
-                                                                        <Monitor size={11} />
+                                                                    <span
+                                                                        className="voice-live-badge"
+                                                                        title="Screen sharing"
+                                                                        aria-label={`${vm.username} screen sharing`}
+                                                                    >
+                                                                        LIVE
                                                                     </span>
                                                                 )}
+                                                            </span>
+                                                        )}
+                                                        {(isDeafened || isMuted) && (
+                                                            <span className="voice-participant-icons">
                                                                 {isDeafened && (
                                                                     <>
                                                                         <span

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1576,6 +1576,8 @@ body {
 }
 
 .voice-participant-name {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1588,24 +1590,45 @@ body {
 }
 
 .voice-live-badge {
-  margin-left: 6px;
-  padding: 1px 5px;
-  border-radius: 999px;
-  background: rgba(233, 69, 96, 0.2);
-  border: 1px solid rgba(233, 69, 96, 0.55);
-  color: #ff9fb0;
+  min-height: 16px;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: #ed4245;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #fff;
   font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.2px;
+  font-weight: 800;
+  line-height: 14px;
+  letter-spacing: 0;
+  box-shadow: 0 1px 4px rgba(237, 66, 69, 0.32);
+}
+
+.voice-participant-media {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+}
+
+.voice-participant-camera {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  flex: 0 0 auto;
 }
 
 .voice-participant-icons {
-  margin-left: auto;
+  margin-left: 0;
   display: inline-flex;
   align-items: center;
   gap: 4px;
   color: #f04747;
   opacity: 0.95;
+  flex: 0 0 auto;
 }
 
 .voice-participant-icon-badge {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Reduced default screen-share bandwidth, unsubscribe viewer-hidden remote media, and pause incoming remote video while the app is hidden or minimized, keeping microphone audio connected.
 - Removed benchmark-only diagnostics controls from user settings and tailored settings copy to web and desktop runtimes.
+- Made voice-channel camera and screen-share activity visible before joining, using a compact camera icon and Discord-style `LIVE` badge.
 
 ### Fixed
 - Made direct-message history open without a false empty state by reusing recent conversations, prefetching on sidebar intent, and deduplicating concurrent history requests.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made voice-channel camera and screen-share activity visible before joining, using a compact camera icon and Discord-style `LIVE` badge.
 
 ### Fixed
+- Updated desktop `quinn-proto` to `0.11.15` to address `RUSTSEC-2026-0185` remote memory exhaustion.
 - Made direct-message history open without a false empty state by reusing recent conversations, prefetching on sidebar intent, and deduplicating concurrent history requests.
 - Made saved microphone and speaker preferences fall back silently to the system default when a selected device is removed, while preserving available custom devices.
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -185,6 +185,7 @@ Speaker
 - **Amplification >100%**: Routed through WebAudio GainNode (gain > 1.0)
 - **Deafen**: Sets `audio.muted = true` on all remote elements
 - **Stop watching screen**: Hiding a remote screen share removes its screen-share audio track from playback while keeping the peer's normal microphone audio active.
+- **Pre-join media presence**: Server members can see a camera icon and `LIVE` screen-share badge beside voice participants before joining the channel. These indicators use the server-broadcast voice control state and do not subscribe the viewer to media.
 
 ### Input and Output Device Selection
 


### PR DESCRIPTION
## Summary
- make camera activity visible beside voice participants
- show screen sharing with a Discord-style LIVE badge
- preserve media indicators for members outside the voice channel
- prevent long usernames from displacing voice status indicators
- add regression coverage and update voice documentation

## Validation
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:ui-smoke