### PR TITLE
Feature/deferred notification permission

### DIFF
--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -2387,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/apps/web/src/components/NotificationPermissionPrompt.test.tsx
+++ b/apps/web/src/components/NotificationPermissionPrompt.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import NotificationPermissionPrompt from './NotificationPermissionPrompt'
+
+const originalNotificationDescriptor = Object.getOwnPropertyDescriptor(window, 'Notification')
+
+function installNotification(permission: NotificationPermission, nextPermission = permission) {
+  const requestPermission = vi.fn().mockResolvedValue(nextPermission)
+  Object.defineProperty(window, 'Notification', {
+    configurable: true,
+    value: {
+      permission,
+      requestPermission,
+    },
+  })
+  return requestPermission
+}
+
+describe('NotificationPermissionPrompt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+    if (originalNotificationDescriptor) {
+      Object.defineProperty(window, 'Notification', originalNotificationDescriptor)
+    } else {
+      Reflect.deleteProperty(window, 'Notification')
+    }
+  })
+
+  it('waits for product readiness and explicit user intent before requesting permission', async () => {
+    const requestPermission = installNotification('default', 'granted')
+    const { rerender } = render(<NotificationPermissionPrompt ready={false} delayMs={1_000} />)
+
+    act(() => vi.advanceTimersByTime(1_000))
+    expect(screen.queryByRole('region', { name: 'Enable notifications' })).not.toBeInTheDocument()
+    expect(requestPermission).not.toHaveBeenCalled()
+
+    rerender(<NotificationPermissionPrompt ready delayMs={1_000} />)
+    act(() => vi.advanceTimersByTime(999))
+    expect(screen.queryByRole('region', { name: 'Enable notifications' })).not.toBeInTheDocument()
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(screen.getByRole('region', { name: 'Enable notifications' })).toBeInTheDocument()
+    expect(requestPermission).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enable' }))
+    await act(async () => Promise.resolve())
+
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('voxpery-settings-push-enabled')).toBe('1')
+    expect(localStorage.getItem('voxpery-settings-push-explicit')).toBe('1')
+    expect(screen.queryByRole('region', { name: 'Enable notifications' })).not.toBeInTheDocument()
+  })
+
+  it('snoozes the soft prompt without opening the native permission dialog', () => {
+    const requestPermission = installNotification('default')
+    const { unmount } = render(<NotificationPermissionPrompt ready delayMs={0} />)
+
+    act(() => vi.runOnlyPendingTimers())
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }))
+
+    expect(requestPermission).not.toHaveBeenCalled()
+    expect(Number(localStorage.getItem('voxpery-push-prompt-snoozed-until'))).toBeGreaterThan(Date.now())
+    unmount()
+
+    render(<NotificationPermissionPrompt ready delayMs={0} />)
+    act(() => vi.runOnlyPendingTimers())
+    expect(screen.queryByRole('region', { name: 'Enable notifications' })).not.toBeInTheDocument()
+  })
+
+  it('does not offer the prompt after a notification preference was explicitly chosen', () => {
+    installNotification('default')
+    localStorage.setItem('voxpery-settings-push-explicit', '1')
+
+    render(<NotificationPermissionPrompt ready delayMs={0} />)
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(screen.queryByRole('region', { name: 'Enable notifications' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/NotificationPermissionPrompt.tsx
+++ b/apps/web/src/components/NotificationPermissionPrompt.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import {
+  PUSH_NOTIFICATION_STATE_CHANGED_EVENT,
+  requestPushNotificationPermission,
+  setPushNotificationsEnabled,
+  shouldOfferPushNotificationPrompt,
+  snoozePushNotificationPrompt,
+} from '../pushNotifications'
+
+const DEFAULT_PROMPT_DELAY_MS = 30_000
+
+interface NotificationPermissionPromptProps {
+  ready: boolean
+  delayMs?: number
+}
+
+export default function NotificationPermissionPrompt({
+  ready,
+  delayMs = DEFAULT_PROMPT_DELAY_MS,
+}: NotificationPermissionPromptProps) {
+  const [visible, setVisible] = useState(false)
+  const [requesting, setRequesting] = useState(false)
+
+  useEffect(() => {
+    setVisible(false)
+    if (!ready) return
+
+    const syncVisibility = () => {
+      if (!shouldOfferPushNotificationPrompt()) setVisible(false)
+    }
+    const timeoutId = window.setTimeout(() => {
+      setVisible(shouldOfferPushNotificationPrompt())
+    }, delayMs)
+
+    window.addEventListener(PUSH_NOTIFICATION_STATE_CHANGED_EVENT, syncVisibility)
+    return () => {
+      window.clearTimeout(timeoutId)
+      window.removeEventListener(PUSH_NOTIFICATION_STATE_CHANGED_EVENT, syncVisibility)
+    }
+  }, [delayMs, ready])
+
+  if (!visible) return null
+
+  const dismiss = () => {
+    snoozePushNotificationPrompt()
+    setVisible(false)
+  }
+
+  const enable = async () => {
+    if (requesting) return
+    setRequesting(true)
+    try {
+      const permission = await requestPushNotificationPermission()
+      if (permission === 'granted') {
+        setPushNotificationsEnabled(true, true)
+      } else if (permission === 'denied') {
+        setPushNotificationsEnabled(false, true)
+      } else {
+        snoozePushNotificationPrompt()
+      }
+      setVisible(false)
+    } catch {
+      snoozePushNotificationPrompt()
+      setVisible(false)
+    } finally {
+      setRequesting(false)
+    }
+  }
+
+  return (
+    <section className="shell-notification-cta" aria-label="Enable notifications">
+      <div className="shell-notification-cta-copy">
+        <strong>Stay in the loop</strong>
+        <span>Get alerts for direct messages and friend requests when Voxpery is in the background.</span>
+      </div>
+      <div className="shell-notification-cta-actions">
+        <button type="button" className="shell-notification-cta-dismiss" onClick={dismiss}>
+          Not now
+        </button>
+        <button
+          type="button"
+          className="shell-notification-cta-enable"
+          onClick={() => void enable()}
+          disabled={requesting}
+        >
+          {requesting ? 'Enabling...' : 'Enable'}
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12777,6 +12777,7 @@ textarea {
   }
 
   .shell-notification-cta {
+    flex-direction: column;
     align-items: flex-start;
     gap: 10px;
     padding: 10px;

--- a/apps/web/src/pages/AppShell.test.tsx
+++ b/apps/web/src/pages/AppShell.test.tsx
@@ -36,6 +36,10 @@ vi.mock('../components/UserBar', () => ({
   default: () => <div data-testid="user-bar" />,
 }))
 
+vi.mock('../components/NotificationPermissionPrompt', () => ({
+  default: () => null,
+}))
+
 vi.mock('../notificationSound', () => ({
   playMessageNotificationSound: vi.fn(),
   shouldPlayNotificationSound: vi.fn(() => false),

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from '../stores/app'
 import ActiveCallBar from '../components/ActiveCallBar'
 import QuickSwitcher, { type QuickSwitcherItem } from '../components/QuickSwitcher'
 import UserBar from '../components/UserBar'
+import NotificationPermissionPrompt from '../components/NotificationPermissionPrompt'
 import { useToastStore } from '../stores/toast'
 import { dmApi, friendApi, type DmChannel, type Friend, type User } from '../api'
 import { playMessageNotificationSound, shouldPlayNotificationSound } from '../notificationSound'
@@ -50,6 +51,7 @@ export default function AppShell() {
     setDmUnreadFromChannels,
     setFriends,
     setSocialDataReady,
+    socialDataReady,
     activeDmChannelId,
     setActiveServer,
     setActiveChannel,
@@ -70,6 +72,7 @@ export default function AppShell() {
       setDmUnreadFromChannels: s.setDmUnreadFromChannels,
       setFriends: s.setFriends,
       setSocialDataReady: s.setSocialDataReady,
+      socialDataReady: s.socialDataReady,
       activeDmChannelId: s.activeDmChannelId,
       setActiveServer: s.setActiveServer,
       setActiveChannel: s.setActiveChannel,
@@ -655,6 +658,7 @@ export default function AppShell() {
         </div>
       </header>
       <main className="shell-content">
+        <NotificationPermissionPrompt ready={socialDataReady} />
         <Outlet />
       </main>
       {/* Voice call bar — fixed to bottom of chat area, visible in both server and DM views */}

--- a/apps/web/src/pages/AuthNotificationPermission.test.tsx
+++ b/apps/web/src/pages/AuthNotificationPermission.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { User } from '../api'
+import { useFeatureStore } from '../stores/features'
+import LoginPage from './LoginPage'
+import RegisterPage from './RegisterPage'
+
+const authApiMocks = vi.hoisted(() => ({
+  login: vi.fn(),
+  register: vi.fn(),
+}))
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    authApi: {
+      ...actual.authApi,
+      login: authApiMocks.login,
+      register: authApiMocks.register,
+    },
+  }
+})
+
+const authUser: User = {
+  id: 'auth-user',
+  username: 'auth_user',
+  email: 'auth@example.test',
+  email_verified: true,
+  status: 'online',
+}
+
+const originalNotificationDescriptor = Object.getOwnPropertyDescriptor(window, 'Notification')
+
+function renderAuthPage(page: 'login' | 'register') {
+  return render(
+    <MemoryRouter initialEntries={[`/${page}`]}>
+      {page === 'login' ? <LoginPage /> : <RegisterPage />}
+    </MemoryRouter>,
+  )
+}
+
+describe('auth notification permission behavior', () => {
+  let requestPermission: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+    useFeatureStore.setState({
+      features: {
+        google_oauth_enabled: false,
+        email_delivery_enabled: false,
+        email_verification_enabled: false,
+        email_verification_required: false,
+        password_reset_enabled: false,
+      },
+      loading: false,
+      error: null,
+    })
+    requestPermission = vi.fn().mockResolvedValue('granted')
+    Object.defineProperty(window, 'Notification', {
+      configurable: true,
+      value: {
+        permission: 'default',
+        requestPermission,
+      },
+    })
+    authApiMocks.login.mockResolvedValue({ token: 'login-token', user: authUser })
+    authApiMocks.register.mockResolvedValue({ token: 'register-token', user: authUser })
+  })
+
+  afterEach(() => {
+    useFeatureStore.setState({ features: null, loading: false, error: null })
+    if (originalNotificationDescriptor) {
+      Object.defineProperty(window, 'Notification', originalNotificationDescriptor)
+    } else {
+      Reflect.deleteProperty(window, 'Notification')
+    }
+  })
+
+  it('does not request notification permission during login', async () => {
+    renderAuthPage('login')
+
+    fireEvent.change(screen.getByPlaceholderText('you@example.com or your_username'), {
+      target: { value: 'auth@example.test' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'password-123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
+
+    await waitFor(() => expect(authApiMocks.login).toHaveBeenCalledTimes(1))
+    expect(requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('does not request notification permission during registration', async () => {
+    renderAuthPage('register')
+
+    fireEvent.change(screen.getByPlaceholderText('your_username'), {
+      target: { value: 'auth_user' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'auth@example.test' },
+    })
+    const passwordInputs = screen.getAllByPlaceholderText('••••••••')
+    fireEvent.change(passwordInputs[0], { target: { value: 'password-123' } })
+    fireEvent.change(passwordInputs[1], { target: { value: 'password-123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    await waitFor(() => expect(authApiMocks.register).toHaveBeenCalledTimes(1))
+    expect(requestPermission).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -7,7 +7,6 @@ import { useFeatureStore } from '../stores/features'
 import { isTauri, setSecureToken } from '../secureStorage'
 import { openExternalUrl } from '../openExternalUrl'
 import { ROUTES } from '../routes'
-import { requestPushNotificationPermissionIfNeeded } from '../pushNotifications'
 import { setPersistedSocialView } from '../socialView'
 import { resolvePostAuthRoute } from '../authRedirect'
 
@@ -81,7 +80,6 @@ export default function LoginPage() {
         setLoading(true)
 
         try {
-            void requestPushNotificationPermissionIfNeeded()
             const res = await authApi.login(identifier, password)
             setAuth(res.token, res.user)
             setActiveDmChannelId(null)

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -8,7 +8,6 @@ import { useFeatureStore } from '../stores/features'
 import { isTauri, setSecureToken } from '../secureStorage'
 import { openExternalUrl } from '../openExternalUrl'
 import { ROUTES } from '../routes'
-import { requestPushNotificationPermissionIfNeeded } from '../pushNotifications'
 import { setPersistedSocialView } from '../socialView'
 import { resolvePostAuthRoute } from '../authRedirect'
 
@@ -90,7 +89,6 @@ export default function RegisterPage() {
 
         setLoading(true)
         try {
-            void requestPushNotificationPermissionIfNeeded()
             const res = await authApi.register(username, email, password, captchaToken || undefined)
             setAuth(res.token, res.user)
             setActiveDmChannelId(null)

--- a/apps/web/src/pushNotifications.ts
+++ b/apps/web/src/pushNotifications.ts
@@ -1,7 +1,14 @@
 const PUSH_KEY = 'voxpery-settings-push-enabled'
 const PUSH_EXPLICIT_KEY = 'voxpery-settings-push-explicit'
+const PUSH_PROMPT_SNOOZED_UNTIL_KEY = 'voxpery-push-prompt-snoozed-until'
 const APP_ICON = '/1024.png'
-const PERMISSION_PROMPTED_SESSION_KEY = 'voxpery-push-permission-prompted'
+export const PUSH_NOTIFICATION_STATE_CHANGED_EVENT = 'voxpery-push-notification-state-changed'
+export const PUSH_NOTIFICATION_PROMPT_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
+
+function notifyPushNotificationStateChanged(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(PUSH_NOTIFICATION_STATE_CHANGED_EVENT))
+}
 
 export function getPushNotificationsEnabled(): boolean {
   try {
@@ -26,6 +33,7 @@ export function setPushNotificationsEnabled(enabled: boolean, explicit = false):
   } catch {
     // ignore storage failures
   }
+  notifyPushNotificationStateChanged()
 }
 
 export function getPushNotificationPermission(): NotificationPermission | 'unsupported' {
@@ -35,26 +43,32 @@ export function getPushNotificationPermission(): NotificationPermission | 'unsup
 
 export async function requestPushNotificationPermission(): Promise<NotificationPermission | 'unsupported'> {
   if (typeof window === 'undefined' || !('Notification' in window)) return 'unsupported'
-  return window.Notification.requestPermission()
+  const permission = await window.Notification.requestPermission()
+  notifyPushNotificationStateChanged()
+  return permission
 }
 
-export async function requestPushNotificationPermissionIfNeeded(): Promise<NotificationPermission | 'unsupported'> {
+export function shouldOfferPushNotificationPrompt(now = Date.now()): boolean {
   const permission = getPushNotificationPermission()
-  if (permission === 'unsupported' || permission === 'granted' || permission === 'denied') return permission
-  if (!getPushNotificationsEnabled()) return permission
+  if (permission !== 'default' || hasExplicitPushPreference()) return false
   try {
-    if (sessionStorage.getItem(PERMISSION_PROMPTED_SESSION_KEY) === '1') return permission
+    const snoozedUntil = Number(localStorage.getItem(PUSH_PROMPT_SNOOZED_UNTIL_KEY) ?? '0')
+    return !Number.isFinite(snoozedUntil) || snoozedUntil <= now
   } catch {
-    // ignore sessionStorage failures
+    return true
   }
-  const nextPermission = await requestPushNotificationPermission()
+}
+
+export function snoozePushNotificationPrompt(
+  now = Date.now(),
+  durationMs = PUSH_NOTIFICATION_PROMPT_SNOOZE_MS,
+): void {
   try {
-    if (nextPermission === 'default') sessionStorage.removeItem(PERMISSION_PROMPTED_SESSION_KEY)
-    else sessionStorage.setItem(PERMISSION_PROMPTED_SESSION_KEY, '1')
+    localStorage.setItem(PUSH_PROMPT_SNOOZED_UNTIL_KEY, String(now + durationMs))
   } catch {
-    // ignore sessionStorage failures
+    // ignore storage failures
   }
-  return nextPermission
+  notifyPushNotificationStateChanged()
 }
 
 export function isAppBackgrounded(): boolean {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Send default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
 - Seed the official Voxpery Community with an enabled onboarding guide that points new users toward first message, voice, and GitHub discovery actions.
+- Defer browser and desktop notification permission requests until the authenticated app is ready and the user accepts a non-blocking in-app prompt.
 
 ### Security
 - Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.
+- Updated the server `spin` lockfile entry from yanked `0.9.8` to `0.9.9`.
 
 ## [0.2.3] - 2026-06-23
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -71,6 +71,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Raid protection records message bursts, invite spikes, and join burst signals in audit/moderation activity without exposing private secrets.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
 - [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
+- [ ] Login and registration do not open a native notification permission prompt; the delayed in-app prompt requests permission only after the user selects `Enable`, and `Not now` suppresses it during the snooze window.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.
 - [ ] Uploaded chat image attachments render inline after channel/server navigation and open only in the in-app preview modal on web and desktop, with no external tab/browser navigation.


### PR DESCRIPTION
## Summary

- remove native notification permission requests from login and registration
- show a delayed, non-blocking notification prompt after authenticated app data is ready
- request browser or desktop permission only after explicit user action
- snooze the prompt for seven days when the user selects `Not now`
- update the server lockfile from yanked `spin 0.9.8` to `0.9.9`
- add regression coverage and release smoke guidance

## Validation

- `npm run lint`
- `npm run test:run` — 179 tests passed
- `npm run build`
- `npm run test:e2e:ui-smoke` — 31 tests passed
- `cargo check --locked`
- `cargo test --locked`

Closes #236