### PR TITLE
fix: roll back failed attachment uploads

### DIFF
--- a/apps/server/src/routes/attachments.rs
+++ b/apps/server/src/routes/attachments.rs
@@ -80,10 +80,49 @@ async fn upload_attachments(
     )
     .await?;
 
+    let mut tx = state.db.begin().await?;
+    let mut stored_keys = Vec::new();
+    let upload_result = process_attachment_upload(
+        &state,
+        claims.sub,
+        &mut multipart,
+        &mut tx,
+        &mut stored_keys,
+    )
+    .await;
+
+    match upload_result {
+        Ok(uploaded) => {
+            if let Err(error) = tx.commit().await {
+                cleanup_failed_upload_files(&state, &stored_keys).await;
+                return Err(error.into());
+            }
+            Ok(Json(uploaded))
+        }
+        Err(error) => {
+            if let Err(rollback_error) = tx.rollback().await {
+                tracing::error!(
+                    user_id = %claims.sub,
+                    error = %rollback_error,
+                    "Failed to roll back attachment upload transaction"
+                );
+            }
+            cleanup_failed_upload_files(&state, &stored_keys).await;
+            Err(error)
+        }
+    }
+}
+
+async fn process_attachment_upload(
+    state: &Arc<AppState>,
+    user_id: Uuid,
+    multipart: &mut Multipart,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    stored_keys: &mut Vec<String>,
+) -> Result<Vec<AttachmentResponseItem>, AppError> {
     let mut uploaded = Vec::<AttachmentResponseItem>::new();
     let mut file_count = 0usize;
     let max_files = state.attachment_service.max_files_per_request();
-    let mut tx = state.db.begin().await?;
 
     while let Some(field) = multipart
         .next_field()
@@ -126,9 +165,9 @@ async fn upload_attachments(
                RETURNING id"#,
         )
         .bind(prepared.size_bytes)
-        .bind(claims.sub)
+        .bind(user_id)
         .bind(FREE_TIER_STORAGE_QUOTA_BYTES)
-        .fetch_optional(&mut *tx)
+        .fetch_optional(&mut **tx)
         .await?;
 
         if reserve_result.is_none() {
@@ -141,9 +180,10 @@ async fn upload_attachments(
             .attachment_service
             .store_prepared_file(prepared)
             .await?;
+        stored_keys.push(stored.storage_key.clone());
 
         let attachment_id = Uuid::new_v4();
-        let insert_result = sqlx::query(
+        sqlx::query(
             r#"INSERT INTO uploaded_attachments (
                    id,
                    user_id,
@@ -159,22 +199,15 @@ async fn upload_attachments(
                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'clean',NOW())"#,
         )
         .bind(attachment_id)
-        .bind(claims.sub)
+        .bind(user_id)
         .bind(stored.storage_backend)
         .bind(&stored.storage_key)
         .bind(&stored.original_name)
         .bind(&stored.content_type)
         .bind(stored.size_bytes)
         .bind(&stored.sha256)
-        .execute(&mut *tx)
-        .await;
-        if let Err(e) = insert_result {
-            let _ = state
-                .attachment_service
-                .delete_local_file_by_storage_key(&stored.storage_key)
-                .await;
-            return Err(e.into());
-        }
+        .execute(&mut **tx)
+        .await?;
 
         uploaded.push(AttachmentResponseItem {
             id: attachment_id,
@@ -193,9 +226,24 @@ async fn upload_attachments(
             "No files received. Use multipart field name 'files'.".into(),
         ));
     }
-    tx.commit().await?;
 
-    Ok(Json(uploaded))
+    Ok(uploaded)
+}
+
+async fn cleanup_failed_upload_files(state: &Arc<AppState>, stored_keys: &[String]) {
+    for storage_key in stored_keys.iter().rev() {
+        if let Err(error) = state
+            .attachment_service
+            .delete_local_file_by_storage_key(storage_key)
+            .await
+        {
+            tracing::error!(
+                storage_key,
+                error = %error,
+                "Failed to clean up attachment after upload rollback"
+            );
+        }
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/apps/server/src/services/attachments.rs
+++ b/apps/server/src/services/attachments.rs
@@ -669,9 +669,7 @@ impl AttachmentService {
                 AppError::Internal(format!("Failed to prepare local upload directory: {e}"))
             })?;
         }
-        fs::write(&path, &bytes)
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to write uploaded attachment: {e}")))?;
+        write_file_atomically(&path, &bytes).await?;
         Ok(StoredAttachment {
             storage_backend: "local",
             storage_key: key,
@@ -794,6 +792,48 @@ impl AttachmentService {
 
         Err(format!("Unexpected ClamAV response: {}", text.trim()))
     }
+}
+
+async fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    let temporary_path = path.with_extension(format!("uploading-{}", Uuid::new_v4()));
+    let mut temporary_file = match fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary_path)
+        .await
+    {
+        Ok(file) => file,
+        Err(error) => {
+            let _ = fs::remove_file(&temporary_path).await;
+            return Err(AppError::Internal(format!(
+                "Failed to create temporary attachment file: {error}"
+            )));
+        }
+    };
+
+    let write_result = async {
+        temporary_file.write_all(bytes).await?;
+        temporary_file.flush().await?;
+        temporary_file.sync_all().await
+    }
+    .await;
+    drop(temporary_file);
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temporary_path).await;
+        return Err(AppError::Internal(format!(
+            "Failed to write uploaded attachment: {error}"
+        )));
+    }
+
+    if let Err(error) = fs::rename(&temporary_path, path).await {
+        let _ = fs::remove_file(&temporary_path).await;
+        return Err(AppError::Internal(format!(
+            "Failed to finalize uploaded attachment: {error}"
+        )));
+    }
+
+    Ok(())
 }
 
 fn validate_upload_content(
@@ -1533,6 +1573,42 @@ mod tests {
             .next_back()
             .expect("last storage key segment");
         assert!(Uuid::parse_str(object_id).is_ok());
+        let stored_path = service
+            .resolve_local_path(&stored.storage_key)
+            .expect("stored path");
+        assert_eq!(fs::read(&stored_path).await.expect("stored bytes"), b"hello");
+        let mut sibling_entries = fs::read_dir(stored_path.parent().expect("storage parent"))
+            .await
+            .expect("storage directory");
+        while let Some(entry) = sibling_entries.next_entry().await.expect("storage entry") {
+            assert!(
+                !entry.file_name().to_string_lossy().contains(".uploading-"),
+                "successful writes must not leave temporary files"
+            );
+        }
+
+        fs::remove_dir_all(test_root).await.expect("cleanup");
+    }
+
+    #[tokio::test]
+    async fn atomic_write_removes_temporary_file_when_finalize_fails() {
+        let test_root = std::env::temp_dir().join(format!("voxpery-att-test-{}", Uuid::new_v4()));
+        fs::create_dir_all(&test_root).await.expect("test root");
+        let target_path = test_root.join("existing-directory");
+        fs::create_dir(&target_path).await.expect("conflicting target");
+
+        let error = write_file_atomically(&target_path, b"temporary payload")
+            .await
+            .expect_err("renaming a file over a directory must fail");
+        assert!(error.to_string().contains("Failed to finalize"));
+
+        let mut entries = fs::read_dir(&test_root).await.expect("test root entries");
+        while let Some(entry) = entries.next_entry().await.expect("test root entry") {
+            assert!(
+                !entry.file_name().to_string_lossy().contains(".uploading-"),
+                "failed finalization must remove temporary files"
+            );
+        }
 
         fs::remove_dir_all(test_root).await.expect("cleanup");
     }

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -13,7 +13,7 @@ use http_body_util::BodyExt;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use sqlx::postgres::PgPoolOptions;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 use tokio::sync::broadcast;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -136,6 +136,27 @@ async fn setup_app_with_auth_features(
 
     let app = build_app(state.clone(), vec!["http://localhost:5173".to_string()]);
     (app, state)
+}
+
+async fn count_regular_files(root: &Path) -> usize {
+    let mut directories = vec![root.to_path_buf()];
+    let mut count = 0;
+
+    while let Some(directory) = directories.pop() {
+        let mut entries = tokio::fs::read_dir(&directory)
+            .await
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()));
+        while let Some(entry) = entries.next_entry().await.expect("failed to read entry") {
+            let file_type = entry.file_type().await.expect("failed to read file type");
+            if file_type.is_dir() {
+                directories.push(entry.path());
+            } else if file_type.is_file() {
+                count += 1;
+            }
+        }
+    }
+
+    count
 }
 
 async fn oneshot(app: &mut axum::Router, req: Request<Body>) -> (StatusCode, bytes::Bytes) {
@@ -3132,6 +3153,82 @@ async fn attachment_upload_fails_when_user_storage_quota_is_exceeded() {
         String::from_utf8_lossy(&body).contains("Storage quota exceeded"),
         "quota error message should be explicit: {}",
         String::from_utf8_lossy(&body)
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_rolls_back_prior_files_when_later_file_exceeds_quota() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+
+    let uid = Uuid::new_v4();
+    let email = format!("quota-rollback-{}@example.com", uid);
+    let username = format!("quota_rollback_{}", uid.as_u128() % 1_000_000);
+    let password = test_credential("default");
+    let (token, user_id) = register_user(&mut app, &email, &username, password).await;
+    let auth = format!("Bearer {}", token);
+    let initial_storage_used = 1_073_741_819_i64;
+
+    sqlx::query("UPDATE users SET storage_used_bytes = $1 WHERE id = $2")
+        .bind(initial_storage_used)
+        .bind(user_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+    let boundary = format!("----voxperyquotarollback{}", Uuid::new_v4());
+    let body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"files\"; filename=\"first.txt\"\r\nContent-Type: text/plain\r\n\r\nhello\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"files\"; filename=\"second.txt\"\r\nContent-Type: text/plain\r\n\r\nworld\r\n--{boundary}--\r\n"
+    );
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/attachments/upload")
+        .header("Authorization", &auth)
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(Body::from(body.into_bytes()))
+        .unwrap();
+    let (status, response_body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "second upload should exceed quota: {}",
+        String::from_utf8_lossy(&response_body)
+    );
+
+    let storage_used: i64 =
+        sqlx::query_scalar("SELECT storage_used_bytes FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    assert_eq!(
+        storage_used, initial_storage_used,
+        "quota reservation must roll back"
+    );
+
+    let stored_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM uploaded_attachments WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    assert_eq!(stored_count, 0, "attachment metadata must roll back");
+
+    let storage_root = state
+        .attachment_service
+        .local_storage_dir()
+        .expect("local attachment storage root");
+    assert_eq!(
+        count_regular_files(&storage_root).await,
+        0,
+        "rollback must remove files stored earlier in the request"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -169,7 +169,8 @@ Notes:
   - The client MIME value must be allowlisted, but it is not trusted as proof of content. The server checks magic bytes, rejects MIME mismatches, active markup, executable formats, and unidentified binary data, then stores the canonical detected MIME.
   - Generic `application/octet-stream` declarations remain compatible with files whose actual type is safely detected, including ZIP uploads from browsers that do not report a specific ZIP MIME.
   - Returns uploaded attachment objects with `id`, signed `url`, `type`, `name`, `size`, `sha256`.
-  - Upload pipeline: size/allowlist validation -> magic-byte content validation -> bounded JPEG/PNG decode and metadata cleanup -> optional ClamAV scan -> local storage -> metadata insert -> short-lived signed URL.
+  - Upload pipeline: size/allowlist validation -> magic-byte content validation -> bounded JPEG/PNG decode and metadata cleanup -> optional ClamAV scan -> atomic local storage write -> quota and metadata transaction -> short-lived signed URL.
+  - Multi-file uploads are all-or-nothing. If validation, quota reservation, metadata persistence, or transaction commit fails, database changes are rolled back and files already written for that request are removed.
 - `GET /api/attachments/content/:attachment_id?exp=...&sig=...`
   - Auth-required endpoint guarded by signature + expiry + attachment ACL checks.
   - Streams attachment media in chat without exposing permanent public file URLs.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -258,7 +258,9 @@ let query = format!("SELECT * FROM users WHERE username = '{}'", username); // S
   - Docker Compose keeps ClamAV disabled by default; enable it explicitly with `--profile security`
 - **Storage backends**:
   - Local filesystem (`ATTACHMENTS_LOCAL_DIR` + `ATTACHMENTS_KEY_PREFIX`)
+  - Local files are written to a same-directory temporary path, flushed, and atomically renamed so partially written files are never exposed under final storage keys
   - Upload metadata persisted in `uploaded_attachments`
+  - Multi-file requests reserve quota and insert metadata in one database transaction; any request or commit failure rolls back the transaction and removes every file already finalized by that request
 - **Delivery model**:
   - Files are not exposed under a permanent public `/uploads` route.
   - API returns short-lived signed URLs (`/api/attachments/content/:id?exp=...&sig=...`).


### PR DESCRIPTION
## Summary

- write local attachments through same-directory temporary files and atomic renames
- roll back quota and metadata changes when a multi-file upload fails
- remove every attachment file finalized earlier in a failed request
- add coverage for storage finalization cleanup and multi-file quota rollback
- document the all-or-nothing upload behavior

## Validation

- `cargo check --locked`
- `cargo test --locked`
- attachment service tests: 16 passed
- Graphify knowledge graph updated

## Notes

The DB-backed rollback integration test is included and will run against the CI PostgreSQL and Redis services.