### PR TITLE
security: rate limit abuse-sensitive endpoints

### DIFF
--- a/apps/server/src/routes/attachments.rs
+++ b/apps/server/src/routes/attachments.rs
@@ -24,6 +24,9 @@ use crate::{
 };
 
 const FREE_TIER_STORAGE_QUOTA_BYTES: i64 = 1_073_741_824; // 1 GiB
+const ATTACHMENT_CONTENT_USER_RATE_LIMIT_MAX: usize = 240;
+const ATTACHMENT_CONTENT_ITEM_RATE_LIMIT_MAX: usize = 30;
+const ATTACHMENT_CONTENT_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 
 pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
     let protected = Router::new()
@@ -258,6 +261,26 @@ async fn get_attachment_content(
     Path(attachment_id): Path<Uuid>,
     Query(query): Query<AttachmentContentQuery>,
 ) -> Result<impl IntoResponse, AppError> {
+    enforce_rate_limit(
+        &state.redis,
+        format!("attachments:content:user:{}", claims.sub),
+        ATTACHMENT_CONTENT_USER_RATE_LIMIT_MAX,
+        ATTACHMENT_CONTENT_RATE_LIMIT_WINDOW,
+        "Attachment content rate limit exceeded. Please retry shortly.",
+    )
+    .await?;
+    enforce_rate_limit(
+        &state.redis,
+        format!(
+            "attachments:content:item:{}:{}",
+            claims.sub, attachment_id
+        ),
+        ATTACHMENT_CONTENT_ITEM_RATE_LIMIT_MAX,
+        ATTACHMENT_CONTENT_RATE_LIMIT_WINDOW,
+        "Attachment content rate limit exceeded. Please retry shortly.",
+    )
+    .await?;
+
     let allowed = state.attachment_service.verify_signed_content_url(
         attachment_id,
         query.exp,

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -18,6 +18,9 @@ use crate::{
     AppState,
 };
 
+const DM_SEARCH_RATE_LIMIT_MAX: usize = 15;
+const DM_SEARCH_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
 fn escape_ilike_pattern(input: &str) -> String {
     input
         .replace('\\', "\\\\")
@@ -709,6 +712,14 @@ async fn search_dm_messages(
     Query(query): Query<DmSearchQuery>,
 ) -> Result<Json<Vec<MessageWithAuthor>>, AppError> {
     check_dm_access(&state, channel_id, claims.sub).await?;
+    enforce_rate_limit(
+        &state.redis,
+        format!("dm:search:{}:{}", claims.sub, channel_id),
+        DM_SEARCH_RATE_LIMIT_MAX,
+        DM_SEARCH_RATE_LIMIT_WINDOW,
+        "Search rate limit exceeded. Please slow down.",
+    )
+    .await?;
 
     let term = query.q.as_deref().unwrap_or("").trim();
     let author = query.from.as_deref().unwrap_or("").trim().trim_start_matches('@');

--- a/apps/server/src/routes/webrtc.rs
+++ b/apps/server/src/routes/webrtc.rs
@@ -17,9 +17,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::{
     errors::AppError,
     middleware::auth::{require_auth, Claims},
+    services::rate_limit::enforce_rate_limit,
     ws::access::can_join_voice_channel,
     AppState,
 };
+
+const TURN_CREDENTIAL_RATE_LIMIT_MAX: usize = 30;
+const LIVEKIT_TOKEN_USER_RATE_LIMIT_MAX: usize = 30;
+const LIVEKIT_TOKEN_RATE_LIMIT_MAX: usize = 20;
+const MEDIA_TOKEN_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Serialize)]
 pub struct TurnCredentialsResponse {
@@ -65,6 +71,15 @@ async fn turn_credentials(
     State(state): State<Arc<AppState>>,
     Extension(claims): Extension<Claims>,
 ) -> Result<Json<TurnCredentialsResponse>, AppError> {
+    enforce_rate_limit(
+        &state.redis,
+        format!("webrtc:turn-credentials:{}", claims.sub),
+        TURN_CREDENTIAL_RATE_LIMIT_MAX,
+        MEDIA_TOKEN_RATE_LIMIT_WINDOW,
+        "TURN credential rate limit exceeded. Please retry shortly.",
+    )
+    .await?;
+
     tracing::info!(
         "User {} ({}) requested TURN credentials",
         claims.username,
@@ -145,6 +160,22 @@ async fn livekit_token(
 ) -> Result<Json<LivekitTokenResponse>, AppError> {
     let channel_id = uuid::Uuid::parse_str(&query.channel_id)
         .map_err(|_| AppError::Validation("Invalid channel_id".into()))?;
+    enforce_rate_limit(
+        &state.redis,
+        format!("webrtc:livekit-token:{}", claims.sub),
+        LIVEKIT_TOKEN_USER_RATE_LIMIT_MAX,
+        MEDIA_TOKEN_RATE_LIMIT_WINDOW,
+        "Voice token rate limit exceeded. Please retry shortly.",
+    )
+    .await?;
+    enforce_rate_limit(
+        &state.redis,
+        format!("webrtc:livekit-token:{}:{}", claims.sub, channel_id),
+        LIVEKIT_TOKEN_RATE_LIMIT_MAX,
+        MEDIA_TOKEN_RATE_LIMIT_WINDOW,
+        "Voice token rate limit exceeded. Please retry shortly.",
+    )
+    .await?;
 
     let can_join = can_join_voice_channel(&state.db, claims.sub, channel_id).await?;
     if !can_join {

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -4124,3 +4124,250 @@ async fn concurrent_duplicate_reports_create_one_open_report() {
     .unwrap();
     assert_eq!(duplicate_groups, 0);
 }
+
+#[tokio::test]
+async fn dm_message_search_rate_limit_matches_server_search() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let user_suffix = Uuid::new_v4();
+    let (user_token, user_id) = register_user(
+        &mut app,
+        &format!("dm-search-limit-{user_suffix}@example.com"),
+        &format!("dm_search_{}", user_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let peer_suffix = Uuid::new_v4();
+    let (_, peer_id) = register_user(
+        &mut app,
+        &format!("dm-search-peer-{peer_suffix}@example.com"),
+        &format!("dm_peer_{}", peer_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let auth_header = format!("Bearer {user_token}");
+    let channel_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO dm_channels (id) VALUES ($1)")
+        .bind(channel_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO dm_channel_members (channel_id, user_id) VALUES ($1, $2), ($1, $3)",
+    )
+    .bind(channel_id)
+    .bind(user_id)
+    .bind(peer_id)
+    .execute(&state.db)
+    .await
+    .unwrap();
+
+    let search_request = || {
+        Request::builder()
+            .uri(format!(
+                "/api/dm/messages/{channel_id}/search?q=rate-limit"
+            ))
+            .header("Authorization", &auth_header)
+            .body(Body::empty())
+            .unwrap()
+    };
+    for attempt in 1..=15 {
+        let (status, body) = oneshot(&mut app, search_request()).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "DM search attempt {attempt} failed unexpectedly: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let (status, body) = oneshot(&mut app, search_request()).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the sixteenth DM search should be rate limited: {}",
+        String::from_utf8_lossy(&body)
+    );
+}
+
+#[tokio::test]
+async fn voice_credential_endpoints_rate_limit_token_minting() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let suffix = Uuid::new_v4();
+    let (token, _) = register_user(
+        &mut app,
+        &format!("voice-token-limit-{suffix}@example.com"),
+        &format!("voice_limit_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let auth_header = format!("Bearer {token}");
+    let (server_id, _, _) = create_server_with_default_text_channel(
+        &mut app,
+        &state,
+        &auth_header,
+        "Voice Token Limit Server",
+    )
+    .await;
+    let voice_channel_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM channels WHERE server_id = $1 AND channel_type = 'voice' LIMIT 1",
+    )
+    .bind(server_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+
+    let turn_request = || {
+        Request::builder()
+            .uri("/api/webrtc/turn-credentials")
+            .header("Authorization", &auth_header)
+            .body(Body::empty())
+            .unwrap()
+    };
+    for attempt in 1..=30 {
+        let (status, body) = oneshot(&mut app, turn_request()).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "TURN credential attempt {attempt} failed unexpectedly: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let (status, body) = oneshot(&mut app, turn_request()).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the thirty-first TURN request should be rate limited: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let livekit_request = || {
+        Request::builder()
+            .uri(format!(
+                "/api/webrtc/livekit-token?channel_id={voice_channel_id}"
+            ))
+            .header("Authorization", &auth_header)
+            .body(Body::empty())
+            .unwrap()
+    };
+    for attempt in 1..=20 {
+        let (status, body) = oneshot(&mut app, livekit_request()).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "LiveKit token attempt {attempt} failed unexpectedly: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let (status, body) = oneshot(&mut app, livekit_request()).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the twenty-first LiveKit token request should be rate limited: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let second_suffix = Uuid::new_v4();
+    let (second_token, _) = register_user(
+        &mut app,
+        &format!("voice-global-limit-{second_suffix}@example.com"),
+        &format!("voice_global_{}", second_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let second_auth_header = format!("Bearer {second_token}");
+    let unauthorized_livekit_request = || {
+        Request::builder()
+            .uri(format!(
+                "/api/webrtc/livekit-token?channel_id={}",
+                Uuid::new_v4()
+            ))
+            .header("Authorization", &second_auth_header)
+            .body(Body::empty())
+            .unwrap()
+    };
+    for attempt in 1..=30 {
+        let (status, body) = oneshot(&mut app, unauthorized_livekit_request()).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "unauthorized LiveKit attempt {attempt} should reach access validation: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let (status, body) = oneshot(&mut app, unauthorized_livekit_request()).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the thirty-first cross-channel LiveKit request should hit the user-wide limit: {}",
+        String::from_utf8_lossy(&body)
+    );
+}
+
+#[tokio::test]
+async fn attachment_content_rate_limit_runs_before_signature_and_storage_work() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app().await;
+    let suffix = Uuid::new_v4();
+    let (token, _) = register_user(
+        &mut app,
+        &format!("attachment-read-limit-{suffix}@example.com"),
+        &format!("attachment_read_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let auth_header = format!("Bearer {token}");
+    let attachment_id = Uuid::new_v4();
+    let content_request = |requested_attachment_id: Uuid| {
+        Request::builder()
+            .uri(format!(
+                "/api/attachments/content/{requested_attachment_id}?exp=4102444800&sig=invalid"
+            ))
+            .header("Authorization", &auth_header)
+            .body(Body::empty())
+            .unwrap()
+    };
+
+    for attempt in 1..=30 {
+        let (status, body) = oneshot(&mut app, content_request(attachment_id)).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "attachment attempt {attempt} should reach signature validation: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let (status, body) = oneshot(&mut app, content_request(attachment_id)).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the thirty-first attachment request should be limited before validation: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    for attempt in 32..=240 {
+        let (status, body) = oneshot(&mut app, content_request(Uuid::new_v4())).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "attachment attempt {attempt} should remain under the user-wide limit: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let (status, body) = oneshot(&mut app, content_request(Uuid::new_v4())).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the 241st attachment request should hit the user-wide limit: {}",
+        String::from_utf8_lossy(&body)
+    );
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -276,7 +276,11 @@ Current key limits (Redis-backed):
 - Change password: 5/hour per user
 - Friend request: 5/min per user
 - DM channel create: 5/min per user
+- Server and DM message search: 15/min per user/channel
 - Message send: `MESSAGE_RATE_LIMIT_MAX` / `MESSAGE_RATE_LIMIT_WINDOW_SECS`
+- TURN credentials: 30/min per user
+- LiveKit tokens: 30/min per user and 20/min per user/voice channel
+- Attachment content: 240/min per user and 30/min per user/attachment
 - Report submit: 5/min per reporter/server
 - WS connect: 3/10s per user
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -132,6 +132,10 @@ pub fn validate_security_config(cors_origins: &[String], cookie_secure: bool) ->
 - **Auth** (`/api/auth/login`, `/api/auth/register`): 10 requests per minute per user
 - **Friend request** (`/api/friends/requests`): 5 requests per minute per user
 - **DM create** (`/api/dm/channels/:peer_id`): 5 requests per minute per user
+- **Message search** (server and DM): 15 requests per minute per user/channel
+- **TURN credentials**: 30 requests per minute per user
+- **LiveKit tokens**: 30 requests per minute per user and 20 requests per minute per user/voice channel
+- **Attachment content**: 240 requests per minute per user and 30 requests per minute per user/attachment
 - **Server join raid signals**: join bursts and new-account join bursts are recorded for moderator review.
 - **Server message raid protection**: message bursts and invite spikes are tracked per server/user; bursts can be rejected with `429` and write raid audit events.
 - **Messages** (`/api/messages/:id`): 30 messages per 10 seconds per user


### PR DESCRIPTION
## Summary

- add Redis-backed rate limiting to DM message search
- protect TURN and LiveKit token endpoints from excessive token generation
- prevent LiveKit per-channel rate-limit bypasses with a user-wide limit
- limit attachment content access per user and per attachment
- add integration coverage for normal thresholds and controlled `429` responses
- document the new endpoint limits

## Validation

- `cargo test --locked -- --test-threads=1`
- `git diff --check`

Closes the abuse and rate-limit hardening task.