### PR TITLE
fix: preserve message integrity under concurrency

### DIFF
--- a/apps/server/migrations/041_open_report_uniqueness.sql
+++ b/apps/server/migrations/041_open_report_uniqueness.sql
@@ -1,0 +1,42 @@
+-- Collapse legacy duplicate open reports before enforcing atomic uniqueness.
+WITH ranked_user_reports AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY server_id, reporter_user_id, reported_user_id
+               ORDER BY created_at ASC, id ASC
+           ) AS duplicate_rank
+    FROM server_reports
+    WHERE status = 'open'
+      AND message_id IS NULL
+      AND message_excerpt IS NULL
+)
+DELETE FROM server_reports report
+USING ranked_user_reports ranked
+WHERE report.id = ranked.id
+  AND ranked.duplicate_rank > 1;
+
+WITH ranked_message_reports AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY server_id, reporter_user_id, message_id
+               ORDER BY created_at ASC, id ASC
+           ) AS duplicate_rank
+    FROM server_reports
+    WHERE status = 'open'
+      AND message_id IS NOT NULL
+)
+DELETE FROM server_reports report
+USING ranked_message_reports ranked
+WHERE report.id = ranked.id
+  AND ranked.duplicate_rank > 1;
+
+CREATE UNIQUE INDEX uq_server_reports_open_user
+    ON server_reports(server_id, reporter_user_id, reported_user_id)
+    WHERE status = 'open'
+      AND message_id IS NULL
+      AND message_excerpt IS NULL;
+
+CREATE UNIQUE INDEX uq_server_reports_open_message
+    ON server_reports(server_id, reporter_user_id, message_id)
+    WHERE status = 'open'
+      AND message_id IS NOT NULL;

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -794,15 +794,48 @@ async fn pin_dm_message(
 ) -> Result<Json<MessageWithAuthor>, AppError> {
     check_dm_access(&state, channel_id, claims.sub).await?;
 
+    let mut tx = state.db.begin().await?;
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM dm_channels WHERE id = $1 FOR UPDATE")
+        .bind(channel_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or_else(|| AppError::NotFound("DM channel not found".into()))?;
+
     let msg_channel: Option<Uuid> =
         sqlx::query_scalar("SELECT channel_id FROM dm_messages WHERE id = $1")
             .bind(body.message_id)
-            .fetch_optional(&state.db)
+            .fetch_optional(&mut *tx)
             .await?;
 
     let msg_channel = msg_channel.ok_or_else(|| AppError::NotFound("Message not found".into()))?;
     if msg_channel != channel_id {
         return Err(AppError::Forbidden("Message is not in this channel".into()));
+    }
+
+    let already_pinned = sqlx::query_scalar::<_, bool>(
+        r#"SELECT EXISTS (
+               SELECT 1
+               FROM dm_channel_pins
+               WHERE dm_channel_id = $1 AND dm_message_id = $2
+           )"#,
+    )
+    .bind(channel_id)
+    .bind(body.message_id)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if !already_pinned {
+        let pin_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM dm_channel_pins WHERE dm_channel_id = $1",
+        )
+        .bind(channel_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if pin_count >= 50 {
+            return Err(AppError::Validation(
+                "This conversation already has the maximum of 50 pinned messages".into(),
+            ));
+        }
     }
 
     sqlx::query(
@@ -813,8 +846,9 @@ async fn pin_dm_message(
     .bind(channel_id)
     .bind(body.message_id)
     .bind(claims.sub)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
 
     let row = sqlx::query_as::<_, DmMessageRow>(
         r#"SELECT m.id, m.channel_id, m.content, m.attachments, m.edited_at, m.created_at,
@@ -978,6 +1012,43 @@ async fn add_dm_reaction(
 
     check_dm_access(&state, channel_id, claims.sub).await?;
 
+    let mut tx = state.db.begin().await?;
+    let locked_channel_id: Uuid =
+        sqlx::query_scalar("SELECT channel_id FROM dm_messages WHERE id = $1 FOR UPDATE")
+            .bind(message_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or(AppError::NotFound("DM message not found".into()))?;
+    if locked_channel_id != channel_id {
+        return Err(AppError::Forbidden("DM message channel changed".into()));
+    }
+
+    let emoji_already_present = sqlx::query_scalar::<_, bool>(
+        r#"SELECT EXISTS (
+               SELECT 1
+               FROM dm_message_reactions
+               WHERE message_id = $1 AND emoji = $2
+           )"#,
+    )
+    .bind(message_id)
+    .bind(&emoji)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if !emoji_already_present {
+        let distinct_emoji_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(DISTINCT emoji) FROM dm_message_reactions WHERE message_id = $1",
+        )
+        .bind(message_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if distinct_emoji_count >= 20 {
+            return Err(AppError::Validation(
+                "This message already has the maximum of 20 different reactions".into(),
+            ));
+        }
+    }
+
     sqlx::query(
         r#"INSERT INTO dm_message_reactions (message_id, user_id, emoji)
            VALUES ($1, $2, $3)
@@ -986,8 +1057,9 @@ async fn add_dm_reaction(
     .bind(message_id)
     .bind(claims.sub)
     .bind(&emoji)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
 
     let mut message = load_dm_message_with_author(&state.db, message_id).await?;
     attach_dm_message_reactions(&state.db, std::slice::from_mut(&mut message), claims.sub).await?;

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -483,10 +483,18 @@ async fn pin_channel_message(
     )
     .await?;
 
+    let mut tx = state.db.begin().await?;
+    let server_id: Uuid =
+        sqlx::query_scalar("SELECT server_id FROM channels WHERE id = $1 FOR UPDATE")
+            .bind(channel_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Channel not found".into()))?;
+
     let msg_channel: Option<Uuid> =
         sqlx::query_scalar("SELECT channel_id FROM messages WHERE id = $1")
             .bind(body.message_id)
-            .fetch_optional(&state.db)
+            .fetch_optional(&mut *tx)
             .await?;
 
     let msg_channel = msg_channel.ok_or_else(|| AppError::NotFound("Message not found".into()))?;
@@ -503,14 +511,14 @@ async fn pin_channel_message(
     )
     .bind(channel_id)
     .bind(body.message_id)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await?;
 
     if !already_pinned {
         let pin_count =
             sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM channel_pins WHERE channel_id = $1")
                 .bind(channel_id)
-                .fetch_one(&state.db)
+                .fetch_one(&mut *tx)
                 .await?;
         if pin_count >= 50 {
             return Err(AppError::Validation(
@@ -519,7 +527,7 @@ async fn pin_channel_message(
         }
     }
 
-    sqlx::query(
+    let inserted = sqlx::query(
         r#"INSERT INTO channel_pins (channel_id, message_id, pinned_by_id)
            VALUES ($1, $2, $3)
            ON CONFLICT (channel_id, message_id) DO NOTHING"#,
@@ -527,25 +535,22 @@ async fn pin_channel_message(
     .bind(channel_id)
     .bind(body.message_id)
     .bind(claims.sub)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
 
-    // We need server_id to log this
-    let server_id: Uuid = sqlx::query_scalar("SELECT server_id FROM channels WHERE id = $1")
-        .bind(channel_id)
-        .fetch_one(&state.db)
+    if inserted.rows_affected() > 0 {
+        crate::services::audit::log_in_transaction(
+            &mut tx,
+            claims.sub,
+            Some(server_id),
+            "message_pin",
+            "message",
+            Some(body.message_id),
+            Some(serde_json::json!({ "channel_id": channel_id })),
+        )
         .await?;
-
-    crate::services::audit::log(
-        &state.db,
-        claims.sub,
-        Some(server_id),
-        "message_pin",
-        "message",
-        Some(body.message_id),
-        Some(serde_json::json!({ "channel_id": channel_id })),
-    )
-    .await?;
+    }
+    tx.commit().await?;
 
     let row = sqlx::query_as::<_, MessageRow>(
         r#"SELECT m.id, m.channel_id, m.content, m.attachments, m.edited_at, m.created_at,
@@ -992,6 +997,17 @@ async fn add_message_reaction(
     )
     .await?;
 
+    let mut tx = state.db.begin().await?;
+    let locked_channel_id: Uuid =
+        sqlx::query_scalar("SELECT channel_id FROM messages WHERE id = $1 FOR UPDATE")
+            .bind(message_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or(AppError::NotFound("Message not found".into()))?;
+    if locked_channel_id != channel_id {
+        return Err(AppError::Forbidden("Message channel changed".into()));
+    }
+
     let emoji_already_present = sqlx::query_scalar::<_, bool>(
         r#"SELECT EXISTS (
                SELECT 1
@@ -1001,7 +1017,7 @@ async fn add_message_reaction(
     )
     .bind(message_id)
     .bind(&emoji)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await?;
 
     if !emoji_already_present {
@@ -1009,7 +1025,7 @@ async fn add_message_reaction(
             "SELECT COUNT(DISTINCT emoji) FROM message_reactions WHERE message_id = $1",
         )
         .bind(message_id)
-        .fetch_one(&state.db)
+        .fetch_one(&mut *tx)
         .await?;
         if distinct_emoji_count >= 20 {
             return Err(AppError::Validation(
@@ -1026,8 +1042,9 @@ async fn add_message_reaction(
     .bind(message_id)
     .bind(claims.sub)
     .bind(&emoji)
-    .execute(&state.db)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
 
     let mut msg_with_author = load_message_with_author(&state.db, message_id).await?;
     attach_message_reactions(

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -2410,31 +2410,12 @@ async fn report_user(
         return Err(AppError::NotFound("Member not found".into()));
     }
 
-    let existing_report_id = sqlx::query_scalar::<_, Uuid>(
-        r#"SELECT id
-           FROM server_reports
-           WHERE server_id = $1
-             AND reporter_user_id = $2
-             AND reported_user_id = $3
-             AND message_id IS NULL
-             AND status = 'open'
-           LIMIT 1"#,
-    )
-    .bind(server_id)
-    .bind(claims.sub)
-    .bind(body.reported_user_id)
-    .fetch_optional(&state.db)
-    .await?;
-    if existing_report_id.is_some() {
-        return Ok(Json(
-            serde_json::json!({ "message": "Report already submitted" }),
-        ));
-    }
-
-    sqlx::query(
+    let inserted_report_id = sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO server_reports (
                 id, server_id, reporter_user_id, reported_user_id, reason, details, created_at
-           ) VALUES ($1, $2, $3, $4, $5, $6, NOW())"#,
+           ) VALUES ($1, $2, $3, $4, $5, $6, NOW())
+           ON CONFLICT DO NOTHING
+           RETURNING id"#,
     )
     .bind(Uuid::new_v4())
     .bind(server_id)
@@ -2442,10 +2423,15 @@ async fn report_user(
     .bind(body.reported_user_id)
     .bind(reason)
     .bind(details)
-    .execute(&state.db)
+    .fetch_optional(&state.db)
     .await?;
 
-    Ok(Json(serde_json::json!({ "message": "Report submitted" })))
+    let message = if inserted_report_id.is_some() {
+        "Report submitted"
+    } else {
+        "Report already submitted"
+    };
+    Ok(Json(serde_json::json!({ "message": message })))
 }
 
 async fn report_message(
@@ -2488,30 +2474,12 @@ async fn report_message(
         ));
     }
 
-    let existing_report_id = sqlx::query_scalar::<_, Uuid>(
-        r#"SELECT id
-           FROM server_reports
-           WHERE server_id = $1
-             AND reporter_user_id = $2
-             AND message_id = $3
-             AND status = 'open'
-           LIMIT 1"#,
-    )
-    .bind(server_id)
-    .bind(claims.sub)
-    .bind(body.message_id)
-    .fetch_optional(&state.db)
-    .await?;
-    if existing_report_id.is_some() {
-        return Ok(Json(
-            serde_json::json!({ "message": "Report already submitted" }),
-        ));
-    }
-
-    sqlx::query(
+    let inserted_report_id = sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO server_reports (
                 id, server_id, reporter_user_id, reported_user_id, channel_id, message_id, message_excerpt, reason, details, created_at
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())"#,
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+           ON CONFLICT DO NOTHING
+           RETURNING id"#,
     )
     .bind(Uuid::new_v4())
     .bind(server_id)
@@ -2522,10 +2490,15 @@ async fn report_message(
     .bind(message_excerpt)
     .bind(reason)
     .bind(details)
-    .execute(&state.db)
+    .fetch_optional(&state.db)
     .await?;
 
-    Ok(Json(serde_json::json!({ "message": "Report submitted" })))
+    let message = if inserted_report_id.is_some() {
+        "Report submitted"
+    } else {
+        "Report already submitted"
+    };
+    Ok(Json(serde_json::json!({ "message": message })))
 }
 
 async fn list_reports(

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -201,6 +201,41 @@ async fn register_user(
     (token, user_id)
 }
 
+async fn create_server_with_default_text_channel(
+    app: &mut axum::Router,
+    state: &AppState,
+    auth_header: &str,
+    name: &str,
+) -> (Uuid, Uuid, String) {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/servers")
+        .header("Authorization", auth_header)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "name": name })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(app, request).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "server create failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let server: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let server_id = Uuid::parse_str(server["id"].as_str().unwrap()).unwrap();
+    let invite_code = server["invite_code"].as_str().unwrap().to_string();
+    let channel_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM channels WHERE server_id = $1 AND channel_type = 'text' ORDER BY position ASC LIMIT 1",
+    )
+    .bind(server_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    (server_id, channel_id, invite_code)
+}
+
 fn token_hash_base64(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
@@ -3751,4 +3786,341 @@ async fn concurrent_text_channel_deletes_preserve_one_channel() {
     .await
     .unwrap();
     assert_eq!(delete_audit_count, 1);
+}
+
+#[tokio::test]
+async fn concurrent_pin_and_reaction_requests_preserve_message_limits() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let suffix = Uuid::new_v4();
+    let (owner_token, owner_id) = register_user(
+        &mut app,
+        &format!("message-limit-{suffix}@example.com"),
+        &format!("message_limit_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let owner_auth = format!("Bearer {owner_token}");
+    let (_server_id, channel_id, _) = create_server_with_default_text_channel(
+        &mut app,
+        &state,
+        &owner_auth,
+        "Message Limit Race Server",
+    )
+    .await;
+
+    sqlx::query(
+        r#"INSERT INTO messages (id, channel_id, user_id, content, created_at)
+           SELECT uuid_generate_v4(), $1, $2, 'pin limit seed', NOW()
+           FROM generate_series(1, 49)"#,
+    )
+    .bind(channel_id)
+    .bind(owner_id)
+    .execute(&state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"INSERT INTO channel_pins (channel_id, message_id, pinned_by_id)
+           SELECT $1, id, $2
+           FROM messages
+           WHERE channel_id = $1 AND content = 'pin limit seed'"#,
+    )
+    .bind(channel_id)
+    .bind(owner_id)
+    .execute(&state.db)
+    .await
+    .unwrap();
+
+    let pin_candidate_a = Uuid::new_v4();
+    let pin_candidate_b = Uuid::new_v4();
+    for message_id in [pin_candidate_a, pin_candidate_b] {
+        sqlx::query(
+            "INSERT INTO messages (id, channel_id, user_id, content) VALUES ($1, $2, $3, 'pin race candidate')",
+        )
+        .bind(message_id)
+        .bind(channel_id)
+        .bind(owner_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    }
+
+    let pin_request = |message_id: Uuid| {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/messages/{channel_id}/pins"))
+            .header("Authorization", &owner_auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "message_id": message_id })).unwrap(),
+            ))
+            .unwrap()
+    };
+    let (pin_a, pin_b) = tokio::join!(
+        app.clone().oneshot(pin_request(pin_candidate_a)),
+        app.clone().oneshot(pin_request(pin_candidate_b))
+    );
+    let pin_statuses = [
+        pin_a.expect("pin request A should resolve").status(),
+        pin_b.expect("pin request B should resolve").status(),
+    ];
+    assert_eq!(
+        pin_statuses
+            .iter()
+            .filter(|status| **status == StatusCode::OK)
+            .count(),
+        1
+    );
+    assert_eq!(
+        pin_statuses
+            .iter()
+            .filter(|status| **status == StatusCode::BAD_REQUEST)
+            .count(),
+        1
+    );
+    let pin_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM channel_pins WHERE channel_id = $1")
+            .bind(channel_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    assert_eq!(pin_count, 50);
+
+    let reaction_message_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO messages (id, channel_id, user_id, content) VALUES ($1, $2, $3, 'reaction race target')",
+    )
+    .bind(reaction_message_id)
+    .bind(channel_id)
+    .bind(owner_id)
+    .execute(&state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"INSERT INTO message_reactions (message_id, user_id, emoji)
+           SELECT $1, $2, 'seed-' || seed
+           FROM generate_series(1, 19) AS seed"#,
+    )
+    .bind(reaction_message_id)
+    .bind(owner_id)
+    .execute(&state.db)
+    .await
+    .unwrap();
+
+    let reaction_request = |emoji: &str| {
+        Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/api/messages/item/{reaction_message_id}/reactions"
+            ))
+            .header("Authorization", &owner_auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "emoji": emoji })).unwrap(),
+            ))
+            .unwrap()
+    };
+    let (reaction_a, reaction_b) = tokio::join!(
+        app.clone().oneshot(reaction_request("new-a")),
+        app.clone().oneshot(reaction_request("new-b"))
+    );
+    let reaction_statuses = [
+        reaction_a
+            .expect("reaction request A should resolve")
+            .status(),
+        reaction_b
+            .expect("reaction request B should resolve")
+            .status(),
+    ];
+    assert_eq!(
+        reaction_statuses
+            .iter()
+            .filter(|status| **status == StatusCode::OK)
+            .count(),
+        1
+    );
+    assert_eq!(
+        reaction_statuses
+            .iter()
+            .filter(|status| **status == StatusCode::BAD_REQUEST)
+            .count(),
+        1
+    );
+    let reaction_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(DISTINCT emoji) FROM message_reactions WHERE message_id = $1",
+    )
+    .bind(reaction_message_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(reaction_count, 20);
+}
+
+#[tokio::test]
+async fn concurrent_duplicate_reports_create_one_open_report() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let reporter_suffix = Uuid::new_v4();
+    let (reporter_token, reporter_id) = register_user(
+        &mut app,
+        &format!("reporter-{reporter_suffix}@example.com"),
+        &format!("reporter_{}", reporter_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let target_suffix = Uuid::new_v4();
+    let (target_token, target_id) = register_user(
+        &mut app,
+        &format!("report-target-{target_suffix}@example.com"),
+        &format!("report_target_{}", target_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let reporter_auth = format!("Bearer {reporter_token}");
+    let target_auth = format!("Bearer {target_token}");
+    let (server_id, channel_id, invite_code) = create_server_with_default_text_channel(
+        &mut app,
+        &state,
+        &reporter_auth,
+        "Report Race Server",
+    )
+    .await;
+
+    let join_request = Request::builder()
+        .method("POST")
+        .uri("/api/servers/join")
+        .header("Authorization", &target_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "invite_code": invite_code })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, join_request).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "target join failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let user_report_request = || {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/servers/{server_id}/reports/user"))
+            .header("Authorization", &reporter_auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "reported_user_id": target_id,
+                    "reason": "spam"
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+    let (user_report_a, user_report_b) = tokio::join!(
+        app.clone().oneshot(user_report_request()),
+        app.clone().oneshot(user_report_request())
+    );
+    assert_eq!(
+        user_report_a
+            .expect("user report A should resolve")
+            .status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        user_report_b
+            .expect("user report B should resolve")
+            .status(),
+        StatusCode::OK
+    );
+
+    let send_request = Request::builder()
+        .method("POST")
+        .uri(format!("/api/messages/{channel_id}"))
+        .header("Authorization", &target_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "content": "report race message" })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, send_request).await;
+    assert_eq!(status, StatusCode::OK);
+    let message: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let message_id = Uuid::parse_str(message["id"].as_str().unwrap()).unwrap();
+
+    let message_report_request = || {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/servers/{server_id}/reports/message"))
+            .header("Authorization", &reporter_auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "message_id": message_id,
+                    "reason": "spam"
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+    let (message_report_a, message_report_b) = tokio::join!(
+        app.clone().oneshot(message_report_request()),
+        app.clone().oneshot(message_report_request())
+    );
+    assert_eq!(
+        message_report_a
+            .expect("message report A should resolve")
+            .status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        message_report_b
+            .expect("message report B should resolve")
+            .status(),
+        StatusCode::OK
+    );
+
+    let open_report_count: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*)
+           FROM server_reports
+           WHERE server_id = $1
+             AND reporter_user_id = $2
+             AND reported_user_id = $3
+             AND status = 'open'"#,
+    )
+    .bind(server_id)
+    .bind(reporter_id)
+    .bind(target_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(open_report_count, 2, "one user and one message report should remain");
+
+    let duplicate_groups: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*)
+           FROM (
+               SELECT message_id
+               FROM server_reports
+               WHERE server_id = $1
+                 AND reporter_user_id = $2
+                 AND reported_user_id = $3
+                 AND status = 'open'
+               GROUP BY message_id
+               HAVING COUNT(*) > 1
+           ) duplicates"#,
+    )
+    .bind(server_id)
+    .bind(reporter_id)
+    .bind(target_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(duplicate_groups, 0);
 }

--- a/apps/web/e2e/core-ui-smoke.spec.ts
+++ b/apps/web/e2e/core-ui-smoke.spec.ts
@@ -268,6 +268,48 @@ test.describe('mocked core UI smoke', () => {
     expect(state.messagesByChannelId[general.id].some((message) => message.id === 'own-message')).toBe(false)
   })
 
+  test('keeps reactions below inline media and attachments', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const general = channels.find((channel) => channel.name === 'general')
+    if (!general) throw new Error('Core channel fixture is incomplete.')
+
+    const message = buildServerMessage(
+      general.id,
+      'Media order\n![gif](https://media.example.test/reaction.gif)',
+      {
+        id: 'media-reaction-message',
+        attachments: [
+          {
+            url: 'https://cdn.example.test/screenshot.png',
+            type: 'image/png',
+            name: 'screenshot.png',
+          },
+        ],
+        reactions: [{ emoji: '👍', count: 2, reacted: false }],
+      }
+    )
+    const state = createMockCoreState({
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: { [general.id]: [message] },
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/servers')
+    const row = page.locator('[data-message-id="media-reaction-message"]')
+    await expect(row.locator('.message-reactions')).toBeVisible()
+    await expect(row.locator('.dm-attachments')).toBeVisible()
+    await expect(row.locator('.chat-inline-gif-link')).toBeVisible()
+    await expect.poll(async () =>
+      row.locator('.chat-inline-gif-link, .dm-attachments, .message-reactions').evaluateAll(
+        (elements) => elements.map((element) => element.className)
+      )
+    ).toEqual(['chat-inline-gif-link', 'dm-attachments', 'message-reactions'])
+  })
+
   test('opens Voice & Audio settings without overflowing the settings modal', async ({ page }) => {
     const state = createMockCoreState({ friends: buildFriends(3) })
     await installMockCoreApi(page, state)

--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -57,7 +57,23 @@ test.describe('mocked mobile web smoke', () => {
       channelsByServerId: { [server.id]: channels },
       membersByServerId: { [server.id]: buildCoreMembers() },
       messagesByChannelId: {
-        [general.id]: [buildServerMessage(general.id, 'Mobile smoke baseline message')],
+        [general.id]: [
+          buildServerMessage(
+            general.id,
+            'Mobile smoke baseline message\n![gif](https://media.example.test/mobile.gif)',
+            {
+              id: 'mobile-media-reaction-message',
+              attachments: [
+                {
+                  url: 'https://cdn.example.test/mobile.png',
+                  type: 'image/png',
+                  name: 'mobile.png',
+                },
+              ],
+              reactions: [{ emoji: '👍', count: 1, reacted: false }],
+            }
+          ),
+        ],
       },
     })
     await installMockCoreApi(page, state)
@@ -71,6 +87,14 @@ test.describe('mocked mobile web smoke', () => {
     await expect(page.getByRole('button', { name: 'Browse GIFs' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Browse stickers' })).toBeVisible()
     await expectNoHorizontalOverflow(page.locator('.shell-layout'))
+
+    const mediaRow = page.locator('[data-message-id="mobile-media-reaction-message"]')
+    await expect(mediaRow.locator('.message-reactions')).toBeVisible()
+    await expect.poll(async () =>
+      mediaRow.locator('.chat-inline-gif-link, .dm-attachments, .message-reactions').evaluateAll(
+        (elements) => elements.map((element) => element.className)
+      )
+    ).toEqual(['chat-inline-gif-link', 'dm-attachments', 'message-reactions'])
 
     const content = `Mobile smoke message ${Date.now()}`
     const messageInput = page.getByPlaceholder('Message #general')

--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -561,4 +561,38 @@ describe('ChatArea regressions', () => {
     expect(preview).toHaveAttribute('height', '180')
     expect(preview).toHaveAttribute('alt', '')
   })
+
+  it('renders reactions after inline media and attachments', async () => {
+    mockDecodedImages()
+
+    const { container } = renderChatArea({
+      messages: [
+        {
+          ...message(
+            'message-media-reaction',
+            'party\n![gif](https://media.example.test/reaction.gif)',
+            0
+          ),
+          attachments: [
+            {
+              url: 'https://cdn.example.test/screenshot.png',
+              type: 'image/png',
+              name: 'screenshot.png',
+            },
+          ],
+          reactions: [{ emoji: '👍', count: 2, reacted: true }],
+        },
+      ],
+      onToggleReaction: vi.fn(),
+    })
+
+    await screen.findByRole('button', { name: 'Preview screenshot.png' })
+    const messageRow = container.querySelector('[data-message-id="message-media-reaction"]')
+    expect(messageRow).not.toBeNull()
+    expect(
+      Array.from(
+        messageRow!.querySelectorAll('.chat-inline-gif-link, .dm-attachments, .message-reactions')
+      ).map((element) => element.className)
+    ).toEqual(['chat-inline-gif-link', 'dm-attachments', 'message-reactions'])
+  })
 })

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -2249,22 +2249,6 @@ export default function ChatArea({
                                             ) : (
                                                 renderMessageContent(msg.content)
                                             )}
-                                            {Array.isArray(msg.reactions) && msg.reactions.length > 0 && (
-                                                <div className="message-reactions">
-                                                    {msg.reactions.map((reaction) => (
-                                                        <button
-                                                            key={`${msg.id}-${reaction.emoji}`}
-                                                            type="button"
-                                                            className={`message-reaction-btn ${reaction.reacted ? 'is-reacted' : ''}`}
-                                                            disabled={!onToggleReaction}
-                                                            onClick={() => onToggleReaction?.(msg.id, reaction.emoji, !!reaction.reacted)}
-                                                        >
-                                                            <span>{reaction.emoji}</span>
-                                                            <span>{reaction.count}</span>
-                                                        </button>
-                                                    ))}
-                                                </div>
-                                            )}
                                             {msg.clientStatus === 'failed' && msg.clientId && (
                                                 <div className="message-retry-row">
                                                     <button
@@ -2289,6 +2273,22 @@ export default function ChatArea({
                                                             <AttachmentLink key={`${att.url}-${i}`} attachment={att} index={i} />
                                                         )
                                                     })}
+                                                </div>
+                                            )}
+                                            {Array.isArray(msg.reactions) && msg.reactions.length > 0 && (
+                                                <div className="message-reactions">
+                                                    {msg.reactions.map((reaction) => (
+                                                        <button
+                                                            key={`${msg.id}-${reaction.emoji}`}
+                                                            type="button"
+                                                            className={`message-reaction-btn ${reaction.reacted ? 'is-reacted' : ''}`}
+                                                            disabled={!onToggleReaction}
+                                                            onClick={() => onToggleReaction?.(msg.id, reaction.emoji, !!reaction.reacted)}
+                                                        >
+                                                            <span>{reaction.emoji}</span>
+                                                            <span>{reaction.count}</span>
+                                                        </button>
+                                                    ))}
                                                 </div>
                                             )}
                                             {isDm && msg.author?.user_id === currentUserId && isSeenMessage(msg.id) && (

--- a/docs/API.md
+++ b/docs/API.md
@@ -204,12 +204,14 @@ Notes:
 - `GET /api/messages/:channel_id/pins`
 - `POST /api/messages/:channel_id/pins` (requires `MANAGE_PINS`)
 - `DELETE /api/messages/:channel_id/pins/:message_id` (requires `MANAGE_PINS`)
+- Server channels and direct-message conversations accept at most 50 pinned messages. Concurrent pin requests are serialized against the parent channel.
 
 ### Reactions
 
 - `POST /api/messages/item/:message_id/reactions`
 - `DELETE /api/messages/item/:message_id/reactions?emoji=...`
 - Reaction add/remove requires effective `SEND_MESSAGES`.
+- Server and direct messages accept at most 20 distinct reaction emoji. Concurrent additions are serialized against the parent message.
 
 ## Friends Endpoints
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -207,6 +207,8 @@ Critical multi-row writes use explicit PostgreSQL transactions and serialize com
 - Server creation commits the server, owner membership, default text/voice channels, default category, and bootstrap roles as one unit. A failed bootstrap cannot expose a partially initialized server.
 - Member-role replacement locks the server and target membership rows, re-checks permissions on the same connection, validates requested roles in one batch, replaces assignments in bulk, updates the legacy bridge role, and writes its audit entry in one transaction.
 - Channel creation and deletion serialize on the same server-row lock. Text-channel deletion counts the remaining channels while holding that lock, so concurrent deletes cannot remove the final text channel.
+- Pin additions lock their server or DM channel before enforcing the 50-pin limit. Reaction additions lock their server or DM message before enforcing the 20-distinct-emoji limit.
+- Open user and message reports are protected by partial unique indexes. Concurrent duplicate submissions resolve to the existing moderation-queue item instead of creating duplicate rows.
 
 WebSocket broadcasts and LiveKit reconciliation happen only after the database commit. They may report or reconcile committed state, but they cannot cause a successful database transaction to be presented as rolled back.
 
@@ -259,6 +261,7 @@ All migrations currently present:
 - `038_server_onboarding_guides.sql`
 - `039_default_dm_privacy_everyone.sql`
 - `040_dm_channel_hidden_state.sql`
+- `041_open_report_uniqueness.sql`
 
 ## Notes
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -364,7 +364,9 @@ Critical role replacement and channel deletion flows lock their server-scoped da
 
 AutoMod rules are server-scoped and require `MANAGE_MESSAGES` to manage. Enabled rules can block server-channel sends/edits for blocked keywords, invite links, links, or mention spam before persistence/broadcast. AutoMod matching removes common invisible Unicode format/control characters before evaluation so zero-width and bidi override characters cannot be used to split blocked keywords or links. AutoMod blocks write audit entries with rule metadata and a truncated content preview.
 
-User and message reports require server membership, are rate limited per reporter/server, and repeated open reports for the same target are deduplicated before they reach the moderation queue. Report listing is capped to keep the safety panel responsive under abuse.
+User and message reports require server membership, are rate limited per reporter/server, and use partial unique database indexes so concurrent repeated open reports for the same target cannot duplicate moderation work. Report listing is capped to keep the safety panel responsive under abuse.
+
+Pin and reaction limits are enforced while holding row locks on their parent channel or message. Concurrent requests therefore cannot exceed the 50-pin or 20-distinct-reaction limits in server and direct-message conversations.
 
 Temporary member timeouts require `MANAGE_MESSAGES`, respect role hierarchy, cannot target the server owner, and block server-channel sends/edits plus new reactions until expiration or manual clearing. Timeout create/clear actions are audit logged.
 


### PR DESCRIPTION
## Summary

- render message reactions below inline GIFs, stickers, and attachments
- enforce server and DM pin/reaction limits with transactional row locks
- prevent duplicate open user and message reports with partial unique indexes
- add concurrent backend integration tests and desktop/mobile UI regressions
- document the new message integrity guarantees

## Validation

- `cargo check --locked`
- `cargo test --locked -- --test-threads=1`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run test:e2e:ui-smoke`
- `npm run test:e2e:mobile-smoke`