### PR TITLE
fix: make critical write flows transaction-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,29 @@ jobs:
     name: Checks / Backend
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: voxpery_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: voxpery_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U voxpery_test -d voxpery_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -81,7 +104,10 @@ jobs:
 
       - name: Test
         working-directory: apps/server
-        run: cargo test --locked
+        env:
+          TEST_DATABASE_URL: postgres://voxpery_test:postgres@127.0.0.1:5432/voxpery_test
+          TEST_REDIS_URL: redis://127.0.0.1:6379
+        run: cargo test --locked -- --test-threads=1
 
   frontend:
     name: Checks / Frontend

--- a/apps/server/src/routes/channels.rs
+++ b/apps/server/src/routes/channels.rs
@@ -183,9 +183,23 @@ async fn delete_channel(
         .await?
         .ok_or(AppError::NotFound("Channel not found".into()))?;
 
-    // Require MANAGE_CHANNELS permission on this channel.
-    permissions::ensure_channel_permission(
-        &state.db,
+    let mut tx = state.db.begin().await?;
+    let locked_server_id =
+        sqlx::query_scalar::<_, Uuid>("SELECT id FROM servers WHERE id = $1 FOR NO KEY UPDATE")
+            .bind(channel.server_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Server not found".into()))?;
+
+    let channel = sqlx::query_as::<_, Channel>("SELECT * FROM channels WHERE id = $1 FOR UPDATE")
+        .bind(channel_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Channel not found".into()))?;
+    debug_assert_eq!(locked_server_id, channel.server_id);
+
+    permissions::ensure_channel_permission_on_connection(
+        &mut tx,
         channel_id,
         claims.sub,
         Permissions::MANAGE_CHANNELS,
@@ -198,7 +212,7 @@ async fn delete_channel(
             "SELECT COUNT(*) FROM channels WHERE server_id = $1 AND channel_type = 'text'",
         )
         .bind(channel.server_id)
-        .fetch_one(&state.db)
+        .fetch_one(&mut *tx)
         .await?;
         if text_count <= 1 {
             return Err(AppError::Validation(
@@ -207,8 +221,8 @@ async fn delete_channel(
         }
     }
 
-    audit::log(
-        &state.db,
+    audit::log_in_transaction(
+        &mut tx,
         claims.sub,
         Some(channel.server_id),
         "channel_delete",
@@ -220,8 +234,10 @@ async fn delete_channel(
 
     sqlx::query("DELETE FROM channels WHERE id = $1")
         .bind(channel_id)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
+
+    tx.commit().await?;
 
     crate::ws::publish_event(
         &state,

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -374,6 +374,21 @@ async fn get_or_create_dm_channel(
     // Always enforce peer's DM privacy (open and create). So if they unfriend you, you can't open the channel either.
     check_can_dm_peer(&state, claims.sub, peer_id).await?;
 
+    let (pair_low, pair_high) = if claims.sub < peer_id {
+        (claims.sub, peer_id)
+    } else {
+        (peer_id, claims.sub)
+    };
+    let pair_lock_key = format!("dm:{pair_low}:{pair_high}");
+    let mut tx = state.db.begin().await?;
+
+    // Serialize this user pair across all application instances before checking for an
+    // existing channel. This closes the check-then-insert race without changing legacy data.
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(pair_lock_key)
+        .execute(&mut *tx)
+        .await?;
+
     let existing = sqlx::query_scalar::<_, Uuid>(
         r#"SELECT c.id
            FROM dm_channels c
@@ -383,7 +398,7 @@ async fn get_or_create_dm_channel(
     )
     .bind(claims.sub)
     .bind(peer_id)
-    .fetch_optional(&state.db)
+    .fetch_optional(&mut *tx)
     .await?;
 
     let channel_id = if let Some(id) = existing {
@@ -392,21 +407,21 @@ async fn get_or_create_dm_channel(
         let id = Uuid::new_v4();
         sqlx::query("INSERT INTO dm_channels (id, created_at) VALUES ($1, NOW())")
             .bind(id)
-            .execute(&state.db)
+            .execute(&mut *tx)
             .await?;
         sqlx::query(
             "INSERT INTO dm_channel_members (channel_id, user_id, joined_at) VALUES ($1, $2, NOW())",
         )
         .bind(id)
         .bind(claims.sub)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
         sqlx::query(
             "INSERT INTO dm_channel_members (channel_id, user_id, joined_at) VALUES ($1, $2, NOW())",
         )
         .bind(id)
         .bind(peer_id)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
         id
     };
@@ -416,7 +431,7 @@ async fn get_or_create_dm_channel(
     )
     .bind(channel_id)
     .bind(claims.sub)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
     let info = sqlx::query_as::<_, DmChannelInfo>(
@@ -450,8 +465,10 @@ async fn get_or_create_dm_channel(
     )
     .bind(claims.sub)
     .bind(channel_id)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     let peer_status = visible_presence(
         &info.peer_status,

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -6,6 +6,7 @@ use axum::{
     Extension, Json, Router,
 };
 use chrono::{Duration as ChronoDuration, Utc};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::{
     net::{IpAddr, SocketAddr},
@@ -590,6 +591,7 @@ async fn create_server(
 
     let server_id = Uuid::new_v4();
     let invite_code = generate_invite_code();
+    let mut tx = state.db.begin().await?;
 
     let server = sqlx::query_as::<_, Server>(
         r#"INSERT INTO servers (id, name, icon_url, description, owner_id, invite_code, created_at)
@@ -602,7 +604,7 @@ async fn create_server(
     .bind(&body.description)
     .bind(claims.sub)
     .bind(&invite_code)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await?;
 
     // Add creator as owner member
@@ -611,7 +613,7 @@ async fn create_server(
     )
     .bind(server_id)
     .bind(claims.sub)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
     // Create default "general" text channel in a shared category.
@@ -621,7 +623,7 @@ async fn create_server(
     )
     .bind(Uuid::new_v4())
     .bind(server_id)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
     // Create default "General" voice channel under the same category.
@@ -631,7 +633,7 @@ async fn create_server(
     )
     .bind(Uuid::new_v4())
     .bind(server_id)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
     sqlx::query(
@@ -640,7 +642,7 @@ async fn create_server(
            ON CONFLICT (server_id, name) DO NOTHING"#,
     )
     .bind(server_id)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
     // Seed a default "Moderator" role for this server (no members yet).
@@ -660,7 +662,7 @@ async fn create_server(
     .bind(Uuid::new_v4())
     .bind(server_id)
     .bind(moderator_perms)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
     // Seed default "@everyone" baseline role.
@@ -674,8 +676,10 @@ async fn create_server(
     .bind(Uuid::new_v4())
     .bind(server_id)
     .bind(everyone_perms)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(Json(server))
 }
@@ -1644,127 +1648,157 @@ async fn update_member_roles(
     Path((server_id, user_id)): Path<(Uuid, Uuid)>,
     Json(body): Json<UpdateMemberRolesRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    permissions::ensure_server_permission(
-        &state.db,
+    if body.role_ids.len() > MAX_REORDER_ROLE_IDS {
+        return Err(AppError::Validation("Too many role_ids".into()));
+    }
+    let requested_role_ids = body.role_ids;
+    let requested_role_set: HashSet<Uuid> = requested_role_ids.iter().copied().collect();
+    if requested_role_set.len() != requested_role_ids.len() {
+        return Err(AppError::Validation(
+            "Duplicate role_ids are not allowed".into(),
+        ));
+    }
+
+    let mut tx = state.db.begin().await?;
+    let owner_id = sqlx::query_scalar::<_, Uuid>(
+        "SELECT owner_id FROM servers WHERE id = $1 FOR NO KEY UPDATE",
+    )
+    .bind(server_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Server not found".into()))?;
+
+    permissions::ensure_server_permission_on_connection(
+        &mut tx,
         server_id,
         claims.sub,
         Permissions::MANAGE_ROLES,
     )
     .await?;
 
-    let owner_id: Option<Uuid> = sqlx::query_scalar("SELECT owner_id FROM servers WHERE id = $1")
-        .bind(server_id)
-        .fetch_optional(&state.db)
-        .await?;
-
     // Only the server owner themselves may change the owner's roles.
-    if owner_id == Some(user_id) && owner_id != Some(claims.sub) {
+    if owner_id == user_id && owner_id != claims.sub {
         return Err(AppError::Forbidden(
             "Only the server owner can change their own roles".into(),
         ));
     }
 
-    // Ensure target user is a member of this server.
-    let exists = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM server_members WHERE server_id = $1 AND user_id = $2",
+    let target_member_role = sqlx::query_scalar::<_, String>(
+        "SELECT role FROM server_members WHERE server_id = $1 AND user_id = $2 FOR UPDATE",
     )
     .bind(server_id)
     .bind(user_id)
-    .fetch_one(&state.db)
+    .fetch_optional(&mut *tx)
     .await?;
-    if exists == 0 {
+    if target_member_role.is_none() {
         return Err(AppError::NotFound("Member not found".into()));
     }
 
-    // Role Hierarchy Security
-    let caller_pos =
-        permissions::get_user_highest_role_position(&state.db, server_id, claims.sub).await?;
-    let target_pos =
-        permissions::get_user_highest_role_position(&state.db, server_id, user_id).await?;
+    let (caller_role_pos, target_role_pos): (Option<i32>, Option<i32>) = sqlx::query_as(
+        r#"SELECT
+               (SELECT MIN(sr.position)
+                FROM server_member_roles smr
+                INNER JOIN server_roles sr ON sr.id = smr.role_id
+                WHERE smr.server_id = $1 AND smr.user_id = $2),
+               (SELECT MIN(sr.position)
+                FROM server_member_roles smr
+                INNER JOIN server_roles sr ON sr.id = smr.role_id
+                WHERE smr.server_id = $1 AND smr.user_id = $3)"#,
+    )
+    .bind(server_id)
+    .bind(claims.sub)
+    .bind(user_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    let caller_pos = if owner_id == claims.sub {
+        -1
+    } else {
+        caller_role_pos.unwrap_or(i32::MAX)
+    };
+    let target_pos = if owner_id == user_id {
+        -1
+    } else {
+        target_role_pos.unwrap_or(i32::MAX)
+    };
 
     // 1. Cannot modify someone with a higher or equal role.
-    if caller_pos >= target_pos && claims.sub != user_id && owner_id != Some(claims.sub) {
+    if caller_pos >= target_pos && claims.sub != user_id && owner_id != claims.sub {
         return Err(AppError::Forbidden(
             "You cannot modify the roles of a member with an equal or higher role".into(),
         ));
     }
 
-    // 2. Cannot assign or remove roles that are higher or equal to the caller's highest role.
-    // First, check the new roles being assigned.
-    for role_id in &body.role_ids {
-        let role_row = sqlx::query_as::<_, (i32, String)>(
-            "SELECT position, name FROM server_roles WHERE id = $1 AND server_id = $2",
+    let requested_roles: Vec<(Uuid, i32, String)> = if requested_role_ids.is_empty() {
+        Vec::new()
+    } else {
+        sqlx::query_as(
+            "SELECT id, position, name FROM server_roles WHERE server_id = $1 AND id = ANY($2)",
         )
-        .bind(role_id)
         .bind(server_id)
-        .fetch_optional(&state.db)
-        .await?;
-
-        let (pos, name) = role_row
-            .ok_or_else(|| AppError::Validation("One or more role_ids are invalid".into()))?;
-
+        .bind(requested_role_ids.as_slice())
+        .fetch_all(&mut *tx)
+        .await?
+    };
+    if requested_roles.len() != requested_role_ids.len() {
+        return Err(AppError::Validation(
+            "One or more role_ids are invalid".into(),
+        ));
+    }
+    for (_, pos, name) in &requested_roles {
         if name.eq_ignore_ascii_case("everyone") {
             return Err(AppError::Validation(
                 "The Everyone role is system-managed and cannot be assigned manually".into(),
             ));
         }
-
-        if caller_pos >= pos && owner_id != Some(claims.sub) {
+        if caller_pos >= *pos && owner_id != claims.sub {
             return Err(AppError::Forbidden(
                 "You cannot assign a role higher or equal to your own highest role".into(),
             ));
         }
     }
 
-    // Then, check the roles being removed (roles they currently have but aren't in the new list).
-    let old_role_ids: Vec<Uuid> = sqlx::query_scalar(
-        "SELECT role_id FROM server_member_roles WHERE server_id = $1 AND user_id = $2",
+    let old_roles: Vec<(Uuid, i32, String)> = sqlx::query_as(
+        r#"SELECT smr.role_id, sr.position, sr.name
+           FROM server_member_roles smr
+           INNER JOIN server_roles sr ON sr.id = smr.role_id
+           WHERE smr.server_id = $1 AND smr.user_id = $2"#,
     )
     .bind(server_id)
     .bind(user_id)
-    .fetch_all(&state.db)
+    .fetch_all(&mut *tx)
     .await?;
-
-    for old_role_id in &old_role_ids {
-        if !body.role_ids.contains(old_role_id) {
-            let role_row = sqlx::query_as::<_, (i32, String)>(
-                "SELECT position, name FROM server_roles WHERE id = $1 AND server_id = $2",
-            )
-            .bind(old_role_id)
-            .bind(server_id)
-            .fetch_optional(&state.db)
-            .await?;
-
-            if let Some((pos, name)) = role_row {
-                if name.eq_ignore_ascii_case("everyone") {
-                    continue;
-                }
-                if caller_pos >= pos && owner_id != Some(claims.sub) {
-                    return Err(AppError::Forbidden(
-                        "You cannot remove a role higher or equal to your own highest role".into(),
-                    ));
-                }
-            }
+    let old_role_ids: Vec<Uuid> = old_roles.iter().map(|(id, _, _)| *id).collect();
+    for (old_role_id, pos, name) in &old_roles {
+        if !requested_role_set.contains(old_role_id)
+            && !name.eq_ignore_ascii_case("everyone")
+            && caller_pos >= *pos
+            && owner_id != claims.sub
+        {
+            return Err(AppError::Forbidden(
+                "You cannot remove a role higher or equal to your own highest role".into(),
+            ));
         }
     }
 
-    let is_owner = owner_id == Some(user_id);
+    let is_owner = owner_id == user_id;
 
     // Replace all current roles with the provided set.
     sqlx::query("DELETE FROM server_member_roles WHERE server_id = $1 AND user_id = $2")
         .bind(server_id)
         .bind(user_id)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
 
-    for role_id in &body.role_ids {
+    if !requested_role_ids.is_empty() {
         sqlx::query(
-            "INSERT INTO server_member_roles (server_id, user_id, role_id) VALUES ($1, $2, $3)",
+            r#"INSERT INTO server_member_roles (server_id, user_id, role_id)
+               SELECT $1, $2, requested.role_id
+               FROM UNNEST($3::uuid[]) AS requested(role_id)"#,
         )
         .bind(server_id)
         .bind(user_id)
-        .bind(*role_id)
-        .execute(&state.db)
+        .bind(requested_role_ids.as_slice())
+        .execute(&mut *tx)
         .await?;
     }
 
@@ -1776,12 +1810,12 @@ async fn update_member_roles(
         .bind(new_legacy_role)
         .bind(server_id)
         .bind(user_id)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
 
     // Audit log: record granular role changes.
-    audit::log(
-        &state.db,
+    audit::log_in_transaction(
+        &mut tx,
         claims.sub,
         Some(server_id),
         "member_role_change",
@@ -1789,11 +1823,13 @@ async fn update_member_roles(
         Some(user_id),
         Some(serde_json::json!({
             "old_role_ids": old_role_ids,
-            "new_role_ids": body.role_ids,
+            "new_role_ids": requested_role_ids,
             "legacy_role": new_legacy_role,
         })),
     )
     .await?;
+
+    tx.commit().await?;
 
     // Notify clients via WebSocket so member list / badges update without full reload.
     crate::ws::publish_event(
@@ -1806,12 +1842,19 @@ async fn update_member_roles(
     )
     .await;
 
-    voice_revoke::revoke_invalid_voice_sessions_for_server(
+    if let Err(error) = voice_revoke::revoke_invalid_voice_sessions_for_server(
         &state,
         server_id,
         "member roles updated",
     )
-    .await?;
+    .await
+    {
+        tracing::error!(
+            "Post-commit voice permission reconciliation failed for server {}: {}",
+            server_id,
+            error
+        );
+    }
 
     Ok(Json(
         serde_json::json!({ "message": "Member roles updated" }),
@@ -1824,58 +1867,47 @@ async fn update_member_role(
     Path((server_id, user_id)): Path<(Uuid, Uuid)>,
     Json(body): Json<UpdateMemberRoleRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    // Only owner can manage roles
-    let server = sqlx::query_as::<_, Server>("SELECT * FROM servers WHERE id = $1")
-        .bind(server_id)
-        .fetch_optional(&state.db)
-        .await?
-        .ok_or(AppError::NotFound("Server not found".into()))?;
+    if body.role != "admin" && body.role != "member" {
+        return Err(AppError::Validation("Invalid role".into()));
+    }
 
-    if server.owner_id != claims.sub {
+    let mut tx = state.db.begin().await?;
+    let owner_id = sqlx::query_scalar::<_, Uuid>(
+        "SELECT owner_id FROM servers WHERE id = $1 FOR NO KEY UPDATE",
+    )
+    .bind(server_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Server not found".into()))?;
+    if owner_id != claims.sub {
         return Err(AppError::Forbidden(
             "Only the server owner can change member roles".into(),
         ));
     }
-
-    // Do not allow changing the owner role via this endpoint
-    if user_id == server.owner_id {
+    if user_id == owner_id {
         return Err(AppError::Validation(
             "Cannot change the owner's role via this endpoint".into(),
         ));
     }
 
-    if body.role != "admin" && body.role != "member" {
-        return Err(AppError::Validation("Invalid role".into()));
-    }
-
-    let exists = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM server_members WHERE server_id = $1 AND user_id = $2",
+    let old_role = sqlx::query_scalar::<_, String>(
+        "SELECT role FROM server_members WHERE server_id = $1 AND user_id = $2 FOR UPDATE",
     )
     .bind(server_id)
     .bind(user_id)
-    .fetch_one(&state.db)
-    .await?;
-
-    if exists == 0 {
-        return Err(AppError::NotFound("Member not found".into()));
-    }
-
-    let old_role: String =
-        sqlx::query_scalar("SELECT role FROM server_members WHERE server_id = $1 AND user_id = $2")
-            .bind(server_id)
-            .bind(user_id)
-            .fetch_one(&state.db)
-            .await?;
+    .fetch_optional(&mut *tx)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Member not found".into()))?;
 
     sqlx::query("UPDATE server_members SET role = $1 WHERE server_id = $2 AND user_id = $3")
         .bind(&body.role)
         .bind(server_id)
         .bind(user_id)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
 
-    audit::log(
-        &state.db,
+    audit::log_in_transaction(
+        &mut tx,
         claims.sub,
         Some(server_id),
         "member_role_change",
@@ -1884,6 +1916,8 @@ async fn update_member_role(
         Some(serde_json::json!({ "old_role": old_role, "new_role": body.role })),
     )
     .await?;
+
+    tx.commit().await?;
 
     crate::ws::publish_event(
         &state,
@@ -1895,12 +1929,19 @@ async fn update_member_role(
     )
     .await;
 
-    voice_revoke::revoke_invalid_voice_sessions_for_server(
+    if let Err(error) = voice_revoke::revoke_invalid_voice_sessions_for_server(
         &state,
         server_id,
         "member role updated",
     )
-    .await?;
+    .await
+    {
+        tracing::error!(
+            "Post-commit voice permission reconciliation failed for server {}: {}",
+            server_id,
+            error
+        );
+    }
 
     Ok(Json(serde_json::json!({ "message": "Role updated" })))
 }

--- a/apps/server/src/services/audit.rs
+++ b/apps/server/src/services/audit.rs
@@ -1,6 +1,6 @@
 //! Moderation-critical audit log: who did what and when.
 
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 /// Insert an audit log entry. Caller must provide valid server_id where applicable.
@@ -24,6 +24,31 @@ pub async fn log(
     .bind(resource_id)
     .bind(details)
     .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Insert an audit entry as part of an existing database transaction.
+pub async fn log_in_transaction(
+    tx: &mut Transaction<'_, Postgres>,
+    actor_id: Uuid,
+    server_id: Option<Uuid>,
+    action: &str,
+    resource_type: &str,
+    resource_id: Option<Uuid>,
+    details: Option<serde_json::Value>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"INSERT INTO audit_log (actor_id, server_id, action, resource_type, resource_id, details)
+           VALUES ($1, $2, $3, $4, $5, $6)"#,
+    )
+    .bind(actor_id)
+    .bind(server_id)
+    .bind(action)
+    .bind(resource_type)
+    .bind(resource_id)
+    .bind(details)
+    .execute(&mut **tx)
     .await?;
     Ok(())
 }

--- a/apps/server/src/services/permissions.rs
+++ b/apps/server/src/services/permissions.rs
@@ -1,4 +1,4 @@
-use sqlx::PgPool;
+use sqlx::{PgConnection, PgPool};
 use uuid::Uuid;
 
 use crate::errors::AppError;
@@ -32,10 +32,19 @@ pub async fn get_user_server_permissions(
     server_id: Uuid,
     user_id: Uuid,
 ) -> Result<Permissions, AppError> {
+    let mut connection = db.acquire().await?;
+    get_user_server_permissions_on_connection(&mut connection, server_id, user_id).await
+}
+
+pub async fn get_user_server_permissions_on_connection(
+    db: &mut PgConnection,
+    server_id: Uuid,
+    user_id: Uuid,
+) -> Result<Permissions, AppError> {
     // Owner always has all permissions.
     let owner_id: Option<Uuid> = sqlx::query_scalar("SELECT owner_id FROM servers WHERE id = $1")
         .bind(server_id)
-        .fetch_optional(db)
+        .fetch_optional(&mut *db)
         .await?;
 
     if owner_id.map(|id| id == user_id).unwrap_or(false) {
@@ -48,7 +57,7 @@ pub async fn get_user_server_permissions(
     )
     .bind(server_id)
     .bind(user_id)
-    .fetch_one(db)
+    .fetch_one(&mut *db)
     .await?;
     if is_member == 0 {
         return Ok(Permissions::empty());
@@ -71,7 +80,7 @@ pub async fn get_user_server_permissions(
     )
     .bind(server_id)
     .bind(user_id)
-    .fetch_all(db)
+    .fetch_all(&mut *db)
     .await?;
 
     let mut perms = Permissions::empty();
@@ -94,11 +103,20 @@ pub async fn get_user_channel_permissions(
     channel_id: Uuid,
     user_id: Uuid,
 ) -> Result<Permissions, AppError> {
+    let mut connection = db.acquire().await?;
+    get_user_channel_permissions_on_connection(&mut connection, channel_id, user_id).await
+}
+
+pub async fn get_user_channel_permissions_on_connection(
+    db: &mut PgConnection,
+    channel_id: Uuid,
+    user_id: Uuid,
+) -> Result<Permissions, AppError> {
     // Resolve server_id and category from channel.
     let channel_row: Option<(Uuid, Option<String>)> =
         sqlx::query_as("SELECT server_id, category FROM channels WHERE id = $1")
             .bind(channel_id)
-            .fetch_optional(db)
+            .fetch_optional(&mut *db)
             .await?;
 
     let (server_id, category) = match channel_row {
@@ -106,7 +124,8 @@ pub async fn get_user_channel_permissions(
         None => return Ok(Permissions::empty()),
     };
 
-    let mut perms: Permissions = get_user_server_permissions(db, server_id, user_id).await?;
+    let mut perms: Permissions =
+        get_user_server_permissions_on_connection(&mut *db, server_id, user_id).await?;
     // Full admin (MANAGE_SERVER) bypasses channel/category overrides.
     if perms.contains(Permissions::MANAGE_SERVER) {
         return Ok(Permissions::all());
@@ -135,7 +154,7 @@ pub async fn get_user_channel_permissions(
         .bind(server_id)
         .bind(user_id)
         .bind(category_name)
-        .fetch_all(db)
+        .fetch_all(&mut *db)
         .await?;
 
         let mut deny_mask = Permissions::empty();
@@ -174,7 +193,7 @@ pub async fn get_user_channel_permissions(
     .bind(server_id)
     .bind(user_id)
     .bind(channel_id)
-    .fetch_all(db)
+    .fetch_all(&mut *db)
     .await?;
 
     let mut deny_mask = Permissions::empty();
@@ -272,6 +291,20 @@ pub async fn ensure_server_permission(
     }
 }
 
+pub async fn ensure_server_permission_on_connection(
+    db: &mut PgConnection,
+    server_id: Uuid,
+    user_id: Uuid,
+    required: Permissions,
+) -> Result<(), AppError> {
+    let perms = get_user_server_permissions_on_connection(db, server_id, user_id).await?;
+    if perms.contains(required) {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden("Missing required permission".into()))
+    }
+}
+
 pub async fn ensure_channel_permission(
     db: &PgPool,
     channel_id: Uuid,
@@ -279,6 +312,20 @@ pub async fn ensure_channel_permission(
     required: Permissions,
 ) -> Result<(), AppError> {
     let perms: Permissions = get_user_channel_permissions(db, channel_id, user_id).await?;
+    if perms.contains(required) {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden("Missing required permission".into()))
+    }
+}
+
+pub async fn ensure_channel_permission_on_connection(
+    db: &mut PgConnection,
+    channel_id: Uuid,
+    user_id: Uuid,
+    required: Permissions,
+) -> Result<(), AppError> {
+    let perms = get_user_channel_permissions_on_connection(db, channel_id, user_id).await?;
     if perms.contains(required) {
         Ok(())
     } else {

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -984,6 +984,24 @@ async fn create_server_seeds_recommended_moderator_permissions() {
         creator_has_everyone, 0,
         "@everyone is implicit and should not require explicit member-role row"
     );
+
+    let bootstrap_counts: (i64, i64, i64, i64) = sqlx::query_as(
+        r#"SELECT
+               (SELECT COUNT(*) FROM server_members WHERE server_id = $1 AND user_id = $2),
+               (SELECT COUNT(*) FROM channels WHERE server_id = $1 AND channel_type = 'text'),
+               (SELECT COUNT(*) FROM channels WHERE server_id = $1 AND channel_type = 'voice'),
+               (SELECT COUNT(*) FROM server_channel_categories WHERE server_id = $1)"#,
+    )
+    .bind(server_id)
+    .bind(creator_user_id)
+    .fetch_one(&state.db)
+    .await
+    .expect("server bootstrap state should be readable");
+    assert_eq!(
+        bootstrap_counts,
+        (1, 1, 1, 1),
+        "server creation must commit its owner, channels, and category together"
+    );
 }
 
 #[tokio::test]
@@ -3170,4 +3188,334 @@ async fn channel_create_race_is_serialized_at_500_channel_limit() {
         total_channels, 500,
         "row lock must keep channel count capped at 500"
     );
+}
+
+#[tokio::test]
+async fn dm_channel_create_race_returns_one_shared_channel() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    let alice_username = format!("dmalice{}", &suffix[..8]);
+    let bob_username = format!("dmbob{}", &suffix[8..16]);
+    let (alice_token, alice_id) = register_user(
+        &mut app,
+        &format!("{alice_username}@example.com"),
+        &alice_username,
+        test_credential("default"),
+    )
+    .await;
+    let (_, bob_id) = register_user(
+        &mut app,
+        &format!("{bob_username}@example.com"),
+        &bob_username,
+        test_credential("default"),
+    )
+    .await;
+    let auth_header = format!("Bearer {alice_token}");
+
+    let request = || {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/dm/channels/{bob_id}"))
+            .header("Authorization", &auth_header)
+            .body(Body::empty())
+            .unwrap()
+    };
+    let (response_a, response_b) = tokio::join!(
+        app.clone().oneshot(request()),
+        app.clone().oneshot(request())
+    );
+    let response_a = response_a.expect("DM create request A should resolve");
+    let response_b = response_b.expect("DM create request B should resolve");
+    assert_eq!(response_a.status(), StatusCode::OK);
+    assert_eq!(response_b.status(), StatusCode::OK);
+
+    let body_a = response_a.into_body().collect().await.unwrap().to_bytes();
+    let body_b = response_b.into_body().collect().await.unwrap().to_bytes();
+    let channel_a: serde_json::Value = serde_json::from_slice(&body_a).unwrap();
+    let channel_b: serde_json::Value = serde_json::from_slice(&body_b).unwrap();
+    assert_eq!(channel_a["id"], channel_b["id"]);
+
+    let pair_channel_count: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*)
+           FROM dm_channels c
+           WHERE EXISTS (
+               SELECT 1 FROM dm_channel_members m
+               WHERE m.channel_id = c.id AND m.user_id = $1
+           )
+             AND EXISTS (
+               SELECT 1 FROM dm_channel_members m
+               WHERE m.channel_id = c.id AND m.user_id = $2
+           )"#,
+    )
+    .bind(alice_id)
+    .bind(bob_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(pair_channel_count, 1, "a DM pair must have one channel");
+}
+
+#[tokio::test]
+async fn concurrent_member_role_replacements_leave_one_complete_state() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+
+    let owner_suffix = Uuid::new_v4();
+    let (owner_token, _) = register_user(
+        &mut app,
+        &format!("role-owner-{owner_suffix}@example.com"),
+        &format!("role_owner_{}", owner_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let member_suffix = Uuid::new_v4();
+    let (member_token, member_id) = register_user(
+        &mut app,
+        &format!("role-member-{member_suffix}@example.com"),
+        &format!("role_member_{}", member_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let owner_auth = format!("Bearer {owner_token}");
+    let member_auth = format!("Bearer {member_token}");
+
+    let create_server_request = Request::builder()
+        .method("POST")
+        .uri("/api/servers")
+        .header("Authorization", &owner_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "name": "Role Race Server" })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, create_server_request).await;
+    assert_eq!(status, StatusCode::OK);
+    let server: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let server_id = Uuid::parse_str(server["id"].as_str().unwrap()).unwrap();
+    let invite_code = server["invite_code"].as_str().unwrap();
+
+    let join_request = Request::builder()
+        .method("POST")
+        .uri("/api/servers/join")
+        .header("Authorization", &member_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "invite_code": invite_code })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, join_request).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "member join failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let mut role_ids = Vec::new();
+    for name in ["Race Alpha", "Race Beta"] {
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("/api/servers/{server_id}/roles"))
+            .header("Authorization", &owner_auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "name": name,
+                    "permissions": 0,
+                    "color": null
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let (status, body) = oneshot(&mut app, request).await;
+        assert_eq!(status, StatusCode::OK);
+        let role: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        role_ids.push(Uuid::parse_str(role["id"].as_str().unwrap()).unwrap());
+    }
+
+    let role_request = |role_id: Uuid| {
+        Request::builder()
+            .method("PUT")
+            .uri(format!(
+                "/api/servers/{server_id}/members/{member_id}/roles"
+            ))
+            .header("Authorization", &owner_auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "role_ids": [role_id] })).unwrap(),
+            ))
+            .unwrap()
+    };
+    let (response_a, response_b) = tokio::join!(
+        app.clone().oneshot(role_request(role_ids[0])),
+        app.clone().oneshot(role_request(role_ids[1]))
+    );
+    assert_eq!(
+        response_a.expect("role request A should resolve").status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        response_b.expect("role request B should resolve").status(),
+        StatusCode::OK
+    );
+
+    let assigned_role_ids: Vec<Uuid> = sqlx::query_scalar(
+        "SELECT role_id FROM server_member_roles WHERE server_id = $1 AND user_id = $2",
+    )
+    .bind(server_id)
+    .bind(member_id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(assigned_role_ids.len(), 1);
+    assert!(role_ids.contains(&assigned_role_ids[0]));
+
+    let invalid_role_request = Request::builder()
+        .method("PUT")
+        .uri(format!(
+            "/api/servers/{server_id}/members/{member_id}/roles"
+        ))
+        .header("Authorization", &owner_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "role_ids": [assigned_role_ids[0], Uuid::new_v4()]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let (status, _) = oneshot(&mut app, invalid_role_request).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let roles_after_rejection: Vec<Uuid> = sqlx::query_scalar(
+        "SELECT role_id FROM server_member_roles WHERE server_id = $1 AND user_id = $2",
+    )
+    .bind(server_id)
+    .bind(member_id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(roles_after_rejection, assigned_role_ids);
+
+    let legacy_role: String =
+        sqlx::query_scalar("SELECT role FROM server_members WHERE server_id = $1 AND user_id = $2")
+            .bind(server_id)
+            .bind(member_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    assert_eq!(legacy_role, "member");
+}
+
+#[tokio::test]
+async fn concurrent_text_channel_deletes_preserve_one_channel() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+
+    let suffix = Uuid::new_v4();
+    let (owner_token, _) = register_user(
+        &mut app,
+        &format!("delete-race-{suffix}@example.com"),
+        &format!("delete_race_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let owner_auth = format!("Bearer {owner_token}");
+
+    let create_server_request = Request::builder()
+        .method("POST")
+        .uri("/api/servers")
+        .header("Authorization", &owner_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "name": "Delete Race Server" })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, create_server_request).await;
+    assert_eq!(status, StatusCode::OK);
+    let server: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let server_id = Uuid::parse_str(server["id"].as_str().unwrap()).unwrap();
+    let first_channel_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM channels WHERE server_id = $1 AND channel_type = 'text' LIMIT 1",
+    )
+    .bind(server_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+
+    let create_channel_request = Request::builder()
+        .method("POST")
+        .uri("/api/channels")
+        .header("Authorization", &owner_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "server_id": server_id,
+                "name": "second-text",
+                "channel_type": "text"
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, create_channel_request).await;
+    assert_eq!(status, StatusCode::OK);
+    let second_channel: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let second_channel_id = Uuid::parse_str(second_channel["id"].as_str().unwrap()).unwrap();
+
+    let delete_request = |channel_id: Uuid| {
+        Request::builder()
+            .method("DELETE")
+            .uri(format!("/api/channels/{channel_id}"))
+            .header("Authorization", &owner_auth)
+            .body(Body::empty())
+            .unwrap()
+    };
+    let (response_a, response_b) = tokio::join!(
+        app.clone().oneshot(delete_request(first_channel_id)),
+        app.clone().oneshot(delete_request(second_channel_id))
+    );
+    let status_a = response_a
+        .expect("delete request A should resolve")
+        .status();
+    let status_b = response_b
+        .expect("delete request B should resolve")
+        .status();
+    let success_count = [status_a, status_b]
+        .iter()
+        .filter(|status| **status == StatusCode::OK)
+        .count();
+    let rejected_count = [status_a, status_b]
+        .iter()
+        .filter(|status| **status == StatusCode::BAD_REQUEST)
+        .count();
+    assert_eq!(success_count, 1);
+    assert_eq!(rejected_count, 1);
+
+    let remaining_text_channels: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM channels WHERE server_id = $1 AND channel_type = 'text'",
+    )
+    .bind(server_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(remaining_text_channels, 1);
+
+    let delete_audit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_log WHERE server_id = $1 AND action = 'channel_delete'",
+    )
+    .bind(server_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(delete_audit_count, 1);
 }

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -58,6 +58,13 @@ fn redis_client() -> redis::Client {
 }
 
 async fn setup_app() -> (axum::Router, Arc<AppState>) {
+    setup_app_with_auth_features(false, false).await
+}
+
+async fn setup_app_with_auth_features(
+    email_verification_enabled: bool,
+    password_reset_enabled: bool,
+) -> (axum::Router, Arc<AppState>) {
     let database_url = test_db_url().expect("DATABASE_URL must be set for integration tests");
     let db = PgPoolOptions::new()
         .max_connections(5)
@@ -118,9 +125,9 @@ async fn setup_app() -> (axum::Router, Arc<AppState>) {
         smtp_password: None,
         smtp_user: None,
         email_delivery_enabled: false,
-        email_verification_enabled: false,
+        email_verification_enabled,
         email_verification_required: false,
-        password_reset_enabled: false,
+        password_reset_enabled,
         attachment_service: Arc::new(attachment_service),
         release_http_client,
         latest_release_cache: tokio::sync::RwLock::new(None),
@@ -2373,7 +2380,7 @@ async fn password_reset_invalidates_old_token() {
         eprintln!("SKIP: DATABASE_URL not set");
         return;
     };
-    let (mut app, state) = setup_app().await;
+    let (mut app, state) = setup_app_with_auth_features(false, true).await;
 
     let uid = Uuid::new_v4();
     let email = format!("pwreset-{}@example.com", uid);
@@ -2909,7 +2916,7 @@ async fn forgot_password_rate_limit_blocks_after_three_attempts() {
         eprintln!("SKIP: DATABASE_URL not set");
         return;
     };
-    let (mut app, _) = setup_app().await;
+    let (mut app, _) = setup_app_with_auth_features(false, true).await;
 
     let email = format!("forgot-rate-limit-{}@example.com", Uuid::new_v4());
     for attempt in 0..3 {
@@ -3005,7 +3012,7 @@ async fn email_verification_confirm_works_without_existing_session() {
         eprintln!("SKIP: DATABASE_URL not set");
         return;
     };
-    let (mut app, state) = setup_app().await;
+    let (mut app, state) = setup_app_with_auth_features(true, false).await;
 
     let uid = Uuid::new_v4();
     let email = format!("verify-{}@example.com", uid);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Send default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
 - Seed the official Voxpery Community with an enabled onboarding guide that points new users toward first message, voice, and GitHub discovery actions.
 - Defer browser and desktop notification permission requests until the authenticated app is ready and the user accepts a non-blocking in-app prompt.
+- Serialize critical DM creation, server bootstrap, member-role replacement, and channel deletion writes so concurrent requests cannot leave duplicate or partial state.
+- Run backend integration and concurrency tests in CI against isolated PostgreSQL and Redis services instead of silently skipping database coverage.
 
 ### Security
 - Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.
 - Updated the server `spin` lockfile entry from yanked `0.9.8` to `0.9.9`.
+- Re-check permissions inside locked database transactions and commit matching audit entries atomically with role and channel mutations.
 
 ## [0.2.3] - 2026-06-23
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -199,6 +199,17 @@ Uniqueness (case-insensitive):
 - malware fields: `scan_status`, `malware_signature`
 - `created_at`
 
+## Transactional Write Invariants
+
+Critical multi-row writes use explicit PostgreSQL transactions and serialize competing requests before checking invariants:
+
+- Direct-message creation acquires a transaction-scoped advisory lock for the canonical user pair. Channel creation, both membership rows, and caller unhide then commit together, so concurrent opens resolve to one shared DM.
+- Server creation commits the server, owner membership, default text/voice channels, default category, and bootstrap roles as one unit. A failed bootstrap cannot expose a partially initialized server.
+- Member-role replacement locks the server and target membership rows, re-checks permissions on the same connection, validates requested roles in one batch, replaces assignments in bulk, updates the legacy bridge role, and writes its audit entry in one transaction.
+- Channel creation and deletion serialize on the same server-row lock. Text-channel deletion counts the remaining channels while holding that lock, so concurrent deletes cannot remove the final text channel.
+
+WebSocket broadcasts and LiveKit reconciliation happen only after the database commit. They may report or reconcile committed state, but they cannot cause a successful database transaction to be presented as rolled back.
+
 ## Removed/Deprecated
 
 - `server_webhooks` was created in migration `021` and removed in migration `025`.
@@ -256,4 +267,4 @@ All migrations currently present:
 
 ---
 
-Last verified against code on 2026-04-15.
+Last verified against code on 2026-07-18.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -91,7 +91,7 @@ npm run rate-limit:check
 Runs on `push` and `pull_request`:
 
 - `Secret Scan (gitleaks)` (containerized CLI)
-- `Backend` (`cargo check`, `cargo test`)
+- `Backend` (`cargo check`, then unit and integration tests against isolated PostgreSQL and Redis services)
 - `Frontend` (`npm ci`, `npm run lint`, `npm run build`)
 
 ### `.github/workflows/dependency-security.yml`
@@ -108,4 +108,4 @@ Runs on schedule, manual dispatch, and PR:
 
 ---
 
-Last verified against code on 2026-04-15.
+Last verified against code on 2026-07-18.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -344,6 +344,8 @@ The production web image passes `APP_ENV=production` and uses `apps/web/nginx.pr
 
 Audit logging is implemented for core moderation/server actions (for example role updates, kick, ban, and server settings updates) and exposed via server audit endpoints.
 
+Critical role replacement and channel deletion flows lock their server-scoped database state, re-check authorization on the transaction connection, and commit the mutation with its audit record. External WebSocket and voice reconciliation side effects run after commit so delivery failures do not create ambiguous rollback responses for already-persisted changes.
+
 AutoMod rules are server-scoped and require `MANAGE_MESSAGES` to manage. Enabled rules can block server-channel sends/edits for blocked keywords, invite links, links, or mention spam before persistence/broadcast. AutoMod matching removes common invisible Unicode format/control characters before evaluation so zero-width and bidi override characters cannot be used to split blocked keywords or links. AutoMod blocks write audit entries with rule metadata and a truncated content preview.
 
 User and message reports require server membership, are rate limited per reporter/server, and repeated open reports for the same target are deduplicated before they reach the moderation queue. Report listing is capped to keep the safety panel responsive under abuse.


### PR DESCRIPTION
## Summary

- make critical DM creation, server bootstrap, member-role replacement, and channel deletion flows transaction-safe
- serialize concurrent writes with PostgreSQL locks and commit audit records atomically
- replace per-role queries with batch validation and bulk assignment
- add concurrency and rollback regression coverage
- run backend integration tests in CI against isolated PostgreSQL and Redis services
- document the new transactional invariants

## Validation

- `cargo check --locked`
- `cargo clippy --locked --all-targets`
- `cargo test --locked`
- CI workflow YAML validation
- `graphify update .`
- staged diff whitespace validation

Closes #249