### PR TITLE
fix: anchor unread divider to real boundary

### DIFF
--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -420,6 +420,83 @@ describe('ChatArea regressions', () => {
     expect(screen.getByRole('button', { name: 'Jump to latest messages' })).toBeInTheDocument()
   })
 
+  it('keeps the unread divider anchored to the original remote message', async () => {
+    const localMessage = {
+      ...message('message-local', 'my new message', 2),
+      author: {
+        user_id: 'local-user',
+        username: 'local',
+      },
+    }
+    const initialMessages = [
+      message('message-read', 'already read', 0),
+      message('message-unread', 'first unread', 1),
+      localMessage,
+    ]
+    const { rerender } = renderChatArea({
+      messages: initialMessages,
+      currentUserId: 'local-user',
+      unreadDividerCount: 1,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('New unread messages').closest('[data-message-id]'))
+        .toHaveAttribute('data-message-id', 'message-unread')
+    })
+
+    const nextLocalMessage = {
+      ...message('message-local-2', 'another local message', 3),
+      author: {
+        user_id: 'local-user',
+        username: 'local',
+      },
+    }
+    rerender(
+      <ChatArea
+        activeChannel={channel('general', 'general')}
+        messages={[...initialMessages, nextLocalMessage]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+        currentUserId="local-user"
+        unreadDividerCount={1}
+      />
+    )
+
+    expect(screen.getByLabelText('New unread messages').closest('[data-message-id]'))
+      .toHaveAttribute('data-message-id', 'message-unread')
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('general', 'general')}
+        messages={[
+          message('message-older', 'loaded history', 0),
+          ...initialMessages,
+          nextLocalMessage,
+          message('message-live', 'live arrival while open', 4),
+        ]}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+        currentUserId="local-user"
+        unreadDividerCount={1}
+      />
+    )
+
+    expect(screen.getByLabelText('New unread messages').closest('[data-message-id]'))
+      .toHaveAttribute('data-message-id', 'message-unread')
+  })
+
   it('exposes separate emoji, GIF, and sticker composer actions', async () => {
     renderChatArea()
 

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -27,6 +27,12 @@ type MentionUser = {
 
 type MessagePickerMode = 'emoji' | 'gif' | 'sticker'
 
+type UnreadDividerSnapshot = {
+    channelId: string | null
+    unreadCount: number
+    messageIds: string[]
+}
+
 /** Synthetic entry for @all mention (server-wide). Shown at top when user types @. */
 const MENTION_ALL: MentionUser = { user_id: '__all__', username: 'all' }
 const TOP_AUTO_LOAD_THRESHOLD_PX = 96
@@ -626,6 +632,11 @@ export default function ChatArea({
     const virtualListSpacerRef = useRef<HTMLDivElement | null>(null)
     const currentChatChannelId = activeChannel?.id ?? null
     const currentChatChannelIdRef = useRef<string | null>(currentChatChannelId)
+    const [unreadDividerSnapshot, setUnreadDividerSnapshot] = useState<UnreadDividerSnapshot>({
+        channelId: null,
+        unreadCount: 0,
+        messageIds: [],
+    })
     const setMessagesScrollRef = useCallback(
         (el: HTMLDivElement | null) => {
             (messagesScrollRef as React.MutableRefObject<HTMLDivElement | null>).current = el
@@ -724,11 +735,86 @@ export default function ChatArea({
         return withAll.slice(0, 9)
     }, [mentionCandidates, mentionOpen, mentionQuery])
 
+    const normalizedUnreadDividerCount = Number.isFinite(unreadDividerCount)
+        ? Math.max(0, Math.trunc(unreadDividerCount))
+        : 0
+    const isCurrentViewActive = isViewActive !== false
+
+    useLayoutEffect(() => {
+        setUnreadDividerSnapshot((previous) => {
+            if (previous.channelId !== currentChatChannelId) {
+                if (!currentChatChannelId || !isCurrentViewActive || normalizedUnreadDividerCount <= 0) {
+                    return {
+                        channelId: currentChatChannelId,
+                        unreadCount: normalizedUnreadDividerCount,
+                        messageIds: [],
+                    }
+                }
+            } else if (!isCurrentViewActive) {
+                if (previous.messageIds.length === 0 && previous.unreadCount === 0) return previous
+                return {
+                    channelId: currentChatChannelId,
+                    unreadCount: 0,
+                    messageIds: [],
+                }
+            } else if (normalizedUnreadDividerCount <= 0) {
+                // Search temporarily suppresses the divider by passing zero. Preserve
+                // the open-chat snapshot so clearing search restores the same boundary.
+                return previous
+            } else if (
+                previous.unreadCount === normalizedUnreadDividerCount
+                && previous.messageIds.length > 0
+            ) {
+                return previous
+            }
+
+            if (!currentChatChannelId || !isCurrentViewActive || normalizedUnreadDividerCount <= 0) {
+                return previous
+            }
+
+            const unreadCandidates = messages.filter((message) => (
+                message.channel_id === currentChatChannelId
+                && !message.clientId
+                && (!currentUserId || message.author?.user_id !== currentUserId)
+            ))
+            if (unreadCandidates.length === 0) {
+                return previous.channelId === currentChatChannelId
+                    ? previous
+                    : {
+                        channelId: currentChatChannelId,
+                        unreadCount: normalizedUnreadDividerCount,
+                        messageIds: [],
+                    }
+            }
+
+            return {
+                channelId: currentChatChannelId,
+                unreadCount: normalizedUnreadDividerCount,
+                messageIds: unreadCandidates
+                    .slice(-normalizedUnreadDividerCount)
+                    .map((message) => message.id),
+            }
+        })
+    }, [
+        currentChatChannelId,
+        currentUserId,
+        isCurrentViewActive,
+        messages,
+        normalizedUnreadDividerCount,
+    ])
+
     const firstUnreadIndex = useMemo(() => {
-        if (!Number.isFinite(unreadDividerCount) || unreadDividerCount <= 0) return -1
-        if (messages.length === 0) return -1
-        return Math.max(0, messages.length - unreadDividerCount)
-    }, [messages.length, unreadDividerCount])
+        if (!isCurrentViewActive || normalizedUnreadDividerCount <= 0) return -1
+        if (unreadDividerSnapshot.channelId !== currentChatChannelId) return -1
+        const unreadIds = new Set(unreadDividerSnapshot.messageIds)
+        return messages.findIndex((message) => unreadIds.has(message.id))
+    }, [
+        currentChatChannelId,
+        isCurrentViewActive,
+        messages,
+        normalizedUnreadDividerCount,
+        unreadDividerSnapshot,
+    ])
 
     const virtualCount = messages.length + (typingIndicatorLabel ? 1 : 0)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made voice-channel camera and screen-share activity visible before joining, using a compact camera icon and Discord-style `LIVE` badge.
 
 ### Fixed
+- Anchored the chat `New messages` divider to the actual unread message boundary so local sends, live arrivals, and history pagination cannot move it onto already-read content.
 - Updated desktop `quinn-proto` to `0.11.15` to address `RUSTSEC-2026-0185` remote memory exhaustion.
 - Made direct-message history open without a false empty state by reusing recent conversations, prefetching on sidebar intent, and deduplicating concurrent history requests.
 - Made saved microphone and speaker preferences fall back silently to the system default when a selected device is removed, while preserving available custom devices.


### PR DESCRIPTION
## Summary
- Anchor the chat `New messages` divider to the actual unread remote message boundary.
- Prevent local sends, live arrivals, and history pagination from moving the divider onto already-read or self-sent messages.
- Add a regression test covering local sends, live remote arrivals, and prepended history.

## Validation
- `npm run test:run -- src/components/ChatArea.test.tsx`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run test:e2e:ui-smoke`