### PR TITLE
security: enforce response header policies

### DIFF
--- a/.github/scripts/validate-desktop-release.mjs
+++ b/.github/scripts/validate-desktop-release.mjs
@@ -128,6 +128,12 @@ if (tauri) {
   requireCspSource(tauri.app?.security?.csp, 'connect-src', 'https://challenges.cloudflare.com')
   requireCspSource(tauri.app?.security?.csp, 'script-src', 'https://challenges.cloudflare.com')
   requireCspSource(tauri.app?.security?.csp, 'frame-src', 'https://challenges.cloudflare.com')
+  requireCspSource(tauri.app?.security?.csp, 'media-src', "'self'")
+  requireCspSource(tauri.app?.security?.csp, 'media-src', 'blob:')
+  requireCspSource(tauri.app?.security?.csp, 'object-src', "'none'")
+  requireCspSource(tauri.app?.security?.csp, 'base-uri', "'none'")
+  requireCspSource(tauri.app?.security?.csp, 'form-action', "'self'")
+  requireCspSource(tauri.app?.security?.csp, 'frame-ancestors', "'none'")
 
   const installerIcon = tauri.bundle?.windows?.nsis?.installerIcon
   if (installerIcon !== 'icons/icon.ico') {

--- a/.github/scripts/validate-security-policies.mjs
+++ b/.github/scripts/validate-security-policies.mjs
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs'
+
+import { securityHeaderFailures } from '../../apps/web/scripts/security-headers.mjs'
+
+const failures = []
+
+function read(path) {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (error) {
+    failures.push(`Unable to read ${path}: ${String(error)}`)
+    return ''
+  }
+}
+
+function requireText(label, text, expected) {
+  if (!text.includes(expected)) failures.push(`${label} must include: ${expected}`)
+}
+
+function includesLocalBackendTarget(value) {
+  return /(^|[^a-z0-9.-])(localhost|127\.0\.0\.1)(?::|\/|\\|\*|"|$)/i.test(value)
+}
+
+function validateNginx(path, { production }) {
+  const config = read(path)
+  const label = path
+  requireText(label, config, 'add_header X-Frame-Options "DENY" always;')
+  requireText(label, config, 'add_header X-Content-Type-Options "nosniff" always;')
+  requireText(label, config, 'add_header Referrer-Policy "no-referrer" always;')
+  requireText(label, config, 'camera=(self), microphone=(self), display-capture=(self)')
+  requireText(label, config, "object-src 'none'")
+  requireText(label, config, "base-uri 'self'")
+  requireText(label, config, "form-action 'self'")
+  requireText(label, config, "frame-ancestors 'none'")
+  requireText(label, config, "script-src 'self' 'wasm-unsafe-eval'")
+  requireText(label, config, 'location = /healthz {')
+  requireText(label, config, 'default_type text/plain;')
+
+  if (production) {
+    requireText(label, config, 'add_header Strict-Transport-Security "max-age=31536000" always;')
+    if (includesLocalBackendTarget(config)) {
+      failures.push(`${label} must not include loopback CSP targets`)
+    }
+  }
+
+  const healthBlock = config.match(/location\s*=\s*\/healthz\s*\{([\s\S]*?)\}/)?.[1] || ''
+  if (/\badd_header\b/.test(healthBlock)) {
+    failures.push(`${label} /healthz must inherit server security headers instead of declaring add_header`)
+  }
+}
+
+function validateTauri(path, { production }) {
+  let config
+  try {
+    config = JSON.parse(read(path))
+  } catch (error) {
+    failures.push(`Invalid JSON in ${path}: ${String(error)}`)
+    return
+  }
+  const csp = config?.app?.security?.csp || {}
+  const requirements = {
+    'media-src': ["'self'", 'blob:'],
+    'object-src': ["'none'"],
+    'base-uri': ["'none'"],
+    'form-action': ["'self'"],
+    'frame-ancestors': ["'none'"],
+  }
+  for (const [directive, sources] of Object.entries(requirements)) {
+    const value = typeof csp[directive] === 'string' ? csp[directive].split(/\s+/) : []
+    for (const source of sources) {
+      if (!value.includes(source)) failures.push(`${path} ${directive} must include ${source}`)
+    }
+  }
+  if (production && includesLocalBackendTarget(JSON.stringify(csp))) {
+    failures.push(`${path} release CSP must not include loopback targets`)
+  }
+}
+
+validateNginx('apps/web/nginx.production.conf', { production: true })
+validateNginx('apps/web/nginx.development.conf', { production: false })
+validateTauri('apps/desktop/src-tauri/tauri.conf.json', { production: true })
+validateTauri('apps/desktop/src-tauri/tauri.dev.conf.json', { production: false })
+
+const apiFixture = new Response(null, {
+  headers: {
+    'content-security-policy': "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'",
+    'strict-transport-security': 'max-age=31536000',
+    'x-frame-options': 'DENY',
+    'x-content-type-options': 'nosniff',
+    'referrer-policy': 'no-referrer',
+    'permissions-policy': 'camera=(), microphone=(), display-capture=(), geolocation=(), payment=()',
+  },
+})
+for (const failure of securityHeaderFailures(apiFixture, {
+  surface: 'api',
+  url: 'https://api.voxpery.com/health',
+})) {
+  failures.push(`API runtime smoke contract rejected the expected policy: ${failure}`)
+}
+
+const webFixture = new Response(null, {
+  headers: {
+    'content-security-policy': "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https://api.voxpery.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'",
+    'strict-transport-security': 'max-age=31536000',
+    'x-frame-options': 'DENY',
+    'x-content-type-options': 'nosniff',
+    'referrer-policy': 'no-referrer',
+    'permissions-policy': 'camera=(self), microphone=(self), display-capture=(self), geolocation=(), payment=()',
+  },
+})
+for (const failure of securityHeaderFailures(webFixture, {
+  surface: 'web',
+  url: 'https://voxpery.com/healthz',
+})) {
+  failures.push(`Web runtime smoke contract rejected the expected policy: ${failure}`)
+}
+
+if (failures.length > 0) {
+  console.error('Security policy validation failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Security policy validation passed.')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 
+      - name: Validate security policies
+        run: node .github/scripts/validate-security-policies.mjs
+
       - name: Install
         working-directory: apps/web
         run: npm ci

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       require_security_headers:
-        description: Fail API smoke when production security headers are missing or invalid
+        description: Fail API smoke when production API security headers are missing or invalid
         required: true
         type: choice
         default: 'yes'

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -32,8 +32,13 @@
         "script-src": "'self' blob: 'wasm-unsafe-eval' https://challenges.cloudflare.com",
         "frame-src": "https://challenges.cloudflare.com",
         "worker-src": "'self' blob:",
+        "media-src": "'self' blob:",
         "style-src": "'self' 'unsafe-inline'",
-        "font-src": "'self'"
+        "font-src": "'self'",
+        "object-src": "'none'",
+        "base-uri": "'none'",
+        "form-action": "'self'",
+        "frame-ancestors": "'none'"
       }
     }
   },

--- a/apps/desktop/src-tauri/tauri.dev.conf.json
+++ b/apps/desktop/src-tauri/tauri.dev.conf.json
@@ -8,8 +8,13 @@
         "script-src": "'self' blob: 'wasm-unsafe-eval' https://challenges.cloudflare.com",
         "frame-src": "https://challenges.cloudflare.com",
         "worker-src": "'self' blob:",
+        "media-src": "'self' blob:",
         "style-src": "'self' 'unsafe-inline'",
-        "font-src": "'self'"
+        "font-src": "'self'",
+        "object-src": "'none'",
+        "base-uri": "'none'",
+        "form-action": "'self'",
+        "frame-ancestors": "'none'"
       }
     }
   }

--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -297,7 +297,8 @@ pub fn build_app(state: Arc<AppState>, cors_origins: Vec<String>) -> Router {
             middleware::csrf::protect_cookie_authenticated_writes,
         ))
         .layer(TraceLayer::new_for_http())
-        .layer(cors);
+        .layer(cors)
+        .layer(map_response(middleware::security_headers::apply));
 
     app.with_state(state)
 }

--- a/apps/server/src/middleware/mod.rs
+++ b/apps/server/src/middleware/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
 pub mod csrf;
+pub mod security_headers;

--- a/apps/server/src/middleware/security_headers.rs
+++ b/apps/server/src/middleware/security_headers.rs
@@ -1,0 +1,69 @@
+use axum::{
+    http::{HeaderName, HeaderValue},
+    response::Response,
+};
+
+const CONTENT_SECURITY_POLICY: &str =
+    "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'";
+const PERMISSIONS_POLICY: &str =
+    "camera=(), microphone=(), display-capture=(), geolocation=(), payment=()";
+
+pub async fn apply(mut response: Response) -> Response {
+    let headers = response.headers_mut();
+    headers.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static(CONTENT_SECURITY_POLICY),
+    );
+    headers.insert(
+        HeaderName::from_static("strict-transport-security"),
+        HeaderValue::from_static("max-age=31536000"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        HeaderName::from_static("permissions-policy"),
+        HeaderValue::from_static(PERMISSIONS_POLICY),
+    );
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::Body, http::StatusCode, response::Response};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn applies_the_api_security_header_contract() {
+        let response = apply(
+            Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        let headers = response.headers();
+
+        assert_eq!(headers["x-frame-options"], "DENY");
+        assert_eq!(headers["x-content-type-options"], "nosniff");
+        assert_eq!(headers["referrer-policy"], "no-referrer");
+        assert!(headers["content-security-policy"]
+            .to_str()
+            .unwrap()
+            .contains("frame-ancestors 'none'"));
+        assert!(headers["permissions-policy"]
+            .to_str()
+            .unwrap()
+            .contains("microphone=()"));
+    }
+}

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -262,6 +262,47 @@ async fn health_returns_200_when_db_connected() {
     assert!(json.get("checks").is_none());
 }
 
+#[tokio::test]
+async fn api_security_headers_cover_normal_error_and_preflight_responses() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (app, _) = setup_app().await;
+
+    let requests = [
+        Request::builder().uri("/health").body(Body::empty()).unwrap(),
+        Request::builder()
+            .uri("/missing-route")
+            .body(Body::empty())
+            .unwrap(),
+        Request::builder()
+            .method("OPTIONS")
+            .uri("/api/auth/login")
+            .header("Origin", "http://localhost:5173")
+            .header("Access-Control-Request-Method", "POST")
+            .body(Body::empty())
+            .unwrap(),
+    ];
+
+    for request in requests {
+        let response = app.clone().oneshot(request).await.expect("request failed");
+        let headers = response.headers();
+        assert_eq!(headers["strict-transport-security"], "max-age=31536000");
+        assert_eq!(headers["x-frame-options"], "DENY");
+        assert_eq!(headers["x-content-type-options"], "nosniff");
+        assert_eq!(headers["referrer-policy"], "no-referrer");
+        assert!(headers["content-security-policy"]
+            .to_str()
+            .unwrap()
+            .contains("frame-ancestors 'none'"));
+        assert!(headers["permissions-policy"]
+            .to_str()
+            .unwrap()
+            .contains("display-capture=()"));
+    }
+}
+
 fn assert_feature_disabled(status: StatusCode, body: &[u8]) {
     assert_eq!(
         status,

--- a/apps/web/TESTING.md
+++ b/apps/web/TESTING.md
@@ -84,10 +84,11 @@ Current workflows:
 
 - `.github/workflows/ci.yml`
   - Secret scan
-  - Backend check/tests
+  - Backend check/tests, including API response security headers
+  - Static nginx/Tauri security policy validation
   - Frontend lint/unit tests/core UI smoke/mobile web smoke/build
 - `.github/workflows/release-smoke.yml`
-  - API smoke
+  - API smoke plus deployed API/web security header validation
   - Optional web E2E scope: desktop Chromium, mobile Chromium, or all browser projects
 - `.github/workflows/release-desktop.yml`
   - Desktop release preflight
@@ -98,4 +99,4 @@ Current workflows:
 
 ---
 
-Last verified against code on 2026-06-12.
+Last verified against code on 2026-07-19.

--- a/apps/web/nginx.development.conf
+++ b/apps/web/nginx.development.conf
@@ -5,15 +5,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(self), microphone=(self), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' http://localhost:3001 ws://localhost:3001 http://127.0.0.1:3001 ws://127.0.0.1:3001 http://localhost:7880 ws://localhost:7880 http://127.0.0.1:7880 ws://127.0.0.1:7880 https://api.voxpery.com wss://api.voxpery.com https://livekit.voxpery.com wss://livekit.voxpery.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), fullscreen=(self), geolocation=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' http://localhost:3001 ws://localhost:3001 http://127.0.0.1:3001 ws://127.0.0.1:3001 http://localhost:7880 ws://localhost:7880 http://127.0.0.1:7880 ws://127.0.0.1:7880 https://api.voxpery.com wss://api.voxpery.com https://livekit.voxpery.com wss://livekit.voxpery.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; media-src 'self' blob:; manifest-src 'self'; form-action 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" always;
 
     location = /healthz {
         access_log off;
-        add_header Content-Type text/plain;
+        default_type text/plain;
         return 200 "ok\n";
     }
 

--- a/apps/web/nginx.production.conf
+++ b/apps/web/nginx.production.conf
@@ -5,15 +5,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(self), microphone=(self), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.voxpery.com wss://api.voxpery.com https://livekit.voxpery.com wss://livekit.voxpery.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), fullscreen=(self), geolocation=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.voxpery.com wss://api.voxpery.com https://livekit.voxpery.com wss://livekit.voxpery.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; media-src 'self' blob:; manifest-src 'self'; form-action 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" always;
 
     location = /healthz {
         access_log off;
-        add_header Content-Type text/plain;
+        default_type text/plain;
         return 200 "ok\n";
     }
 

--- a/apps/web/scripts/release-deploy-smoke.mjs
+++ b/apps/web/scripts/release-deploy-smoke.mjs
@@ -1,3 +1,5 @@
+import { assertSecurityHeaders } from './security-headers.mjs'
+
 const API_BASE = requiredUrl('SMOKE_API_URL')
 const WEB_BASE = requiredUrl('SMOKE_WEB_URL')
 const RAW_EXPECTED_VERSION = process.env.SMOKE_EXPECTED_VERSION?.trim()
@@ -92,12 +94,14 @@ async function main() {
   validateImmutableImageTag(EXPECTED_IMAGE_TAG)
 
   const apiHealth = await getOk(`${API_BASE}/health`, 'API health')
+  assertSecurityHeaders(apiHealth, { surface: 'api', url: `${API_BASE}/health` })
   const apiHealthJson = await apiHealth.json().catch(() => null)
   assert(apiHealthJson?.status === 'ok', 'API health response must be {"status":"ok"}')
-  console.log('[release-smoke] API health OK')
+  console.log('[release-smoke] API health and security headers OK')
 
-  await getOk(`${WEB_BASE}/healthz`, 'web health')
-  console.log('[release-smoke] web health OK')
+  const webHealth = await getOk(`${WEB_BASE}/healthz`, 'web health')
+  assertSecurityHeaders(webHealth, { surface: 'web', url: `${WEB_BASE}/healthz` })
+  console.log('[release-smoke] web health and security headers OK')
 
   await checkVersionInDeployedAssets()
   console.log('[release-smoke] deployed version assets OK')

--- a/apps/web/scripts/security-headers.mjs
+++ b/apps/web/scripts/security-headers.mjs
@@ -1,0 +1,72 @@
+function header(response, name) {
+  return (response.headers.get(name) || '').trim()
+}
+
+function compact(value) {
+  return value.toLowerCase().replace(/\s+/g, '')
+}
+
+function isPublicUrl(rawUrl) {
+  const { hostname } = new URL(rawUrl)
+  return hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1'
+}
+
+export function securityHeaderFailures(response, { surface, url }) {
+  const csp = header(response, 'content-security-policy').toLowerCase()
+  const permissions = compact(header(response, 'permissions-policy'))
+  const failures = []
+
+  if (header(response, 'x-frame-options').toUpperCase() !== 'DENY') {
+    failures.push('x-frame-options=DENY')
+  }
+  if (header(response, 'x-content-type-options').toLowerCase() !== 'nosniff') {
+    failures.push('x-content-type-options=nosniff')
+  }
+  if (header(response, 'referrer-policy').toLowerCase() !== 'no-referrer') {
+    failures.push('referrer-policy=no-referrer')
+  }
+  if (new URL(url).protocol === 'https:' && !/^max-age=\d+/i.test(header(response, 'strict-transport-security'))) {
+    failures.push('strict-transport-security=max-age')
+  }
+  if (!csp.includes("frame-ancestors 'none'")) failures.push("csp frame-ancestors 'none'")
+  if (!csp.includes("object-src 'none'")) failures.push("csp object-src 'none'")
+
+  if (surface === 'api') {
+    if (!csp.includes("default-src 'none'")) failures.push("csp default-src 'none'")
+    if (!csp.includes("base-uri 'none'")) failures.push("csp base-uri 'none'")
+    if (!csp.includes("form-action 'none'")) failures.push("csp form-action 'none'")
+    for (const directive of ['camera=()', 'microphone=()', 'display-capture=()', 'geolocation=()', 'payment=()']) {
+      if (!permissions.includes(directive)) failures.push(`permissions-policy ${directive}`)
+    }
+  } else if (surface === 'web') {
+    if (!csp.includes("default-src 'self'")) failures.push("csp default-src 'self'")
+    if (!csp.includes("script-src 'self' 'wasm-unsafe-eval'")) {
+      failures.push("csp script-src 'wasm-unsafe-eval'")
+    }
+    if (!csp.includes("base-uri 'self'")) failures.push("csp base-uri 'self'")
+    if (!csp.includes("form-action 'self'")) failures.push("csp form-action 'self'")
+    for (const directive of [
+      'camera=(self)',
+      'microphone=(self)',
+      'display-capture=(self)',
+      'geolocation=()',
+      'payment=()',
+    ]) {
+      if (!permissions.includes(directive)) failures.push(`permissions-policy ${directive}`)
+    }
+    if (isPublicUrl(url) && /(?:localhost|127\.0\.0\.1)/i.test(csp)) {
+      failures.push('production CSP contains a loopback target')
+    }
+  } else {
+    failures.push(`unknown security header surface: ${surface}`)
+  }
+
+  return failures
+}
+
+export function assertSecurityHeaders(response, options) {
+  const failures = securityHeaderFailures(response, options)
+  if (failures.length > 0) {
+    throw new Error(`${options.surface} security headers missing/invalid: ${failures.join(', ')}`)
+  }
+}

--- a/apps/web/scripts/smoke-e2e.mjs
+++ b/apps/web/scripts/smoke-e2e.mjs
@@ -1,5 +1,6 @@
 import { WebSocket } from 'ws'
 import { randomUUID } from 'node:crypto'
+import { securityHeaderFailures } from './security-headers.mjs'
 
 const API_BASE = process.env.SMOKE_API_URL || 'http://127.0.0.1:3001'
 const WS_BASE = API_BASE.replace(/^http/, 'ws')
@@ -27,25 +28,15 @@ function assert(condition, message) {
 }
 
 async function checkSecurityHeaders() {
-  const res = await fetch(`${API_BASE}/health`)
+  const url = `${API_BASE}/health`
+  const res = await fetch(url)
   if (!res.ok) {
     throw new Error(`GET /health failed (${res.status})`)
   }
 
-  const header = (name) => (res.headers.get(name) || '').trim()
-  const csp = header('content-security-policy')
-  const xFrameOptions = header('x-frame-options').toUpperCase()
-  const xContentType = header('x-content-type-options').toLowerCase()
-  const referrerPolicy = header('referrer-policy').toLowerCase()
-
-  const missing = []
-  if (!csp || !csp.toLowerCase().includes('default-src')) missing.push('content-security-policy')
-  if (xFrameOptions !== 'DENY') missing.push('x-frame-options=DENY')
-  if (xContentType !== 'nosniff') missing.push('x-content-type-options=nosniff')
-  if (!referrerPolicy) missing.push('referrer-policy')
-
-  if (missing.length > 0) {
-    const msg = `[smoke] security headers missing/invalid: ${missing.join(', ')}`
+  const failures = securityHeaderFailures(res, { surface: 'api', url })
+  if (failures.length > 0) {
+    const msg = `[smoke] API security headers missing/invalid: ${failures.join(', ')}`
     if (REQUIRE_SECURITY_HEADERS) {
       throw new Error(msg)
     }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -142,6 +142,8 @@ Security defaults in compose:
 - `web`, `server`, `postgres`, `redis`, `livekit:7880` bind to `127.0.0.1` only
 - Local compose passes `APP_ENV=development` and builds the web image with `apps/web/nginx.development.conf` so localhost API and LiveKit smoke tests work. Public production images pass `APP_ENV=production` in CI and use `apps/web/nginx.production.conf`, which omits browser loopback `connect-src` allowances.
 - The web image uses unprivileged nginx and listens on container port `8080`; Compose maps it to `127.0.0.1:${WEB_PORT:-5173}`.
+- Production web responses include HSTS, CSP, frame denial, MIME sniffing protection, a no-referrer policy, and media-aware Permissions Policy. API responses apply the corresponding API-safe policy in Axum, including error and CORS preflight responses.
+- Do not override or remove these headers at the public reverse proxy. The release smoke workflow validates the deployed API `/health` and web `/healthz` responses and fails on policy drift.
 - Public media ports stay open for LiveKit:
   - `7881/tcp` (fallback)
   - `7882/udp`

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -33,6 +33,8 @@ This document defines Voxpery desktop release hardening policy for metadata, dee
 - `apps/desktop/src-tauri/capabilities/default.json` must not allow `localhost` or `127.0.0.1` HTTP targets in release builds.
 - `apps/desktop/src-tauri/tauri.conf.json` CSP `connect-src` must not include local HTTP/WS backends in release builds.
 - `apps/desktop/src-tauri/tauri.conf.json` CSP must allow Cloudflare Turnstile on `connect-src`, `script-src`, and `frame-src` so desktop registration can render CAPTCHA when production requires it.
+- Release and development CSPs must deny plugin/object content and parent framing, restrict base/form targets, and explicitly allow only self/blob media required by chat and voice playback.
+- Release preflight rejects missing `object-src 'none'`, `base-uri 'none'`, `frame-ancestors 'none'`, `form-action 'self'`, or `media-src 'self' blob:` directives.
 - If local backend access is needed for development, it must live in a dev-only config and never ship in the default release capability set.
 - Voxpery development uses `apps/desktop/src-tauri/tauri.dev.conf.json` together with `cargo tauri dev --config tauri.dev.conf.json` for local backend connectivity.
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -36,7 +36,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Manual `Release / Smoke` workflow completed successfully against the release candidate web URL.
 - [ ] Manual `Release / Smoke` workflow run URL is recorded in Release Candidate Info.
 - [ ] Tag-triggered `Release / Metadata` check passed for web, server, desktop, and changelog version-bearing files before Docker publishing.
-- [ ] `Release / Smoke` ran with strict security headers enabled for production candidates.
+- [ ] `Release / Smoke` validated strict API `/health` and web `/healthz` security headers, including HTTPS HSTS, frame denial, MIME sniffing protection, referrer policy, Permissions Policy, and surface-specific CSP.
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
@@ -115,6 +115,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Real production voice call with noise suppression on and `Noisy room` selected suppresses clap, keyboard, and room-noise bursts similarly to the local Docker build.
 - [ ] Production web CSP includes `script-src 'wasm-unsafe-eval'` so RNNoise WebAssembly can compile under strict headers.
 - [ ] Production web CSP `connect-src` does not include `localhost` or `127.0.0.1` loopback targets.
+- [ ] Desktop release preflight confirms restrictive `object-src`, `base-uri`, `form-action`, `frame-ancestors`, and media CSP directives.
 - [ ] During the real production voice call, after enabling `localStorage.setItem("voxperyVoiceDiagnostics", "1")` and reloading, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
 - [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` when suppression, CSP, service workers, build output, or production deployment config changed.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -288,18 +288,31 @@ let query = format!("SELECT * FROM users WHERE username = '{}'", username); // S
 
 ## Security Headers
 
-**Recommended nginx config**:
+The API applies a restrictive response policy at the Axum router boundary, including error and CORS preflight responses:
+
+- `Content-Security-Policy: default-src 'none'; ... frame-ancestors 'none'`
+- `Strict-Transport-Security: max-age=31536000`
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: no-referrer`
+- `Permissions-Policy` with camera, microphone, display capture, geolocation, and payment disabled
+
+The production web container applies the browser-facing policy:
+
 ```nginx
+add_header Strict-Transport-Security "max-age=31536000" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "DENY" always;
-add_header X-XSS-Protection "1; mode=block" always;
 add_header Referrer-Policy "no-referrer" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; connect-src 'self' https://api.your-domain.com wss://api.your-domain.com https://livekit.your-domain.com wss://livekit.your-domain.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';" always;
+add_header Permissions-Policy "camera=(self), microphone=(self), display-capture=(self), fullscreen=(self), geolocation=(), payment=()" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; connect-src 'self' https://api.your-domain.com wss://api.your-domain.com https://livekit.your-domain.com wss://livekit.your-domain.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; media-src 'self' blob:; manifest-src 'self'; form-action 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';" always;
 ```
 
 `'wasm-unsafe-eval'` is required for the RNNoise WebAssembly voice suppression runtime. It is narrower than broad JavaScript `'unsafe-eval'` and should stay in `script-src` for production voice releases.
 
-The production web image passes `APP_ENV=production` and uses `apps/web/nginx.production.conf`, which does not allow browser connections to visitor loopback targets. Local Docker compose passes `APP_ENV=development` by default and uses `apps/web/nginx.development.conf` so `localhost` API and LiveKit smoke tests keep working. The web container runs with the unprivileged nginx image and listens on container port `8080`; Compose still exposes it on `127.0.0.1:${WEB_PORT:-5173}`.
+The production web image passes `APP_ENV=production` and uses `apps/web/nginx.production.conf`, which does not allow browser connections to visitor loopback targets. Local Docker compose passes `APP_ENV=development` by default and uses `apps/web/nginx.development.conf` so `localhost` API and LiveKit smoke tests keep working. Development omits HSTS, while both configs deny framing and keep the same media permissions. The `/healthz` location uses `default_type` rather than a nested `add_header`, so it inherits the server-level security policy. The web container runs with the unprivileged nginx image and listens on container port `8080`; Compose still exposes it on `127.0.0.1:${WEB_PORT:-5173}`.
+
+CI validates the nginx and Tauri policy files statically. Release smoke validates the headers returned by the deployed API `/health` and web `/healthz` endpoints, including HSTS on HTTPS URLs and production CSP loopback exclusion.
 
 ## Secrets Management
 


### PR DESCRIPTION
## Summary

- enforce centralized API security headers on normal, error, and CORS preflight responses
- harden production and development nginx CSP, framing, referrer, and permissions policies
- add production HSTS and preserve security headers on `/healthz`
- strengthen Tauri release and development CSP restrictions
- validate nginx and Tauri policies during CI
- validate deployed API and web headers during release smoke
- document the security header and deployment contract

## Validation

- `cargo check --locked`
- `cargo test --locked -- --test-threads=1`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `node .github/scripts/validate-security-policies.mjs`