### PR TITLE
feat(onboarding): implement default community onboarding guide for ne…

### DIFF
--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -911,6 +911,14 @@ const PERM_MANAGE_PINS: i64 = 1 << 9;
 const PERM_CONNECT_VOICE: i64 = 1 << 10;
 const PERM_MUTE_MEMBERS: i64 = 1 << 11;
 const PERM_DEAFEN_MEMBERS: i64 = 1 << 12;
+const DEFAULT_COMMUNITY_ONBOARDING_TITLE: &str = "Welcome to the Voxpery Community";
+const DEFAULT_COMMUNITY_ONBOARDING_BODY: &str =
+    "Start here, say hello, and jump into voice when you are ready.";
+const DEFAULT_COMMUNITY_ONBOARDING_TASKS: [&str; 3] = [
+    "Send your first message in #general",
+    "Join the General voice channel",
+    "Explore the open-source project on GitHub",
+];
 
 /// Env vars to resolve default Voxpery server owner: ADMIN_EMAIL or ADMIN_USERNAME (seeded admin).
 fn official_owner_lookup() -> (Option<String>, Option<String>) {
@@ -1109,6 +1117,8 @@ pub async fn ensure_default_server_join(db: &sqlx::PgPool, user_id: Uuid) -> Res
         .execute(db)
         .await?;
 
+        ensure_default_onboarding_guide(db, server_id).await?;
+
         let already = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM server_members WHERE server_id = $1 AND user_id = $2",
         )
@@ -1135,6 +1145,47 @@ pub async fn ensure_default_server_join(db: &sqlx::PgPool, user_id: Uuid) -> Res
 
         // "@everyone" is implicit in permission resolution; no explicit member assignment needed.
     }
+    Ok(())
+}
+
+async fn ensure_default_onboarding_guide(
+    db: &sqlx::PgPool,
+    server_id: Uuid,
+) -> Result<(), AppError> {
+    let recommended_channel_ids: Vec<Uuid> = sqlx::query_scalar(
+        r#"SELECT id
+           FROM channels
+           WHERE server_id = $1
+             AND (
+               (channel_type = 'text' AND LOWER(name) = 'general')
+               OR (channel_type = 'voice' AND LOWER(name) = 'general')
+             )
+           ORDER BY CASE WHEN channel_type = 'text' THEN 0 ELSE 1 END, position ASC, created_at ASC
+           LIMIT 2"#,
+    )
+    .bind(server_id)
+    .fetch_all(db)
+    .await?;
+    let starter_tasks = DEFAULT_COMMUNITY_ONBOARDING_TASKS
+        .iter()
+        .map(|task| (*task).to_string())
+        .collect::<Vec<_>>();
+
+    sqlx::query(
+        r#"INSERT INTO server_onboarding_guides (
+               server_id, enabled, title, body, recommended_channel_ids, starter_tasks, updated_at
+           )
+           VALUES ($1, TRUE, $2, $3, $4, $5, NOW())
+           ON CONFLICT (server_id) DO NOTHING"#,
+    )
+    .bind(server_id)
+    .bind(DEFAULT_COMMUNITY_ONBOARDING_TITLE)
+    .bind(DEFAULT_COMMUNITY_ONBOARDING_BODY)
+    .bind(&recommended_channel_ids)
+    .bind(&starter_tasks)
+    .execute(db)
+    .await?;
+
     Ok(())
 }
 

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -423,6 +423,38 @@ async fn default_voxpery_server_has_moderator_role_after_register() {
         "default Voxpery server must have Moderator role after register"
     );
 
+    let guide: (bool, String, String, Vec<Uuid>, Vec<String>) = sqlx::query_as(
+        r#"SELECT sog.enabled, sog.title, sog.body, sog.recommended_channel_ids, sog.starter_tasks
+           FROM server_onboarding_guides sog
+           INNER JOIN servers s ON s.id = sog.server_id
+           WHERE s.invite_code = 'voxpery'"#,
+    )
+    .fetch_one(&state.db)
+    .await
+    .expect("default Voxpery server should have a seeded onboarding guide");
+
+    assert!(guide.0, "default Voxpery onboarding guide should be enabled");
+    assert_eq!(guide.1, "Welcome to the Voxpery Community");
+    assert!(
+        guide
+            .2
+            .contains("Start here, say hello, and jump into voice"),
+        "default Voxpery onboarding guide should explain the first session"
+    );
+    assert_eq!(
+        guide.3.len(),
+        2,
+        "default Voxpery onboarding guide should recommend text and voice channels"
+    );
+    assert_eq!(
+        guide.4,
+        vec![
+            "Send your first message in #general".to_string(),
+            "Join the General voice channel".to_string(),
+            "Explore the open-source project on GitHub".to_string(),
+        ]
+    );
+
     let moderator_permissions = sqlx::query_scalar::<_, i64>(
         r#"SELECT sr.permissions
            FROM server_roles sr

--- a/apps/web/src/components/ServerWelcomeGuide.test.tsx
+++ b/apps/web/src/components/ServerWelcomeGuide.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ServerWelcomeGuide from './ServerWelcomeGuide'
+import type { Channel, ServerOnboardingGuide } from '../api'
+
+const channels: Channel[] = [
+  {
+    id: 'text-1',
+    server_id: 'server-1',
+    name: 'general',
+    channel_type: 'text',
+    category: 'General',
+    position: 0,
+  },
+  {
+    id: 'voice-1',
+    server_id: 'server-1',
+    name: 'General',
+    channel_type: 'voice',
+    category: 'General',
+    position: 1,
+  },
+]
+
+const guide: ServerOnboardingGuide = {
+  server_id: 'server-1',
+  enabled: true,
+  title: 'Welcome to the Voxpery Community',
+  body: 'Start here, say hello, and jump into voice when you are ready.',
+  recommended_channel_ids: ['text-1', 'voice-1'],
+  starter_tasks: [
+    'Send your first message in #general',
+    'Join the General voice channel',
+    'Explore the open-source project on GitHub',
+  ],
+  updated_at: '2026-06-29T00:00:00.000Z',
+}
+
+describe('ServerWelcomeGuide', () => {
+  it('renders official community starter tasks and text/voice channel CTAs', () => {
+    const onSelectChannel = vi.fn()
+
+    render(
+      <ServerWelcomeGuide
+        guide={guide}
+        channels={channels}
+        serverName="Voxpery"
+        onSelectChannel={onSelectChannel}
+        onDismiss={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Welcome to the Voxpery Community' })).toBeInTheDocument()
+    expect(screen.getByText('Send your first message in #general')).toBeInTheDocument()
+    expect(screen.getByText('Join the General voice channel')).toBeInTheDocument()
+    expect(screen.getByText('Explore the open-source project on GitHub')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open channel general' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Join voice channel General' }))
+
+    expect(onSelectChannel).toHaveBeenNthCalledWith(1, 'text-1')
+    expect(onSelectChannel).toHaveBeenNthCalledWith(2, 'voice-1')
+  })
+})

--- a/apps/web/src/components/ServerWelcomeGuide.tsx
+++ b/apps/web/src/components/ServerWelcomeGuide.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Hash, X } from 'lucide-react'
+import { CheckCircle2, Hash, Mic, X } from 'lucide-react'
 import type { Channel, ServerOnboardingGuide } from '../api'
 
 interface ServerWelcomeGuideProps {
@@ -54,9 +54,10 @@ export default function ServerWelcomeGuide({
                             key={channel.id}
                             type="button"
                             className="server-welcome-guide__channel"
+                            aria-label={`${channel.channel_type === 'voice' ? 'Join voice channel' : 'Open channel'} ${channel.name}`}
                             onClick={() => onSelectChannel(channel.id)}
                         >
-                            <Hash size={14} />
+                            {channel.channel_type === 'voice' ? <Mic size={14} /> : <Hash size={14} />}
                             <span>{channel.name}</span>
                         </button>
                     ))}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Send default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
+- Seed the official Voxpery Community with an enabled onboarding guide that points new users toward first message, voice, and GitHub discovery actions.
 
 ### Security
 - Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.


### PR DESCRIPTION
## Summary
- Seed the official Voxpery Community with an enabled onboarding guide by default.
- Add first-session starter tasks for sending a first message, joining voice, and exploring GitHub.
- Recommend the default text and voice channels from the welcome guide.
- Render voice channel guide actions with a voice-specific label/icon.
- Add backend and frontend coverage for the default onboarding experience.

Closes #234

## Validation
- cargo test default_voxpery_server_has_moderator_role_after_register --locked
- cargo check --locked
- npm run lint
- npm run test:run
- npm run build