### PR TITLE
fix: make core write retries idempotent

### DIFF
--- a/apps/server/migrations/042_idempotent_write_requests.sql
+++ b/apps/server/migrations/042_idempotent_write_requests.sql
@@ -1,0 +1,43 @@
+ALTER TABLE messages
+    ADD COLUMN client_request_id TEXT;
+
+CREATE UNIQUE INDEX uq_messages_client_request
+    ON messages(channel_id, user_id, client_request_id)
+    WHERE client_request_id IS NOT NULL;
+
+ALTER TABLE dm_messages
+    ADD COLUMN client_request_id TEXT;
+
+CREATE UNIQUE INDEX uq_dm_messages_client_request
+    ON dm_messages(channel_id, user_id, client_request_id)
+    WHERE client_request_id IS NOT NULL;
+
+ALTER TABLE servers
+    ADD COLUMN client_request_id TEXT;
+
+CREATE UNIQUE INDEX uq_servers_owner_client_request
+    ON servers(owner_id, client_request_id)
+    WHERE client_request_id IS NOT NULL;
+
+-- Retain the oldest pending request for each unordered user pair before
+-- enforcing atomic uniqueness for future concurrent requests.
+WITH ranked_pending_requests AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY LEAST(requester_id, receiver_id), GREATEST(requester_id, receiver_id)
+               ORDER BY created_at ASC, id ASC
+           ) AS duplicate_rank
+    FROM friend_requests
+    WHERE status = 'pending'
+)
+DELETE FROM friend_requests request
+USING ranked_pending_requests ranked
+WHERE request.id = ranked.id
+  AND ranked.duplicate_rank > 1;
+
+CREATE UNIQUE INDEX uq_friend_requests_pending_pair
+    ON friend_requests(
+        LEAST(requester_id, receiver_id),
+        GREATEST(requester_id, receiver_id)
+    )
+    WHERE status = 'pending';

--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -26,6 +26,9 @@ pub enum AppError {
     #[error("Validation error: {0}")]
     Validation(String),
 
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     #[error("Too many requests: {0}")]
     TooManyRequests(String),
 
@@ -48,6 +51,7 @@ impl IntoResponse for AppError {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone(), None),
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone(), None),
             AppError::Validation(msg) => (StatusCode::BAD_REQUEST, msg.clone(), None),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone(), None),
             AppError::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg.clone(), None),
             AppError::FeatureDisabled(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -100,6 +104,7 @@ mod tests {
             (AppError::NotFound("x".into()), StatusCode::NOT_FOUND),
             (AppError::Forbidden("x".into()), StatusCode::FORBIDDEN),
             (AppError::Validation("x".into()), StatusCode::BAD_REQUEST),
+            (AppError::Conflict("x".into()), StatusCode::CONFLICT),
             (
                 AppError::TooManyRequests("x".into()),
                 StatusCode::TOO_MANY_REQUESTS,

--- a/apps/server/src/models/message.rs
+++ b/apps/server/src/models/message.rs
@@ -48,6 +48,7 @@ pub struct MessageAuthor {
 pub struct SendMessageRequest {
     pub content: Option<String>,
     pub attachments: Option<serde_json::Value>,
+    pub client_request_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/server/src/models/server.rs
+++ b/apps/server/src/models/server.rs
@@ -43,6 +43,7 @@ pub struct CreateServerRequest {
     pub name: String,
     pub icon_url: Option<String>,
     pub description: Option<String>,
+    pub client_request_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/server/src/routes/attachments.rs
+++ b/apps/server/src/routes/attachments.rs
@@ -17,6 +17,7 @@ use crate::{
     middleware::auth::{require_auth, Claims},
     services::{
         attachments::AttachmentResponseItem,
+        idempotency::acquire_transaction_lock,
         permissions::{self, Permissions},
         rate_limit::enforce_rate_limit,
     },
@@ -159,6 +160,51 @@ async fn process_attachment_upload(
             .attachment_service
             .prepare_file_for_storage(&file_name, &content_type, &bytes)
             .await?;
+
+        acquire_transaction_lock(
+            tx,
+            &format!(
+                "attachment-upload:{}:{}:{}:{}:{}",
+                user_id,
+                prepared.sha256,
+                prepared.size_bytes,
+                prepared.content_type,
+                prepared.original_name
+            ),
+        )
+        .await?;
+        let existing = sqlx::query_as::<_, (Uuid, String, String, i64, String)>(
+            r#"SELECT id, content_type, original_name, size_bytes, sha256
+               FROM uploaded_attachments
+               WHERE user_id = $1
+                 AND sha256 = $2
+                 AND size_bytes = $3
+                 AND content_type = $4
+                 AND original_name = $5
+                 AND scan_status = 'clean'
+               ORDER BY created_at ASC
+               LIMIT 1"#,
+        )
+        .bind(user_id)
+        .bind(&prepared.sha256)
+        .bind(prepared.size_bytes)
+        .bind(&prepared.content_type)
+        .bind(&prepared.original_name)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if let Some((id, content_type, original_name, size_bytes, sha256)) = existing {
+            uploaded.push(AttachmentResponseItem {
+                id,
+                url: state
+                    .attachment_service
+                    .signed_content_url(id, &state.jwt_secret),
+                content_type,
+                name: original_name,
+                size: size_bytes,
+                sha256,
+            });
+            continue;
+        }
 
         let reserve_result = sqlx::query_scalar::<_, Uuid>(
             r#"UPDATE users

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -13,7 +13,10 @@ use crate::{
     errors::AppError,
     middleware::auth::{require_auth, Claims},
     models::{MessageAuthor, MessageQuery, MessageReactionSummary, MessageWithAuthor},
-    services::rate_limit::enforce_rate_limit,
+    services::{
+        idempotency::normalize_client_request_id,
+        rate_limit::enforce_rate_limit,
+    },
     ws::WsEvent,
     AppState,
 };
@@ -56,6 +59,7 @@ pub struct DmSearchQuery {
 pub struct SendDmMessageRequest {
     pub content: Option<String>,
     pub attachments: Option<serde_json::Value>,
+    pub client_request_id: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -89,6 +93,28 @@ struct DmMessageRow {
     user_id: Uuid,
     username: String,
     avatar_url: Option<String>,
+}
+
+async fn find_dm_message_by_client_request_id(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    user_id: Uuid,
+    client_request_id: &str,
+) -> Result<Option<DmMessageRow>, AppError> {
+    Ok(sqlx::query_as::<_, DmMessageRow>(
+        r#"SELECT m.id, m.channel_id, m.content, m.attachments, m.edited_at, m.created_at,
+                  u.id AS user_id, u.username, u.avatar_url
+           FROM dm_messages m
+           INNER JOIN users u ON u.id = m.user_id
+           WHERE m.channel_id = $1
+             AND m.user_id = $2
+             AND m.client_request_id = $3"#,
+    )
+    .bind(channel_id)
+    .bind(user_id)
+    .bind(client_request_id)
+    .fetch_optional(&state.db)
+    .await?)
 }
 
 impl From<DmMessageRow> for MessageWithAuthor {
@@ -572,15 +598,7 @@ async fn send_dm_message(
     .ok_or(AppError::NotFound("DM channel peer not found".into()))?;
     check_can_dm_peer(&state, claims.sub, peer_id).await?;
 
-    enforce_rate_limit(
-        &state.redis,
-        format!("message:dm:{}:{}", channel_id, claims.sub),
-        state.message_rate_limit_max,
-        Duration::from_secs(state.message_rate_limit_window_secs),
-        "Message rate limit exceeded. Please slow down.",
-    )
-    .await?;
-
+    let client_request_id = normalize_client_request_id(body.client_request_id.as_deref())?;
     let content = body.content.unwrap_or_default();
     let normalized_attachments = state
         .attachment_service
@@ -599,10 +617,53 @@ async fn send_dm_message(
         ));
     }
 
+    let replayed_row = if let Some(request_id) = client_request_id.as_deref() {
+        find_dm_message_by_client_request_id(&state, channel_id, claims.sub, request_id).await?
+    } else {
+        None
+    };
+    if let Some(row) = replayed_row {
+        if row.content != content || row.attachments != normalized_attachments {
+            return Err(AppError::Conflict(
+                "client_request_id was already used for a different DM message".into(),
+            ));
+        }
+        let mut message: MessageWithAuthor = row.into();
+        attach_dm_message_reactions(
+            &state.db,
+            std::slice::from_mut(&mut message),
+            claims.sub,
+        )
+        .await?;
+        message.attachments = state
+            .attachment_service
+            .hydrate_attachments_for_output(
+                &state.db,
+                &state.jwt_secret,
+                message.attachments.clone(),
+            )
+            .await?;
+        return Ok(Json(message));
+    }
+
+    enforce_rate_limit(
+        &state.redis,
+        format!("message:dm:{}:{}", channel_id, claims.sub),
+        state.message_rate_limit_max,
+        Duration::from_secs(state.message_rate_limit_window_secs),
+        "Message rate limit exceeded. Please slow down.",
+    )
+    .await?;
+
     let id = Uuid::new_v4();
-    let row = sqlx::query_as::<_, DmMessageRow>(
-        r#"INSERT INTO dm_messages (id, channel_id, user_id, content, attachments, created_at)
-           VALUES ($1, $2, $3, $4, $5, NOW())
+    let inserted_row = sqlx::query_as::<_, DmMessageRow>(
+        r#"INSERT INTO dm_messages (
+               id, channel_id, user_id, content, attachments, client_request_id, created_at
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, NOW())
+           ON CONFLICT (channel_id, user_id, client_request_id)
+               WHERE client_request_id IS NOT NULL
+           DO NOTHING
            RETURNING id, channel_id, content, attachments, edited_at, created_at,
                      $3 as user_id,
                      (SELECT username FROM users WHERE id = $3) as username,
@@ -613,8 +674,31 @@ async fn send_dm_message(
     .bind(claims.sub)
     .bind(&content)
     .bind(&normalized_attachments)
-    .fetch_one(&state.db)
+    .bind(&client_request_id)
+    .fetch_optional(&state.db)
     .await?;
+
+    let (row, inserted) = if let Some(row) = inserted_row {
+        (row, true)
+    } else {
+        let request_id = client_request_id.as_deref().ok_or_else(|| {
+            AppError::Internal("DM insert returned no row without an idempotency key".into())
+        })?;
+        let row = find_dm_message_by_client_request_id(
+            &state,
+            channel_id,
+            claims.sub,
+            request_id,
+        )
+        .await?
+        .ok_or_else(|| AppError::Internal("Idempotent DM replay was not found".into()))?;
+        if row.content != content || row.attachments != normalized_attachments {
+            return Err(AppError::Conflict(
+                "client_request_id was already used for a different DM message".into(),
+            ));
+        }
+        (row, false)
+    };
 
     let mut message: MessageWithAuthor = row.into();
     attach_dm_message_reactions(&state.db, std::slice::from_mut(&mut message), claims.sub).await?;
@@ -622,15 +706,17 @@ async fn send_dm_message(
         .attachment_service
         .hydrate_attachments_for_output(&state.db, &state.jwt_secret, message.attachments.clone())
         .await?;
-    mark_dm_read(&state, channel_id, claims.sub, Some(message.id)).await?;
-    publish_dm_read(&state, channel_id, claims.sub, Some(message.id)).await;
-    let event = WsEvent::NewMessage {
-        channel_id,
-        channel_type: "dm".to_string(),
-        message: message.clone(),
-    };
-    if let Err(e) = push_dm_event_to_members(&state, channel_id, claims.sub, &event).await {
-        tracing::warn!("Failed to push DM event to members: {}", e);
+    if inserted {
+        mark_dm_read(&state, channel_id, claims.sub, Some(message.id)).await?;
+        publish_dm_read(&state, channel_id, claims.sub, Some(message.id)).await;
+        let event = WsEvent::NewMessage {
+            channel_id,
+            channel_type: "dm".to_string(),
+            message: message.clone(),
+        };
+        if let Err(e) = push_dm_event_to_members(&state, channel_id, claims.sub, &event).await {
+            tracing::warn!("Failed to push DM event to members: {}", e);
+        }
     }
     Ok(Json(message))
 }

--- a/apps/server/src/routes/friends.rs
+++ b/apps/server/src/routes/friends.rs
@@ -188,38 +188,30 @@ async fn send_friend_request(
         return Err(AppError::Validation("You are already friends".into()));
     }
 
-    let pending = sqlx::query_scalar::<_, i64>(
-        r#"SELECT COUNT(*) FROM friend_requests
-           WHERE status = 'pending'
-             AND ((requester_id = $1 AND receiver_id = $2)
-               OR (requester_id = $2 AND receiver_id = $1))"#,
-    )
-    .bind(claims.sub)
-    .bind(target.id)
-    .fetch_one(&state.db)
-    .await?;
-
-    if pending > 0 {
-        return Err(AppError::Validation(
-            "A pending request already exists".into(),
-        ));
-    }
-
-    sqlx::query(
-        "INSERT INTO friend_requests (id, requester_id, receiver_id, status, created_at) VALUES ($1, $2, $3, 'pending', NOW())",
+    let inserted_request_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO friend_requests (id, requester_id, receiver_id, status, created_at)
+           VALUES ($1, $2, $3, 'pending', NOW())
+           ON CONFLICT DO NOTHING
+           RETURNING id"#,
     )
     .bind(Uuid::new_v4())
     .bind(claims.sub)
     .bind(target.id)
-    .execute(&state.db)
+    .fetch_optional(&state.db)
     .await?;
 
-    notify_friend_update(&state, claims.sub).await;
-    notify_friend_update(&state, target.id).await;
+    if inserted_request_id.is_some() {
+        notify_friend_update(&state, claims.sub).await;
+        notify_friend_update(&state, target.id).await;
+    }
 
-    Ok(Json(
-        serde_json::json!({ "message": "Friend request sent" }),
-    ))
+    Ok(Json(serde_json::json!({
+        "message": if inserted_request_id.is_some() {
+            "Friend request sent"
+        } else {
+            "A pending request already exists"
+        }
+    })))
 }
 
 async fn accept_friend_request(

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     services::{
         automod,
+        idempotency::normalize_client_request_id,
         moderation,
         permissions::{self, Permissions},
         rate_limit::enforce_rate_limit,
@@ -175,6 +176,39 @@ struct MessageRow {
     username: String,
     avatar_url: Option<String>,
     role_color: Option<String>,
+}
+
+async fn find_message_by_client_request_id(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    user_id: Uuid,
+    client_request_id: &str,
+) -> Result<Option<MessageRow>, AppError> {
+    Ok(sqlx::query_as::<_, MessageRow>(
+        r#"SELECT m.id, m.channel_id, m.content, m.attachments, m.edited_at, m.created_at,
+                  u.id AS user_id, u.username, u.avatar_url,
+                  (
+                      SELECT sr.color
+                      FROM server_roles sr
+                      INNER JOIN server_member_roles smr ON sr.id = smr.role_id
+                      INNER JOIN channels c ON c.server_id = sr.server_id
+                      WHERE smr.user_id = m.user_id
+                        AND c.id = m.channel_id
+                        AND sr.color IS NOT NULL
+                      ORDER BY sr.position ASC
+                      LIMIT 1
+                  ) AS role_color
+           FROM messages m
+           INNER JOIN users u ON u.id = m.user_id
+           WHERE m.channel_id = $1
+             AND m.user_id = $2
+             AND m.client_request_id = $3"#,
+    )
+    .bind(channel_id)
+    .bind(user_id)
+    .bind(client_request_id)
+    .fetch_optional(&state.db)
+    .await?)
 }
 
 impl From<MessageRow> for MessageWithAuthor {
@@ -654,15 +688,7 @@ async fn send_message(
     let server_id = server_id_for_channel(&state.db, channel_id).await?;
     moderation::ensure_not_timed_out(&state.db, server_id, claims.sub).await?;
 
-    enforce_rate_limit(
-        &state.redis,
-        format!("message:channel:{}:{}", channel_id, claims.sub),
-        state.message_rate_limit_max,
-        Duration::from_secs(state.message_rate_limit_window_secs),
-        "Message rate limit exceeded. Please slow down.",
-    )
-    .await?;
-
+    let client_request_id = normalize_client_request_id(body.client_request_id.as_deref())?;
     let raw_content = body.content.unwrap_or_default();
     let content = if can_use_mass_mentions(channel_perms) {
         raw_content
@@ -685,6 +711,39 @@ async fn send_message(
             "Message must be 1-4000 characters".into(),
         ));
     }
+    let replayed_row = if let Some(request_id) = client_request_id.as_deref() {
+        find_message_by_client_request_id(&state, channel_id, claims.sub, request_id).await?
+    } else {
+        None
+    };
+    if let Some(row) = replayed_row {
+        if row.content != content || row.attachments != normalized_attachments {
+            return Err(AppError::Conflict(
+                "client_request_id was already used for a different message".into(),
+            ));
+        }
+        let mut message: MessageWithAuthor = row.into();
+        attach_message_reactions(&state.db, std::slice::from_mut(&mut message), claims.sub).await?;
+        message.attachments = state
+            .attachment_service
+            .hydrate_attachments_for_output(
+                &state.db,
+                &state.jwt_secret,
+                message.attachments.clone(),
+            )
+            .await?;
+        return Ok(Json(message));
+    }
+
+    enforce_rate_limit(
+        &state.redis,
+        format!("message:channel:{}:{}", channel_id, claims.sub),
+        state.message_rate_limit_max,
+        Duration::from_secs(state.message_rate_limit_window_secs),
+        "Message rate limit exceeded. Please slow down.",
+    )
+    .await?;
+
     if let Some(matched) =
         automod::evaluate_message(&state.db, server_id, channel_id, claims.sub, &content).await?
     {
@@ -706,10 +765,15 @@ async fn send_message(
     .await?;
 
     // Insert and fetch with author in one round-trip using CTE
-    let row = sqlx::query_as::<_, MessageRow>(
+    let inserted_row = sqlx::query_as::<_, MessageRow>(
         r#"WITH new_msg AS (
-               INSERT INTO messages (id, channel_id, user_id, content, attachments, created_at)
-               VALUES ($1, $2, $3, $4, $5, NOW())
+               INSERT INTO messages (
+                   id, channel_id, user_id, content, attachments, client_request_id, created_at
+               )
+               VALUES ($1, $2, $3, $4, $5, $6, NOW())
+               ON CONFLICT (channel_id, user_id, client_request_id)
+                   WHERE client_request_id IS NOT NULL
+               DO NOTHING
                RETURNING *
            )
            SELECT nm.id, nm.channel_id, nm.content, nm.attachments, nm.edited_at, nm.created_at,
@@ -733,8 +797,26 @@ async fn send_message(
     .bind(claims.sub)
     .bind(&content)
     .bind(&normalized_attachments)
-    .fetch_one(&state.db)
+    .bind(&client_request_id)
+    .fetch_optional(&state.db)
     .await?;
+
+    let (row, inserted) = if let Some(row) = inserted_row {
+        (row, true)
+    } else {
+        let request_id = client_request_id.as_deref().ok_or_else(|| {
+            AppError::Internal("Message insert returned no row without an idempotency key".into())
+        })?;
+        let row = find_message_by_client_request_id(&state, channel_id, claims.sub, request_id)
+            .await?
+            .ok_or_else(|| AppError::Internal("Idempotent message replay was not found".into()))?;
+        if row.content != content || row.attachments != normalized_attachments {
+            return Err(AppError::Conflict(
+                "client_request_id was already used for a different message".into(),
+            ));
+        }
+        (row, false)
+    };
 
     let mut msg_with_author: MessageWithAuthor = row.into();
     attach_message_reactions(
@@ -752,16 +834,18 @@ async fn send_message(
         )
         .await?;
 
-    // Broadcast to WebSocket subscribers
-    crate::ws::publish_event(
-        &state,
-        WsEvent::NewMessage {
-            channel_id,
-            channel_type: "text".to_string(), // Text channel messages
-            message: msg_with_author.clone(),
-        },
-    )
-    .await;
+    // Replayed requests return the original message without broadcasting it twice.
+    if inserted {
+        crate::ws::publish_event(
+            &state,
+            WsEvent::NewMessage {
+                channel_id,
+                channel_type: "text".to_string(), // Text channel messages
+                message: msg_with_author.clone(),
+            },
+        )
+        .await;
+    }
 
     Ok(Json(msg_with_author))
 }

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -25,6 +25,7 @@ use crate::{
         automod::AutoModRule,
         avatar_images::validate_server_icon_image_url,
         client_ip::resolve_client_ip,
+        idempotency::{acquire_transaction_lock, normalize_client_request_id},
         moderation::{self, RaidEventEntry, ServerTimeoutEntry},
         permissions::{self, Permissions},
         rate_limit::enforce_rate_limit,
@@ -564,14 +565,44 @@ async fn create_server(
     }
 
     let icon_url = validate_server_icon_url(body.icon_url.as_deref())?;
+    let client_request_id = normalize_client_request_id(body.client_request_id.as_deref())?;
 
     let server_id = Uuid::new_v4();
     let invite_code = generate_invite_code();
     let mut tx = state.db.begin().await?;
 
+    if let Some(request_id) = client_request_id.as_deref() {
+        acquire_transaction_lock(
+            &mut tx,
+            &format!("server-create:{}:{}", claims.sub, request_id),
+        )
+        .await?;
+        let existing = sqlx::query_as::<_, Server>(
+            "SELECT * FROM servers WHERE owner_id = $1 AND client_request_id = $2",
+        )
+        .bind(claims.sub)
+        .bind(request_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some(existing) = existing {
+            if existing.name != body.name
+                || existing.icon_url != icon_url
+                || existing.description != body.description
+            {
+                return Err(AppError::Conflict(
+                    "client_request_id was already used for a different server".into(),
+                ));
+            }
+            tx.commit().await?;
+            return Ok(Json(existing));
+        }
+    }
+
     let server = sqlx::query_as::<_, Server>(
-        r#"INSERT INTO servers (id, name, icon_url, description, owner_id, invite_code, created_at)
-           VALUES ($1, $2, $3, $4, $5, $6, NOW())
+        r#"INSERT INTO servers (
+               id, name, icon_url, description, owner_id, invite_code, client_request_id, created_at
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
            RETURNING *"#,
     )
     .bind(server_id)
@@ -580,6 +611,7 @@ async fn create_server(
     .bind(&body.description)
     .bind(claims.sub)
     .bind(&invite_code)
+    .bind(&client_request_id)
     .fetch_one(&mut *tx)
     .await?;
 

--- a/apps/server/src/services/idempotency.rs
+++ b/apps/server/src/services/idempotency.rs
@@ -1,0 +1,54 @@
+use sqlx::{Postgres, Transaction};
+
+use crate::errors::AppError;
+
+const MAX_CLIENT_REQUEST_ID_LEN: usize = 128;
+
+pub fn normalize_client_request_id(value: Option<&str>) -> Result<Option<String>, AppError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > MAX_CLIENT_REQUEST_ID_LEN
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    {
+        return Err(AppError::Validation(
+            "client_request_id must be 1-128 URL-safe characters".into(),
+        ));
+    }
+    Ok(Some(value.to_owned()))
+}
+
+pub async fn acquire_transaction_lock(
+    tx: &mut Transaction<'_, Postgres>,
+    lock_key: &str,
+) -> Result<(), AppError> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(lock_key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_normal_client_request_ids() {
+        assert_eq!(
+            normalize_client_request_id(Some("request_123:retry-1")).unwrap(),
+            Some("request_123:retry-1".into())
+        );
+    }
+
+    #[test]
+    fn rejects_empty_oversized_and_unsafe_client_request_ids() {
+        assert!(normalize_client_request_id(Some(" ")).is_err());
+        assert!(normalize_client_request_id(Some(&"a".repeat(129))).is_err());
+        assert!(normalize_client_request_id(Some("request/123")).is_err());
+    }
+}

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -5,6 +5,7 @@ pub mod automod;
 pub mod auth;
 pub mod client_ip;
 pub mod email;
+pub mod idempotency;
 pub mod jwt_blacklist;
 pub mod moderation;
 pub mod permissions;

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -4371,3 +4371,309 @@ async fn attachment_content_rate_limit_runs_before_signature_and_storage_work() 
         String::from_utf8_lossy(&body)
     );
 }
+
+#[tokio::test]
+async fn message_and_dm_retries_create_one_persistent_message() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let suffix = Uuid::new_v4();
+    let (token, user_id) = register_user(
+        &mut app,
+        &format!("idempotent-message-{suffix}@example.com"),
+        &format!("idem_msg_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let peer_suffix = Uuid::new_v4();
+    let (_, peer_id) = register_user(
+        &mut app,
+        &format!("idempotent-peer-{peer_suffix}@example.com"),
+        &format!("idem_peer_{}", peer_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let auth = format!("Bearer {token}");
+    let (_, channel_id, _) = create_server_with_default_text_channel(
+        &mut app,
+        &state,
+        &auth,
+        "Idempotent Message Server",
+    )
+    .await;
+
+    let message_request_id = format!("message-{suffix}");
+    let message_request = |content: &str| {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/messages/{channel_id}"))
+            .header("Authorization", &auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "content": content,
+                    "client_request_id": message_request_id
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+    let (first_status, first_body) = oneshot(&mut app, message_request("send once")).await;
+    let (retry_status, retry_body) = oneshot(&mut app, message_request("send once")).await;
+    assert_eq!(first_status, StatusCode::OK);
+    assert_eq!(retry_status, StatusCode::OK);
+    let first_message: serde_json::Value = serde_json::from_slice(&first_body).unwrap();
+    let retried_message: serde_json::Value = serde_json::from_slice(&retry_body).unwrap();
+    assert_eq!(first_message["id"], retried_message["id"]);
+    let message_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM messages WHERE channel_id = $1 AND user_id = $2 AND client_request_id = $3",
+    )
+    .bind(channel_id)
+    .bind(user_id)
+    .bind(&message_request_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(message_count, 1);
+    let (conflict_status, _) = oneshot(&mut app, message_request("different content")).await;
+    assert_eq!(conflict_status, StatusCode::CONFLICT);
+
+    let dm_channel_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO dm_channels (id) VALUES ($1)")
+        .bind(dm_channel_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO dm_channel_members (channel_id, user_id) VALUES ($1, $2), ($1, $3)",
+    )
+    .bind(dm_channel_id)
+    .bind(user_id)
+    .bind(peer_id)
+    .execute(&state.db)
+    .await
+    .unwrap();
+    let dm_request_id = format!("dm-{suffix}");
+    let dm_request = || {
+        Request::builder()
+            .method("POST")
+            .uri(format!("/api/dm/messages/{dm_channel_id}"))
+            .header("Authorization", &auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "content": "send DM once",
+                    "client_request_id": dm_request_id
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+    let (first_status, first_body) = oneshot(&mut app, dm_request()).await;
+    let (retry_status, retry_body) = oneshot(&mut app, dm_request()).await;
+    assert_eq!(first_status, StatusCode::OK);
+    assert_eq!(retry_status, StatusCode::OK);
+    let first_dm: serde_json::Value = serde_json::from_slice(&first_body).unwrap();
+    let retried_dm: serde_json::Value = serde_json::from_slice(&retry_body).unwrap();
+    assert_eq!(first_dm["id"], retried_dm["id"]);
+    let dm_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM dm_messages WHERE channel_id = $1 AND user_id = $2 AND client_request_id = $3",
+    )
+    .bind(dm_channel_id)
+    .bind(user_id)
+    .bind(&dm_request_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(dm_count, 1);
+}
+
+#[tokio::test]
+async fn server_create_retry_returns_the_original_server() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let suffix = Uuid::new_v4();
+    let (token, user_id) = register_user(
+        &mut app,
+        &format!("idempotent-server-{suffix}@example.com"),
+        &format!("idem_server_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let auth = format!("Bearer {token}");
+    let request_id = format!("server-{suffix}");
+    let create_request = |name: &str| {
+        Request::builder()
+            .method("POST")
+            .uri("/api/servers")
+            .header("Authorization", &auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "name": name,
+                    "description": "Retry-safe server",
+                    "client_request_id": request_id
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    };
+    let (first_status, first_body) = oneshot(&mut app, create_request("One Server")).await;
+    let (retry_status, retry_body) = oneshot(&mut app, create_request("One Server")).await;
+    assert_eq!(first_status, StatusCode::OK);
+    assert_eq!(retry_status, StatusCode::OK);
+    let first: serde_json::Value = serde_json::from_slice(&first_body).unwrap();
+    let retry: serde_json::Value = serde_json::from_slice(&retry_body).unwrap();
+    assert_eq!(first["id"], retry["id"]);
+    let server_id = Uuid::parse_str(first["id"].as_str().unwrap()).unwrap();
+    let server_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM servers WHERE owner_id = $1 AND client_request_id = $2",
+    )
+    .bind(user_id)
+    .bind(&request_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(server_count, 1);
+    let channel_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM channels WHERE server_id = $1")
+            .bind(server_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    assert_eq!(channel_count, 2);
+    let (conflict_status, _) = oneshot(&mut app, create_request("Changed Server")).await;
+    assert_eq!(conflict_status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn repeated_attachment_upload_reuses_storage_and_quota() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let suffix = Uuid::new_v4();
+    let (token, user_id) = register_user(
+        &mut app,
+        &format!("idempotent-upload-{suffix}@example.com"),
+        &format!("idem_upload_{}", suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let auth = format!("Bearer {token}");
+    let upload_request = || {
+        let boundary = format!("----voxpery-idempotent-{suffix}");
+        let body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"files\"; filename=\"retry.txt\"\r\nContent-Type: text/plain\r\n\r\nretry-safe upload\r\n--{boundary}--\r\n"
+        );
+        Request::builder()
+            .method("POST")
+            .uri("/api/attachments/upload")
+            .header("Authorization", &auth)
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body.into_bytes()))
+            .unwrap()
+    };
+    let (first_status, first_body) = oneshot(&mut app, upload_request()).await;
+    let (retry_status, retry_body) = oneshot(&mut app, upload_request()).await;
+    assert_eq!(first_status, StatusCode::OK);
+    assert_eq!(retry_status, StatusCode::OK);
+    let first: serde_json::Value = serde_json::from_slice(&first_body).unwrap();
+    let retry: serde_json::Value = serde_json::from_slice(&retry_body).unwrap();
+    assert_eq!(first[0]["id"], retry[0]["id"]);
+    let attachment_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM uploaded_attachments WHERE user_id = $1 AND original_name = 'retry.txt'",
+    )
+    .bind(user_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(attachment_count, 1);
+    let storage_used: i64 =
+        sqlx::query_scalar("SELECT storage_used_bytes FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    assert_eq!(storage_used, 17);
+}
+
+#[tokio::test]
+async fn concurrent_friend_requests_create_one_pending_pair() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+    let sender_suffix = Uuid::new_v4();
+    let (sender_token, sender_id) = register_user(
+        &mut app,
+        &format!("friend-idem-sender-{sender_suffix}@example.com"),
+        &format!("friend_sender_{}", sender_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let target_suffix = Uuid::new_v4();
+    let (target_token, target_id) = register_user(
+        &mut app,
+        &format!("friend-idem-target-{target_suffix}@example.com"),
+        &format!("friend_target_{}", target_suffix.as_u128() % 1_000_000),
+        test_credential("default"),
+    )
+    .await;
+    let sender_auth = format!("Bearer {sender_token}");
+    let target_auth = format!("Bearer {target_token}");
+    let sender_username: String =
+        sqlx::query_scalar("SELECT username FROM users WHERE id = $1")
+            .bind(sender_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    let target_username: String =
+        sqlx::query_scalar("SELECT username FROM users WHERE id = $1")
+            .bind(target_id)
+            .fetch_one(&state.db)
+            .await
+            .unwrap();
+    let friend_request = |auth: &str, username: &str| {
+        Request::builder()
+            .method("POST")
+            .uri("/api/friends/requests")
+            .header("Authorization", auth)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&json!({ "username": username })).unwrap(),
+            ))
+            .unwrap()
+    };
+    let (request_a, request_b) = tokio::join!(
+        app.clone()
+            .oneshot(friend_request(&sender_auth, &target_username)),
+        app.clone()
+            .oneshot(friend_request(&target_auth, &sender_username))
+    );
+    assert_eq!(request_a.unwrap().status(), StatusCode::OK);
+    assert_eq!(request_b.unwrap().status(), StatusCode::OK);
+    let pending_count: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*)
+           FROM friend_requests
+           WHERE status = 'pending'
+             AND LEAST(requester_id, receiver_id) = LEAST($1::uuid, $2::uuid)
+             AND GREATEST(requester_id, receiver_id) = GREATEST($1::uuid, $2::uuid)"#,
+    )
+    .bind(sender_id)
+    .bind(target_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert_eq!(pending_count, 1);
+}

--- a/apps/web/src/api/dm.ts
+++ b/apps/web/src/api/dm.ts
@@ -30,10 +30,16 @@ export const dmApi = {
             { token },
         ),
 
-    sendMessage: (channelId: string, content: string, attachments: unknown, token: AuthToken) =>
+    sendMessage: (
+        channelId: string,
+        content: string,
+        attachments: unknown,
+        token: AuthToken,
+        clientRequestId?: string,
+    ) =>
         apiFetch<MessageWithAuthor>(`/api/dm/messages/${channelId}`, {
             method: 'POST',
-            body: { content, attachments },
+            body: { content, attachments, client_request_id: clientRequestId },
             token,
         }),
 

--- a/apps/web/src/api/messages.ts
+++ b/apps/web/src/api/messages.ts
@@ -15,10 +15,16 @@ export const messageApi = {
             { token },
         ),
 
-    send: (channelId: string, content: string, attachments: unknown, token: AuthToken) =>
+    send: (
+        channelId: string,
+        content: string,
+        attachments: unknown,
+        token: AuthToken,
+        clientRequestId?: string,
+    ) =>
         apiFetch<MessageWithAuthor>(`/api/messages/${channelId}`, {
             method: 'POST',
-            body: { content, attachments },
+            body: { content, attachments, client_request_id: clientRequestId },
             token,
         }),
 

--- a/apps/web/src/api/servers.ts
+++ b/apps/web/src/api/servers.ts
@@ -11,8 +11,17 @@ export const serverApi = {
     get: (serverId: string, token: AuthToken) =>
         apiFetch<ServerDetail>(`/api/servers/${serverId}`, { token }),
 
-    create: (name: string, description: string | undefined, token: AuthToken) =>
-        apiFetch<Server>('/api/servers', { method: 'POST', body: { name, description }, token }),
+    create: (
+        name: string,
+        description: string | undefined,
+        token: AuthToken,
+        clientRequestId?: string,
+    ) =>
+        apiFetch<Server>('/api/servers', {
+            method: 'POST',
+            body: { name, description, client_request_id: clientRequestId },
+            token,
+        }),
 
     update: (
         serverId: string,

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -497,11 +497,13 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
 
     // Refs to avoid stale closures in WebSocket handlers
     const activeChannelIdRef = useRef(activeChannelId)
+    const pendingMessageFingerprintsRef = useRef(new Set<string>())
     const activeServerIdRef = useRef(activeServerId)
     const channelServerMapRef = useRef<Record<string, string>>({})
     const tokenRef = useRef(token)
     const selectedRoleIdRef = useRef<string | null>(selectedRoleId)
     const createServerInFlightRef = useRef(false)
+    const createServerRequestIdRef = useRef<string | null>(null)
     const serverIconInputRef = useRef<HTMLInputElement | null>(null)
     const messagesByChannelRef = useRef<Record<string, UiMessage[]>>({})
     const serverBootstrapRequestRef = useRef(0)
@@ -1279,6 +1281,9 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         const content = replyingTo
             ? `> @${replyingTo.username}: ${replyingTo.contentSnippet}\n\n${bodyText}`
             : bodyText
+        const sendFingerprint = `${channelId}\n${content}\n${JSON.stringify(attachments)}`
+        if (pendingMessageFingerprintsRef.current.has(sendFingerprint)) return
+        pendingMessageFingerprintsRef.current.add(sendFingerprint)
         setReplyingTo(null)
         const clientId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
         const optimisticId = `local-${clientId}`
@@ -1306,7 +1311,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             return next
         })
         try {
-            const msg = await messageApi.send(channelId, content, attachments, token)
+            const msg = await messageApi.send(channelId, content, attachments, token, clientId)
             const applySentMessage = (current: UiMessage[]) => {
                 return reconcileConfirmedMessage(current, clientId, msg)
             }
@@ -1336,6 +1341,8 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             } else {
                 messagesByChannelRef.current[channelId] = applyFailedMessage(messagesByChannelRef.current[channelId] ?? [])
             }
+        } finally {
+            pendingMessageFingerprintsRef.current.delete(sendFingerprint)
         }
     }
 
@@ -1353,7 +1360,13 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             return next
         })
         try {
-            const msg = await messageApi.send(channelId, target.content, target.attachments ?? [], token)
+            const msg = await messageApi.send(
+                channelId,
+                target.content,
+                target.attachments ?? [],
+                token,
+                clientId,
+            )
             const applyRetriedMessage = (current: UiMessage[]) => {
                 if (current.some((m) => m.id === msg.id)) {
                     return current.filter((m) => m.clientId !== clientId)
@@ -1539,13 +1552,22 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         if (!newServerName.trim() || !isLoggedIn) return
         createServerInFlightRef.current = true
         setIsCreatingServer(true)
+        const requestId = createServerRequestIdRef.current
+            ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+        createServerRequestIdRef.current = requestId
         try {
-            const server = await serverApi.create(newServerName, newServerDescription.trim() || undefined, token)
+            const server = await serverApi.create(
+                newServerName,
+                newServerDescription.trim() || undefined,
+                token,
+                requestId,
+            )
             const allServers = await serverApi.list(token)
             setServers(allServers)
             setActiveServer(server.id)
             setNewServerName('')
             setNewServerDescription('')
+            createServerRequestIdRef.current = null
             setShowCreateServer(false)
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Failed to create server.'
@@ -1576,6 +1598,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
 
     const openCreateModal = () => {
         createServerInFlightRef.current = false
+        createServerRequestIdRef.current = null
         setIsCreatingServer(false)
         setCreateServerError(null)
         setShowCreateServer(true)
@@ -3068,6 +3091,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                 if (isCreatingServer) return
                                 setShowCreateServer(false)
                                 setCreateServerError(null)
+                                createServerRequestIdRef.current = null
                             }}
                         >
                             <form className={`modal${isMobileViewport ? ' modal-compact-mobile' : ''}`} onClick={(e) => e.stopPropagation()} onSubmit={handleCreateServer}>
@@ -3080,7 +3104,10 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                     <input
                                         type="text"
                                         value={newServerName}
-                                        onChange={(e) => setNewServerName(e.target.value)}
+                                        onChange={(e) => {
+                                            setNewServerName(e.target.value)
+                                            createServerRequestIdRef.current = null
+                                        }}
                                         placeholder="My Awesome Server"
                                         autoFocus
                                         disabled={isCreatingServer}
@@ -3092,7 +3119,10 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                     <input
                                         type="text"
                                         value={newServerDescription}
-                                        onChange={(e) => setNewServerDescription(e.target.value)}
+                                        onChange={(e) => {
+                                            setNewServerDescription(e.target.value)
+                                            createServerRequestIdRef.current = null
+                                        }}
                                         placeholder="What's this server about?"
                                         maxLength={500}
                                         disabled={isCreatingServer}

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -212,6 +212,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [dmDraftAttachments, setDmDraftAttachments] = useState<DraftAttachmentItem[]>([])
   const dmMessagesByChannelRef = useRef<Record<string, UiDmMessage[]>>({})
   const activeDmChannelIdRef = useRef(activeDmChannelId)
+  const pendingDmMessageFingerprintsRef = useRef(new Set<string>())
   const isDmConversationVisibleRef = useRef(isDmConversationVisible)
   const dmMessagesRequestRef = useRef(0)
   const pushToast = useToastStore((s) => s.pushToast)
@@ -749,6 +750,9 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     const content = replyingToDm
       ? `> @${replyingToDm.username}: ${replyingToDm.contentSnippet}\n\n${bodyText}`
       : bodyText
+    const sendFingerprint = `${channelId}\n${content}\n${JSON.stringify(attachmentsToSend)}`
+    if (pendingDmMessageFingerprintsRef.current.has(sendFingerprint)) return
+    pendingDmMessageFingerprintsRef.current.add(sendFingerprint)
     setReplyingToDm(null)
     setDmInput('')
     setDmDraftAttachments([])
@@ -775,7 +779,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       return next
     })
     try {
-      const msg = await dmApi.sendMessage(channelId, content, attachmentsToSend, token)
+      const msg = await dmApi.sendMessage(channelId, content, attachmentsToSend, token, clientId)
       clearDmUnread(channelId)
       const applySentDm = (current: UiDmMessage[]) => {
         return reconcileConfirmedMessage(current, clientId, msg)
@@ -805,6 +809,8 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       } else {
         rememberDmMessages(channelId, applyFailedDm(dmMessagesByChannelRef.current[channelId] ?? []))
       }
+    } finally {
+      pendingDmMessageFingerprintsRef.current.delete(sendFingerprint)
     }
   }
 
@@ -822,7 +828,13 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         return next
       })
       try {
-        const msg = await dmApi.sendMessage(channelId, target.content, target.attachments ?? [], token)
+        const msg = await dmApi.sendMessage(
+          channelId,
+          target.content,
+          target.attachments ?? [],
+          token,
+          clientId,
+        )
         clearDmUnread(channelId)
         const applyRetriedDm = (current: UiDmMessage[]) => {
           if (current.some((m) => m.id === msg.id)) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -78,6 +78,7 @@ Notes:
 
 - `GET /api/servers`
 - `POST /api/servers`
+  - Optional `client_request_id` (1-128 URL-safe characters) makes retries return the originally created server. Reusing the ID with different server data returns `409`.
 - `GET /api/servers/:server_id`
 - `PATCH /api/servers/:server_id` (requires `MANAGE_SERVER`)
 - `DELETE /api/servers/:server_id` (owner)
@@ -171,6 +172,7 @@ Notes:
   - Returns uploaded attachment objects with `id`, signed `url`, `type`, `name`, `size`, `sha256`.
   - Upload pipeline: size/allowlist validation -> magic-byte content validation -> bounded JPEG/PNG decode and metadata cleanup -> optional ClamAV scan -> atomic local storage write -> quota and metadata transaction -> short-lived signed URL.
   - Multi-file uploads are all-or-nothing. If validation, quota reservation, metadata persistence, or transaction commit fails, database changes are rolled back and files already written for that request are removed.
+  - Retry-equivalent files from the same user reuse the existing clean attachment record and do not consume storage quota twice.
 - `GET /api/attachments/content/:attachment_id?exp=...&sig=...`
   - Auth-required endpoint guarded by signature + expiry + attachment ACL checks.
   - Streams attachment media in chat without exposing permanent public file URLs.
@@ -192,6 +194,7 @@ Notes:
   - `from` filters by message author username.
   - `has_attachment=true` returns only messages with one or more attachments.
 - `POST /api/messages/:channel_id` (requires `SEND_MESSAGES`)
+  - Optional `client_request_id` makes network retries return the original message without a second database row or WebSocket broadcast. Reusing the ID with different content returns `409`.
 - `PATCH /api/messages/item/:message_id` (author only)
 - `DELETE /api/messages/item/:message_id` (author or `MANAGE_MESSAGES`)
 - Enabled AutoMod rules are evaluated before server-channel sends/edits are stored or broadcast. Keyword, link, invite, and mention-spam checks normalize invisible Unicode format/control characters before matching.
@@ -219,6 +222,7 @@ Notes:
 - `DELETE /api/friends/:friend_id`
 - `GET /api/friends/requests`
 - `POST /api/friends/requests`
+  - Concurrent requests for the same unordered user pair create at most one pending request.
 - `POST /api/friends/requests/:request_id/accept`
 - `POST /api/friends/requests/:request_id/reject`
 
@@ -236,6 +240,7 @@ Notes:
   - `from` filters by message author username.
   - `has_attachment=true` returns only messages with one or more attachments.
 - `POST /api/dm/messages/:channel_id`
+  - Supports the same optional `client_request_id` retry contract as server-channel messages.
 - `PATCH /api/dm/messages/item/:message_id`
 - `DELETE /api/dm/messages/item/:message_id`
 - `GET /api/dm/channels/:channel_id/read-state`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -265,6 +265,7 @@ let query = format!("SELECT * FROM users WHERE username = '{}'", username); // S
   - Local files are written to a same-directory temporary path, flushed, and atomically renamed so partially written files are never exposed under final storage keys
   - Upload metadata persisted in `uploaded_attachments`
   - Multi-file requests reserve quota and insert metadata in one database transaction; any request or commit failure rolls back the transaction and removes every file already finalized by that request
+  - Retry-equivalent uploads are serialized by content identity and reuse the existing clean attachment record, preventing duplicate files and quota accounting
 - **Delivery model**:
   - Files are not exposed under a permanent public `/uploads` route.
   - API returns short-lived signed URLs (`/api/attachments/content/:id?exp=...&sig=...`).
@@ -369,6 +370,8 @@ Critical role replacement and channel deletion flows lock their server-scoped da
 AutoMod rules are server-scoped and require `MANAGE_MESSAGES` to manage. Enabled rules can block server-channel sends/edits for blocked keywords, invite links, links, or mention spam before persistence/broadcast. AutoMod matching removes common invisible Unicode format/control characters before evaluation so zero-width and bidi override characters cannot be used to split blocked keywords or links. AutoMod blocks write audit entries with rule metadata and a truncated content preview.
 
 User and message reports require server membership, are rate limited per reporter/server, and use partial unique database indexes so concurrent repeated open reports for the same target cannot duplicate moderation work. Report listing is capped to keep the safety panel responsive under abuse.
+
+Server creation and server/DM message sends accept client request identifiers so a network retry returns the original resource without repeating child setup or WebSocket side effects. Reusing an identifier with different input is rejected with `409`. Pending friend requests use an unordered-pair partial unique index, while attachment uploads serialize equivalent content before storage and quota reservation.
 
 Pin and reaction limits are enforced while holding row locks on their parent channel or message. Concurrent requests therefore cannot exceed the 50-pin or 20-distinct-reaction limits in server and direct-message conversations.
 


### PR DESCRIPTION
## Summary

- make server and DM message retries idempotent using client request IDs
- return the original server when a create request is retried
- prevent duplicate attachment storage and quota usage
- enforce atomic uniqueness for pending friend requests
- reject idempotency key reuse with different payloads
- add database-backed regression coverage and document retry contracts

## Database

Adds migration `042_idempotent_write_requests.sql` with request identifiers and partial unique indexes.

## Validation

- `cargo check --locked`
- `cargo test --locked --no-run`
- `cargo test --locked -- --test-threads=1`
- `npm run lint`
- `npm run test:run`
- `npm run build`