### PR TITLE
chore: bump release to v0.2.3

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -12,11 +12,11 @@ on:
         required: true
         type: string
       expected_version:
-        description: Expected semantic release version, for example 0.2.2 or v0.2.2
+        description: Expected semantic release version, for example 0.2.3 or v0.2.3
         required: false
         type: string
       expected_image_tag:
-        description: Expected immutable Docker image tag, for example v0.2.2 or sha-abc123def456
+        description: Expected immutable Docker image tag, for example v0.2.3 or sha-abc123def456
         required: false
         type: string
       require_security_headers:

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5380,7 +5380,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3141,7 +3141,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-23
+
 ### Added
 - Added a configurable microphone mute shortcut that works while the web tab is focused and system-wide in the desktop app.
 
 ### Changed
+- Bumped web, server, and desktop package metadata to `0.2.3`.
 - Reduced default screen-share bandwidth, unsubscribe viewer-hidden remote media, and pause incoming remote video while the app is hidden or minimized, keeping microphone audio connected.
 - Removed benchmark-only diagnostics controls from user settings and tailored settings copy to web and desktop runtimes.
 - Made voice-channel camera and screen-share activity visible before joining, using a compact camera icon and Discord-style `LIVE` badge.


### PR DESCRIPTION
## Summary
- Bump web, server, and desktop package metadata to `0.2.3`.
- Move current changelog entries into the `0.2.3` release section.
- Refresh release smoke workflow version examples for the new release.

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `cargo check --manifest-path apps/server/Cargo.toml --locked`
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --locked`