### PR TITLE
fix: harden macos media permissions and playback

### DIFF
--- a/.github/scripts/validate-desktop-artifacts.mjs
+++ b/.github/scripts/validate-desktop-artifacts.mjs
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { basename, extname, join, relative, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
 
 const repoRoot = process.cwd()
 const targetRoot = resolve(repoRoot, 'apps/desktop/src-tauri/target')
@@ -135,6 +136,51 @@ function requireUpdaterMetadata(entries) {
   }
 }
 
+function validateMacBundlePrivacyMetadata(entries, appBundles) {
+  const requiredInfoKeys = [
+    'NSMicrophoneUsageDescription',
+    'NSCameraUsageDescription',
+    'NSScreenCaptureUsageDescription',
+    'NSAudioCaptureUsageDescription',
+  ]
+  const infoPlists = requireFiles(
+    'macOS merged Info.plist',
+    entries,
+    (fullPath) => fullPath.endsWith(join('.app', 'Contents', 'Info.plist')),
+    200,
+  )
+  for (const entry of infoPlists) {
+    const contents = readFileSync(entry.fullPath)
+    for (const key of requiredInfoKeys) {
+      if (!contents.includes(Buffer.from(key))) {
+        fail(`${displayPath(entry)} must include ${key}`)
+      }
+    }
+  }
+
+  const requiredEntitlements = [
+    'com.apple.security.device.audio-input',
+    'com.apple.security.device.camera',
+  ]
+  for (const appBundle of appBundles) {
+    const result = spawnSync(
+      '/usr/bin/codesign',
+      ['-d', '--entitlements', ':-', appBundle.fullPath],
+      { encoding: 'utf8' },
+    )
+    const output = `${result.stdout || ''}\n${result.stderr || ''}`
+    if (result.status !== 0) {
+      fail(`Unable to inspect macOS code-signing entitlements for ${displayPath(appBundle)}`)
+      continue
+    }
+    for (const key of requiredEntitlements) {
+      if (!output.includes(key)) {
+        fail(`${displayPath(appBundle)} code signature must include ${key}`)
+      }
+    }
+  }
+}
+
 if (platform === 'unknown') {
   fail('RUNNER_OS is missing or unsupported for desktop artifact validation')
 }
@@ -159,8 +205,9 @@ if (bundleRoots.length === 0) {
     requireFiles('Windows MSI installer', entries, (fullPath) => extname(fullPath).toLowerCase() === '.msi', 1_000_000)
     requireFiles('Windows NSIS installer', entries, (fullPath) => extname(fullPath).toLowerCase() === '.exe', 1_000_000)
   } else if (platform === 'macos') {
-    requireDirectory('macOS .app bundle', entries, (fullPath) => fullPath.endsWith('.app'))
+    const appBundles = requireDirectory('macOS .app bundle', entries, (fullPath) => fullPath.endsWith('.app'))
     requireFiles('macOS DMG installer', entries, (fullPath) => extname(fullPath).toLowerCase() === '.dmg', 1_000_000)
+    validateMacBundlePrivacyMetadata(entries, appBundles)
   } else if (platform === 'linux') {
     requireFiles('Linux DEB package', entries, (fullPath) => extname(fullPath).toLowerCase() === '.deb', 1_000_000)
     requireFiles('Linux RPM package', entries, (fullPath) => extname(fullPath).toLowerCase() === '.rpm', 1_000_000)

--- a/.github/scripts/validate-desktop-release.mjs
+++ b/.github/scripts/validate-desktop-release.mjs
@@ -136,6 +136,16 @@ if (tauri) {
     )
   }
 
+  const macEntitlements = tauri.bundle?.macOS?.entitlements
+  if (macEntitlements !== './Entitlements.plist') {
+    fail(
+      `tauri.conf.json bundle.macOS.entitlements must be "./Entitlements.plist" (found: ${String(macEntitlements)})`,
+    )
+  }
+  if (tauri.bundle?.macOS?.signingIdentity !== '-') {
+    fail('tauri.conf.json bundle.macOS.signingIdentity must use ad-hoc signing ("-") until Developer ID signing is configured')
+  }
+
   const signingPrivateKey = process.env.TAURI_SIGNING_PRIVATE_KEY
   if (createUpdaterArtifacts && !signingPrivateKey) {
     fail('Updater artifacts are enabled but TAURI_SIGNING_PRIVATE_KEY is not configured')
@@ -145,6 +155,37 @@ if (tauri) {
 requireFile('apps/desktop/src-tauri/icons/icon.ico', 16_000)
 requireFile('apps/desktop/src-tauri/icons/icon.icns', 64_000)
 requireFile('apps/desktop/src-tauri/icons/icon.png', 8_000)
+
+requireFile('apps/desktop/src-tauri/Info.plist', 200)
+requireFile('apps/desktop/src-tauri/Entitlements.plist', 150)
+
+const macInfoPlistPath = resolve(repoRoot, 'apps/desktop/src-tauri/Info.plist')
+if (existsSync(macInfoPlistPath)) {
+  const macInfoPlist = readFileSync(macInfoPlistPath, 'utf8')
+  for (const key of [
+    'NSMicrophoneUsageDescription',
+    'NSCameraUsageDescription',
+    'NSScreenCaptureUsageDescription',
+    'NSAudioCaptureUsageDescription',
+  ]) {
+    if (!macInfoPlist.includes(`<key>${key}</key>`)) {
+      fail(`Info.plist must include ${key}`)
+    }
+  }
+}
+
+const macEntitlementsPath = resolve(repoRoot, 'apps/desktop/src-tauri/Entitlements.plist')
+if (existsSync(macEntitlementsPath)) {
+  const macEntitlements = readFileSync(macEntitlementsPath, 'utf8')
+  for (const key of [
+    'com.apple.security.device.audio-input',
+    'com.apple.security.device.camera',
+  ]) {
+    if (!macEntitlements.includes(`<key>${key}</key>`)) {
+      fail(`Entitlements.plist must include ${key}`)
+    }
+  }
+}
 
 const capability = loadJson('apps/desktop/src-tauri/capabilities/default.json')
 if (capability) {

--- a/apps/desktop/src-tauri/Entitlements.plist
+++ b/apps/desktop/src-tauri/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.device.camera</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Voxpery uses your microphone when you join a voice channel.</string>
+  <key>NSCameraUsageDescription</key>
+  <string>Voxpery uses your camera when you enable video in a voice channel.</string>
+  <key>NSScreenCaptureUsageDescription</key>
+  <string>Voxpery records the screen, window, or app you choose when you start screen sharing.</string>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>Voxpery captures shared system audio only when you include audio in a screen share.</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -253,15 +253,16 @@ fn desktop_update_unread_feedback(
 fn desktop_open_media_permission_settings(kind: String) -> Result<(), String> {
     let target = match kind.as_str() {
         "camera" => "camera",
+        "screen" => "screen",
         _ => "microphone",
     };
 
     #[cfg(target_os = "windows")]
     {
-        let uri = if target == "camera" {
-            "ms-settings:privacy-webcam"
-        } else {
-            "ms-settings:privacy-microphone"
+        let uri = match target {
+            "camera" => "ms-settings:privacy-webcam",
+            "screen" => "ms-settings:privacy-screenshots",
+            _ => "ms-settings:privacy-microphone",
         };
         Command::new("cmd")
             .args(["/C", "start", "", uri])
@@ -272,10 +273,12 @@ fn desktop_open_media_permission_settings(kind: String) -> Result<(), String> {
 
     #[cfg(target_os = "macos")]
     {
-        let uri = if target == "camera" {
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
-        } else {
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        let uri = match target {
+            "camera" => "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera",
+            "screen" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+            }
+            _ => "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
         };
         Command::new("open")
             .arg(uri)

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -62,6 +62,10 @@
       "webviewInstallMode": {
         "type": "downloadBootstrapper"
       }
+    },
+    "macOS": {
+      "entitlements": "./Entitlements.plist",
+      "signingIdentity": "-"
     }
   },
   "plugins": {

--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -11,6 +11,7 @@ import {
   GLOBAL_MUTE_SHORTCUT_STORAGE_KEY,
 } from '../globalMuteShortcut'
 import ActiveCallBar from './ActiveCallBar'
+import { SCREEN_SHARE_CAPTURE_READY_EVENT } from '../webrtc/hooks/useLocalMedia'
 
 vi.mock('../webrtc/useLiveKitVoice', () => ({
   useLiveKitVoice: vi.fn(),
@@ -177,6 +178,21 @@ describe('ActiveCallBar regressions', () => {
     expect(voice.setRemoteMediaSubscribed).toHaveBeenLastCalledWith('peer-1', 'screen', true)
     expect(screen.getByTitle('Stop watching screen')).not.toBeNull()
     expect(screen.queryByText('Screen share hidden')).toBeNull()
+  })
+
+  it('reasserts remote microphone playback after the macOS share picker returns', () => {
+    const remoteMic = mediaTrack('audio', 'peer-mic')
+    const remoteStream = new MediaStream([remoteMic])
+    const play = vi.mocked(HTMLMediaElement.prototype.play)
+
+    renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', remoteStream]]),
+    })
+    play.mockClear()
+
+    window.dispatchEvent(new Event(SCREEN_SHARE_CAPTURE_READY_EVENT))
+
+    expect(play).toHaveBeenCalledOnce()
   })
 
   it('keeps mute, deafen, and leave controls wired to the joined voice session', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { useLiveKitVoice } from '../webrtc/useLiveKitVoice'
+import { SCREEN_SHARE_CAPTURE_READY_EVENT } from '../webrtc/hooks/useLocalMedia'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores/app'
 import { useAuthStore } from '../stores/auth'
@@ -414,6 +415,42 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       }
     }
   }, [getPlaybackVolumeFactor, parseRemoteAudioPlaybackKey])
+
+  const recoverRemoteAudioPlayback = useCallback(() => {
+    applyOutputVolumeToElements(outputVolumeRef.current / 100)
+    applyOutputDeviceToElements()
+
+    for (const nodes of perPeerAudioCtxRef.current.values()) {
+      if (nodes.ctx.state === 'suspended') {
+        void nodes.ctx.resume().catch(() => { })
+      }
+    }
+
+    if (deafenedRef.current) return
+    for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
+      const stream = element.srcObject
+      if (!(stream instanceof MediaStream) || stream.getAudioTracks().length === 0) continue
+      ensureRemoteAudioPlayback(playbackKey, element)
+    }
+  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback])
+
+  useEffect(() => {
+    const recoverWhenVisible = () => {
+      if (document.visibilityState === 'hidden') return
+      recoverRemoteAudioPlayback()
+    }
+
+    window.addEventListener('focus', recoverRemoteAudioPlayback)
+    window.addEventListener('pageshow', recoverRemoteAudioPlayback)
+    window.addEventListener(SCREEN_SHARE_CAPTURE_READY_EVENT, recoverRemoteAudioPlayback)
+    document.addEventListener('visibilitychange', recoverWhenVisible)
+    return () => {
+      window.removeEventListener('focus', recoverRemoteAudioPlayback)
+      window.removeEventListener('pageshow', recoverRemoteAudioPlayback)
+      window.removeEventListener(SCREEN_SHARE_CAPTURE_READY_EVENT, recoverRemoteAudioPlayback)
+      document.removeEventListener('visibilitychange', recoverWhenVisible)
+    }
+  }, [recoverRemoteAudioPlayback])
 
   useEffect(() => {
     const onSettingsChanged = () => {
@@ -878,9 +915,12 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     try {
       await startScreenShare()
     } catch (e) {
-      const message = e instanceof Error
-        ? e.message
-        : 'Unable to start screen sharing. Check permission and active window selection.'
+      const permissionDenied = isMediaPermissionDeniedError(e, 'screen')
+      const message = permissionDenied
+        ? desktopMediaPermissionRecoveryMessage('screen')
+        : e instanceof Error
+          ? e.message
+          : 'Unable to start screen sharing. Check permission and active window selection.'
       pushToast({ level: 'error', title: 'Screen share failed', message })
     }
   }

--- a/apps/web/src/desktopMediaPermissions.ts
+++ b/apps/web/src/desktopMediaPermissions.ts
@@ -1,6 +1,6 @@
 import { isTauri } from './secureStorage'
 
-export type MediaPermissionKind = 'microphone' | 'camera'
+export type MediaPermissionKind = 'microphone' | 'camera' | 'screen'
 
 function currentDesktopPlatform(): 'windows' | 'macos' | 'linux' | 'unknown' {
   if (typeof navigator === 'undefined') return 'unknown'
@@ -12,7 +12,9 @@ function currentDesktopPlatform(): 'windows' | 'macos' | 'linux' | 'unknown' {
 }
 
 function mediaLabel(kind: MediaPermissionKind): string {
-  return kind === 'camera' ? 'camera' : 'microphone'
+  if (kind === 'camera') return 'camera'
+  if (kind === 'screen') return 'screen recording'
+  return 'microphone'
 }
 
 export function isMediaPermissionDeniedError(err: unknown, kind: MediaPermissionKind): boolean {
@@ -28,7 +30,7 @@ export function isMediaPermissionDeniedError(err: unknown, kind: MediaPermission
     || errMessage.includes('permission denied')
     || errMessage.includes('notallowederror')
     || errMessage.includes(`${label} permission denied`)
-    || (kind === 'camera' && errMessage.includes('securityerror'))
+    || ((kind === 'camera' || kind === 'screen') && errMessage.includes('securityerror'))
   )
 }
 
@@ -43,7 +45,7 @@ export function desktopMediaPermissionRecoveryMessage(kind: MediaPermissionKind)
     return `Permission was blocked. Open Windows Privacy & security settings, allow ${label} access for desktop apps, then return to Voxpery and retry.`
   }
   if (platform === 'macos') {
-    return `Permission was blocked. Open macOS Privacy & Security settings, allow Voxpery to use the ${label}, then restart Voxpery and retry.`
+    return `Permission was blocked. Open macOS Privacy & Security settings, allow Voxpery to use ${label}, then restart Voxpery and retry.`
   }
   if (platform === 'linux') {
     return `Permission was blocked. Ensure xdg-desktop-portal, a portal backend, and PipeWire are installed/running, then restart Voxpery and retry ${label} access.`

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -3,6 +3,8 @@ import {
   normalizeScreenShareQuality,
   resolveScreenShareProfileForMode,
   SCREEN_SHARE_PRESET_PROFILE,
+  SCREEN_SHARE_CAPTURE_READY_EVENT,
+  toScreenShareDisplayMediaOptions,
   toScreenShareConstraintsForProfile,
 } from './useLocalMedia'
 
@@ -58,5 +60,17 @@ describe('screen share quality profiles', () => {
       height: { ideal: 1080, max: 1080 },
       frameRate: { ideal: 60, max: 60 },
     })
+  })
+
+  it('keeps call playback audible while the screen picker changes focus', () => {
+    const video = toScreenShareConstraintsForProfile(SCREEN_SHARE_PRESET_PROFILE.presentation)
+
+    expect(toScreenShareDisplayMediaOptions(video)).toEqual({
+      video,
+      audio: {
+        suppressLocalAudioPlayback: false,
+      },
+    })
+    expect(SCREEN_SHARE_CAPTURE_READY_EVENT).toBe('voxpery-screen-share-capture-ready')
   })
 })

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -6,6 +6,7 @@ import {
 } from '../../voiceDevices'
 
 export const SCREEN_SHARE_QUALITY_KEY = 'voxpery-settings-screen-share-quality'
+export const SCREEN_SHARE_CAPTURE_READY_EVENT = 'voxpery-screen-share-capture-ready'
 const INPUT_VOL_KEY = 'voxpery-settings-input-volume'
 const NOISE_SUPPRESSION_KEY = 'voxpery-settings-noise-suppression'
 const DEFAULT_INPUT_VOLUME = 80
@@ -73,6 +74,22 @@ export function toScreenShareConstraintsForProfile(profile: ScreenShareProfile):
         case '720p':
         default:
             return { ...base, width: { ideal: 1280, max: 1280 }, height: { ideal: 720, max: 720 } }
+    }
+}
+
+type DisplayAudioConstraints = MediaTrackConstraints & {
+    suppressLocalAudioPlayback: boolean
+}
+
+export function toScreenShareDisplayMediaOptions(
+    video: DisplayMediaStreamOptions['video'],
+): DisplayMediaStreamOptions {
+    return {
+        video,
+        audio: {
+            // Keep the active call audible while the native/macOS share picker changes focus.
+            suppressLocalAudioPlayback: false,
+        } as DisplayAudioConstraints,
     }
 }
 
@@ -218,12 +235,12 @@ export function useLocalMedia() {
             cachedScreenStreamRef.current = null
         }
         const videoConstraints = getScreenShareConstraints()
-        const stream = await navigator.mediaDevices.getDisplayMedia({
-            video: videoConstraints,
-            audio: true,
-        })
+        const stream = await navigator.mediaDevices.getDisplayMedia(
+            toScreenShareDisplayMediaOptions(videoConstraints),
+        )
         await applyScreenShareTrackProfile(stream.getVideoTracks()[0])
         cachedScreenStreamRef.current = stream
+        window.dispatchEvent(new Event(SCREEN_SHARE_CAPTURE_READY_EVENT))
         return stream
     }, [applyScreenShareTrackProfile, getScreenShareConstraints])
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defer browser and desktop notification permission requests until the authenticated app is ready and the user accepts a non-blocking in-app prompt.
 - Serialize critical DM creation, server bootstrap, member-role replacement, and channel deletion writes so concurrent requests cannot leave duplicate or partial state.
 - Run backend integration and concurrency tests in CI against isolated PostgreSQL and Redis services instead of silently skipping database coverage.
+- Register macOS microphone, camera, screen-recording, and shared-audio permission metadata in desktop bundles and keep remote call playback active across the screen-share picker and app focus changes.
 
 ### Security
 - Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -13,6 +13,10 @@ This document defines Voxpery desktop release hardening policy for metadata, dee
     - `icons/icon.icns`
     - `icons/128x128.png`
 - Release pipeline validates icon files and minimum file sizes before build.
+- macOS release bundles must merge `Info.plist` usage descriptions for microphone, camera, screen recording, and shared system audio.
+- macOS release bundles must apply `Entitlements.plist` with audio-input and camera capture entitlements.
+- Until Developer ID signing is configured, macOS release bundles use Tauri's ad-hoc signing identity (`-`) so those entitlements are applied consistently.
+- Release preflight validates both files and their Tauri configuration link so native permission registration cannot regress silently.
 
 ## 2) OAuth Deep-link Safety (required)
 
@@ -77,6 +81,8 @@ Before publishing a desktop release:
 6. Confirm normal app launch opens maximized on a fresh install, then restores the user's last size, position, and maximized state on later launches.
 7. Confirm Windows startup launch stays in the tray until the user opens Voxpery from the tray, and tray Show opens a maximized window.
 8. Confirm installer/update preparation closes tray/minimize state cleanly before install.
+9. On a clean macOS account, confirm microphone and screen-recording prompts identify Voxpery and the app remains listed in both Privacy & Security sections.
+10. Start screen share on macOS and confirm remote voice volume remains stable while the native picker opens, after a source is selected, and while Voxpery is unfocused.
 
 ## 6) Rollback Expectations
 

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -21,6 +21,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] A valid custom microphone and speaker remain selected after reload and voice rejoin.
 - [ ] After a selected custom microphone or speaker is disconnected, the next capture/playback attempt silently uses the system default and Voice Settings shows `Windows Default`.
 - [ ] In desktop builds, the configured mute shortcut also works while Voxpery is unfocused, minimized, or running in the tray.
+- [ ] On a clean macOS install, the first voice join prompts for microphone access and Voxpery appears in Privacy & Security -> Microphone after the decision.
 - [ ] Rebinding or clearing the mute shortcut takes effect immediately; a conflicting desktop shortcut shows an error without losing the previous working binding.
 - [ ] Deafen stops remote audio playback and restores it when disabled.
 - [ ] User B leaves and User A hears a leave cue that is clearly different from the join cue.
@@ -50,6 +51,8 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] `Auto` chooses a balanced profile by shared surface: monitor/browser -> video, window/unknown -> presentation.
 - [ ] Monitor/game and browser/video shares stay motion-first under load: frame pacing remains smooth before sharpness is preserved.
 - [ ] User A starts screen share; User B sees the screen tile.
+- [ ] On a clean macOS install, starting screen share prompts for Screen & System Audio Recording access and Voxpery appears in that Privacy & Security list.
+- [ ] On macOS, opening and closing the native share picker does not lower remote microphone audio; the same level continues without clicking Voxpery again.
 - [ ] User B hears the screen-start cue only once for the screen video track.
 - [ ] Sharing screen audio does not play a duplicate start cue.
 - [ ] User B hides the screen share; the screen tile collapses and its screen video/audio publications stop for that viewer.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -211,7 +211,7 @@ Speaker
 ```typescript
 const stream = await navigator.mediaDevices.getDisplayMedia({
   video: { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 60, max: 60 } },
-  audio: true  // Screen share audio (e.g., YouTube video)
+  audio: { suppressLocalAudioPlayback: false }  // Shared audio without ducking the active call
 })
 await room.localParticipant.publishTrack(videoTrack, {
   source: Track.Source.ScreenShare,
@@ -236,6 +236,7 @@ await room.localParticipant.publishTrack(videoTrack, {
 - Hiding a screen share unsubscribes both its video and screen-share audio publications; the participant's microphone audio continues normally.
 - The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
 - When the Voxpery window is hidden or minimized, remote video subscriptions pause while microphone and screen-share audio continue. Video subscriptions resume when the app becomes visible, without replaying media-start cues.
+- Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, WebAudio state, and remote playback without changing per-user volume settings.
 
 ## Camera
 
@@ -269,13 +270,16 @@ await room.localParticipant.publishTrack(videoTrack, {
 3. Try another browser (Firefox, Chrome, Edge)
 4. Linux desktop: ensure `xdg-desktop-portal` + one backend (`xdg-desktop-portal-gtk` or `xdg-desktop-portal-kde`) and `pipewire` are installed/running, then restart Voxpery.
 
-### Mic or camera permission denied on desktop
+### Mic, camera, or screen-recording permission denied on desktop
 
 1. Open User Settings -> Voice & Audio.
 2. Click `Open settings` when microphone access is blocked, then allow Voxpery or desktop apps to use the microphone in OS privacy settings.
 3. For camera denial, open the OS camera privacy settings, allow Voxpery or desktop apps to use the camera, then retry the camera toggle.
-4. Restart Voxpery if the OS requires a restart before WebView permissions refresh.
-5. Return to Voxpery and click `Retry mic access` or retry the camera action.
+4. On macOS, allow Voxpery under Privacy & Security -> Screen & System Audio Recording before retrying screen share.
+5. Restart Voxpery if the OS requires a restart before WebView permissions refresh.
+6. Return to Voxpery and click `Retry mic access`, retry the camera action, or start screen share again.
+
+The macOS application bundle declares microphone, camera, screen-recording, and shared-audio usage descriptions. Its code-signing entitlements allow microphone and camera capture. These files are release-validated so a desktop build cannot silently lose its native permission registration.
 
 ### Voice quality diagnostics
 


### PR DESCRIPTION
## Summary

- add required macOS microphone, camera, screen recording, and audio capture metadata
- apply macOS capture entitlements with ad-hoc code signing
- preserve remote call audio across screen-share picker and focus changes
- validate packaged macOS privacy metadata and entitlements during release builds
- expand macOS voice and screen-share smoke coverage

## Validation

- npm run lint
- npm run test:run
- npm run build
- cargo check --locked
- desktop release script syntax and plist validation

Refs #239