### PR TITLE
security: protect cookie auth from csrf

### DIFF
--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -7,7 +7,7 @@ use axum::{
     body::{to_bytes, Body},
     extract::{DefaultBodyLimit, State},
     http::{header, Method, StatusCode},
-    middleware::map_response,
+    middleware::{from_fn_with_state, map_response},
     response::{IntoResponse, Response},
     routing::get,
     Json, Router,
@@ -269,6 +269,8 @@ pub fn build_app(state: Arc<AppState>, cors_origins: Vec<String>) -> Router {
         .allow_credentials(true);
 
     const BODY_LIMIT: usize = 10 * 1024 * 1024;
+    let cookie_csrf =
+        middleware::csrf::CookieCsrfConfig::new(state.cookie_name.clone(), cors_origins.clone());
 
     let app = Router::new()
         .route("/health", get(health_handler))
@@ -289,6 +291,10 @@ pub fn build_app(state: Arc<AppState>, cors_origins: Vec<String>) -> Router {
         .route("/ws", axum::routing::get(ws::handler::ws_handler))
         .layer(DefaultBodyLimit::max(BODY_LIMIT))
         .layer(map_response(sanitize_verbose_client_errors))
+        .layer(from_fn_with_state(
+            cookie_csrf,
+            middleware::csrf::protect_cookie_authenticated_writes,
+        ))
         .layer(TraceLayer::new_for_http())
         .layer(cors);
 

--- a/apps/server/src/middleware/csrf.rs
+++ b/apps/server/src/middleware/csrf.rs
@@ -1,0 +1,190 @@
+use axum::{
+    extract::{Request, State},
+    http::{header, HeaderMap, Method, Uri},
+    middleware::Next,
+    response::Response,
+};
+
+use crate::errors::AppError;
+
+#[derive(Clone, Debug)]
+pub struct CookieCsrfConfig {
+    cookie_name: String,
+    allowed_origins: Vec<String>,
+}
+
+impl CookieCsrfConfig {
+    pub fn new(cookie_name: String, allowed_origins: Vec<String>) -> Self {
+        Self {
+            cookie_name,
+            allowed_origins: allowed_origins
+                .into_iter()
+                .map(|origin| origin.trim().trim_end_matches('/').to_string())
+                .filter(|origin| !origin.is_empty())
+                .collect(),
+        }
+    }
+
+    fn allows_origin(&self, origin: &str) -> bool {
+        // Opaque origins can be created by sandboxed documents and local files,
+        // so they are never sufficient proof for cookie-authenticated writes.
+        origin != "null" && self.allowed_origins.iter().any(|allowed| allowed == origin)
+    }
+}
+
+fn is_safe_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+    )
+}
+
+fn has_bearer_token(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|token| !token.trim().is_empty())
+}
+
+fn has_named_cookie(headers: &HeaderMap, cookie_name: &str) -> bool {
+    let Some(cookie_header) = headers
+        .get(header::COOKIE)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let prefix = format!("{cookie_name}=");
+    cookie_header.split(';').map(str::trim).any(|part| {
+        part.strip_prefix(&prefix)
+            .is_some_and(|value| !value.trim().is_empty())
+    })
+}
+
+fn referer_origin(headers: &HeaderMap) -> Option<String> {
+    let referer = headers.get(header::REFERER)?.to_str().ok()?;
+    let uri = referer.parse::<Uri>().ok()?;
+    let scheme = uri.scheme_str()?;
+    let authority = uri.authority()?.as_str();
+    Some(format!("{scheme}://{authority}"))
+}
+
+fn has_trusted_request_origin(headers: &HeaderMap, config: &CookieCsrfConfig) -> bool {
+    if let Some(origin) = headers.get(header::ORIGIN) {
+        return origin
+            .to_str()
+            .ok()
+            .is_some_and(|origin| config.allows_origin(origin));
+    }
+
+    referer_origin(headers)
+        .as_deref()
+        .is_some_and(|origin| config.allows_origin(origin))
+}
+
+fn validate_request(
+    method: &Method,
+    headers: &HeaderMap,
+    config: &CookieCsrfConfig,
+) -> Result<(), AppError> {
+    if is_safe_method(method)
+        || has_bearer_token(headers)
+        || !has_named_cookie(headers, &config.cookie_name)
+    {
+        return Ok(());
+    }
+
+    if has_trusted_request_origin(headers, config) {
+        return Ok(());
+    }
+
+    Err(AppError::Forbidden("Cross-site request rejected".into()))
+}
+
+/// Reject state-changing requests that rely on the web auth cookie unless the
+/// browser proves they came from an explicitly allowed origin.
+pub async fn protect_cookie_authenticated_writes(
+    State(config): State<CookieCsrfConfig>,
+    req: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    validate_request(req.method(), req.headers(), &config)?;
+    Ok(next.run(req).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn config() -> CookieCsrfConfig {
+        CookieCsrfConfig::new(
+            "voxpery_token".into(),
+            vec![
+                "https://voxpery.com".into(),
+                "http://localhost:5173".into(),
+                "null".into(),
+            ],
+        )
+    }
+
+    fn cookie_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_static("voxpery_token=session-token"),
+        );
+        headers
+    }
+
+    #[test]
+    fn rejects_cookie_write_without_origin_proof() {
+        assert!(validate_request(&Method::POST, &cookie_headers(), &config()).is_err());
+    }
+
+    #[test]
+    fn rejects_cookie_write_from_untrusted_or_opaque_origin() {
+        for origin in [
+            "https://evil.example",
+            "https://voxpery.com.evil.example",
+            "null",
+        ] {
+            let mut headers = cookie_headers();
+            headers.insert(header::ORIGIN, HeaderValue::from_str(origin).unwrap());
+            assert!(validate_request(&Method::DELETE, &headers, &config()).is_err());
+        }
+    }
+
+    #[test]
+    fn allows_cookie_write_from_allowed_origin_or_referer() {
+        let mut origin_headers = cookie_headers();
+        origin_headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("https://voxpery.com"),
+        );
+        assert!(validate_request(&Method::PATCH, &origin_headers, &config()).is_ok());
+
+        let mut referer_headers = cookie_headers();
+        referer_headers.insert(
+            header::REFERER,
+            HeaderValue::from_static("https://voxpery.com/channels/123"),
+        );
+        assert!(validate_request(&Method::PUT, &referer_headers, &config()).is_ok());
+    }
+
+    #[test]
+    fn bearer_auth_and_safe_methods_do_not_require_origin() {
+        let mut bearer_headers = cookie_headers();
+        bearer_headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer desktop-token"),
+        );
+        assert!(validate_request(&Method::POST, &bearer_headers, &config()).is_ok());
+        assert!(validate_request(&Method::GET, &cookie_headers(), &config()).is_ok());
+    }
+
+    #[test]
+    fn unauthenticated_public_writes_do_not_require_origin() {
+        assert!(validate_request(&Method::POST, &HeaderMap::new(), &config()).is_ok());
+    }
+}

--- a/apps/server/src/middleware/mod.rs
+++ b/apps/server/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod csrf;

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -381,6 +381,81 @@ async fn register_login_me_flow() {
 }
 
 #[tokio::test]
+async fn cookie_authenticated_writes_require_a_trusted_origin() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app().await;
+
+    let uid = Uuid::new_v4();
+    let email = format!("csrf-{uid}@example.com");
+    let username = format!("csrf_{}", uid.as_u128() % 1_000_000);
+    let password = test_credential("csrf");
+    let (token, _) = register_user(&mut app, &email, &username, password).await;
+    let cookie = format!("voxpery_token={token}");
+
+    for origin in [None, Some("https://evil.example"), Some("null")] {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/api/auth/email/request-verification")
+            .header("cookie", &cookie)
+            .header("content-type", "application/json");
+        if let Some(origin) = origin {
+            request = request.header("origin", origin);
+        }
+        let (status, _) = oneshot(&mut app, request.body(Body::from("{}")).unwrap()).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "cookie write from {origin:?} should be rejected"
+        );
+    }
+
+    let allowed_origin = Request::builder()
+        .method("POST")
+        .uri("/api/auth/email/request-verification")
+        .header("cookie", &cookie)
+        .header("origin", "http://localhost:5173")
+        .header("content-type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let (status, _) = oneshot(&mut app, allowed_origin).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let allowed_referer = Request::builder()
+        .method("POST")
+        .uri("/api/auth/email/request-verification")
+        .header("cookie", &cookie)
+        .header("referer", "http://localhost:5173/settings/account")
+        .header("content-type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let (status, _) = oneshot(&mut app, allowed_referer).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let desktop_bearer = Request::builder()
+        .method("POST")
+        .uri("/api/auth/email/request-verification")
+        .header("authorization", format!("Bearer {token}"))
+        .header("cookie", &cookie)
+        .header("origin", "https://evil.example")
+        .header("content-type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let (status, _) = oneshot(&mut app, desktop_bearer).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let safe_cookie_read = Request::builder()
+        .uri("/api/auth/me")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = oneshot(&mut app, safe_cookie_read).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn default_voxpery_server_has_moderator_role_after_register() {
     let Some(_) = test_db_url() else {
         eprintln!("SKIP: DATABASE_URL not set");

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,11 @@ REST API for auth, servers, channels/categories, messages/reactions, friends, DM
 - Web: httpOnly cookie (`voxpery_token` by default)
 - Desktop: `Authorization: Bearer <jwt>`
 
+Cookie-authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests must come from an
+origin listed in `CORS_ORIGINS`. The API verifies `Origin` (or same-origin `Referer`
+when `Origin` is absent); cross-site cookie mutations return `403`. Bearer-authenticated
+desktop requests are not subject to browser CSRF checks.
+
 ## Authorization Model
 
 Role/permission system is bitmask-based (`apps/server/src/services/permissions.rs`).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -30,6 +30,8 @@ Edit `.env` and set strong production values at minimum:
 - `ADMIN_PASSWORD`
 - `COOKIE_SECURE=1` (when using HTTPS)
 - `CORS_ORIGINS` with your production origins only
+- Keep every web origin that sends cookie-authenticated writes in `CORS_ORIGINS`; the
+  same allowlist is used for server-side CSRF origin verification.
 - `VITE_API_URL` (public backend URL used by frontend build)
 - `FRONTEND_URL` (public web app URL used in password reset and email verification links)
 - `ATTACHMENTS_PUBLIC_BASE_URL` (for uploaded file URLs; usually your API domain)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -115,7 +115,13 @@ pub fn validate_security_config(cors_origins: &[String], cookie_secure: bool) ->
 
 - **httpOnly**: Prevents JavaScript access (XSS mitigation)
 - **Secure**: Only sent over HTTPS (enforced for non-local origins)
-- **SameSite**: `Lax` (default, prevents CSRF)
+- **SameSite**: `Lax` (defense in depth; not the sole CSRF control)
+- **State-changing requests**: Cookie-authenticated non-safe methods require an exact
+  `Origin` match against `CORS_ORIGINS`, with same-origin `Referer` as a fallback.
+- **Desktop exception**: Bearer-authenticated desktop requests do not require browser
+  origin proof. OAuth callbacks retain their separate state-cookie validation.
+- **Opaque origins**: `Origin: null` is never accepted as proof for a cookie-authenticated
+  write, even if it exists in the CORS list for a legacy desktop integration.
 
 **Production requirement**: `COOKIE_SECURE=1` when `CORS_ORIGINS` includes non-localhost domains.
 


### PR DESCRIPTION
## Summary

- add centralized CSRF protection for cookie-authenticated state-changing requests
- validate Origin or Referer against the configured CORS allowlist
- reject opaque and untrusted origins with HTTP 403
- preserve desktop Bearer authentication and OAuth callback flows
- document the updated cookie authentication requirements

## Validation

- `cargo check --locked`
- `cargo test --locked`
- Graphify repository graph updated