### PR TITLE
feat(auth): implement resolvePostAuthRoute for improved redirect hand…

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/apps/web/src/authRedirect.test.ts
+++ b/apps/web/src/authRedirect.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePostAuthRoute } from './authRedirect'
+import { ROUTES } from './routes'
+
+describe('auth redirect resolution', () => {
+  it('opens the community server surface by default after auth', () => {
+    expect(resolvePostAuthRoute()).toBe(ROUTES.servers)
+    expect(resolvePostAuthRoute('')).toBe(ROUTES.servers)
+  })
+
+  it('keeps explicit redirect paths from invite and protected routes', () => {
+    expect(resolvePostAuthRoute('/invite/abc')).toBe('/invite/abc')
+    expect(resolvePostAuthRoute('/social/dm')).toBe('/social/dm')
+  })
+})

--- a/apps/web/src/authRedirect.ts
+++ b/apps/web/src/authRedirect.ts
@@ -1,0 +1,5 @@
+import { ROUTES } from './routes'
+
+export function resolvePostAuthRoute(redirectTo?: string): string {
+  return redirectTo || ROUTES.servers
+}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import { openExternalUrl } from '../openExternalUrl'
 import { ROUTES } from '../routes'
 import { requestPushNotificationPermissionIfNeeded } from '../pushNotifications'
 import { setPersistedSocialView } from '../socialView'
+import { resolvePostAuthRoute } from '../authRedirect'
 
 function GoogleLogoIcon() {
     return (
@@ -87,7 +88,7 @@ export default function LoginPage() {
             setPersistedSocialView('friends')
             // Desktop: also save to secure storage
             if (isTauri()) await setSecureToken(res.token)
-            navigate(redirectTo || ROUTES.home)
+            navigate(resolvePostAuthRoute(redirectTo))
         } catch (err: unknown) {
             const { message, code } = getAuthErrorMessage(err)
             setError(code ? `${message} (Error code: ${code})` : message || 'Login failed')
@@ -101,7 +102,7 @@ export default function LoginPage() {
             <form className="auth-card" onSubmit={handleSubmit}>
                 <img src="/1024.png" alt="Voxpery" className="auth-logo" width={80} height={80} />
                 <h1>Voxpery</h1>
-                <p>Sign in to your account</p>
+                <p>Sign in and continue to your community</p>
 
                 {error && (
                     <div className="auth-error" role="alert">

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -10,6 +10,7 @@ import { openExternalUrl } from '../openExternalUrl'
 import { ROUTES } from '../routes'
 import { requestPushNotificationPermissionIfNeeded } from '../pushNotifications'
 import { setPersistedSocialView } from '../socialView'
+import { resolvePostAuthRoute } from '../authRedirect'
 
 function GoogleLogoIcon() {
     return (
@@ -96,7 +97,7 @@ export default function RegisterPage() {
             setPersistedSocialView('friends')
             // Desktop: also save to secure storage
             if (isTauri()) await setSecureToken(res.token)
-            navigate(redirectTo || ROUTES.home)
+            navigate(resolvePostAuthRoute(redirectTo))
         } catch (err: unknown) {
             const { message, code } = getAuthErrorMessage(err)
             setError(code ? `${message} (Error code: ${code})` : message || 'Registration failed')
@@ -110,7 +111,7 @@ export default function RegisterPage() {
             <form className="auth-card" onSubmit={handleSubmit}>
                 <img src="/1024.png" alt="Voxpery" className="auth-logo" width={80} height={80} />
                 <h1>Voxpery</h1>
-                <p>Create a new account</p>
+                <p>Create an account and jump into the community</p>
 
                 {error && (
                     <div className="auth-error" role="alert">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Send default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
+
 ## [0.2.3] - 2026-06-23
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Send default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
 
+### Security
+- Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.
+
 ## [0.2.3] - 2026-06-23
 
 ### Added


### PR DESCRIPTION
## Summary
- Route default login and registration completions to the server/community surface instead of the social home.
- Preserve explicit auth redirects for invites and protected routes.
- Add unit coverage for the post-auth route resolver.
- Document the onboarding behavior change in the changelog.

## Validation
- npm run lint
- npm run test:run
- npm run build