### PR TITLE
perf: reduce initial frontend bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,10 @@ jobs:
         working-directory: apps/web
         run: npm run build
 
+      - name: Check initial bundle budget
+        working-directory: apps/web
+        run: npm run check:initial-bundle
+
   docker_publish:
     name: ${{ matrix.component == 'backend' && 'Publish / Docker Backend' || 'Publish / Docker Frontend' }}
     needs:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.3",
         "@shiguredo/rnnoise-wasm": "^2025.1.5",
-        "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-virtual": "^3.14.6",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-autostart": "^2",
@@ -1731,32 +1730,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.101.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
     },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.14.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "check:initial-bundle": "node scripts/check-initial-bundle.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
@@ -31,7 +32,6 @@
   "dependencies": {
     "@marsidev/react-turnstile": "^1.5.3",
     "@shiguredo/rnnoise-wasm": "^2025.1.5",
-    "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-virtual": "^3.14.6",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-autostart": "^2",

--- a/apps/web/scripts/check-initial-bundle.mjs
+++ b/apps/web/scripts/check-initial-bundle.mjs
@@ -1,0 +1,73 @@
+import { readFileSync, statSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const distDir = path.resolve(scriptDir, '..', 'dist')
+const indexPath = path.join(distDir, 'index.html')
+const indexHtml = readFileSync(indexPath, 'utf8')
+
+const entryScriptMatches = indexHtml.matchAll(/<script\b[^>]*\btype="module"[^>]*\bsrc="([^"]+\.js)"[^>]*>/g)
+const preloadMatches = indexHtml.matchAll(/<link\b[^>]*\brel="modulepreload"[^>]*\bhref="([^"]+\.js)"[^>]*>/g)
+const initialJsUrls = [...new Set([
+  ...Array.from(entryScriptMatches, (match) => match[1]),
+  ...Array.from(preloadMatches, (match) => match[1]),
+])]
+
+if (initialJsUrls.length === 0) {
+  throw new Error('Initial bundle validation failed: no entry or modulepreload JavaScript was found.')
+}
+
+const initialFiles = initialJsUrls.map((url) => {
+  const relativePath = url.replace(/^\//, '')
+  const filePath = path.join(distDir, relativePath)
+  const contents = readFileSync(filePath)
+  return {
+    url,
+    rawBytes: statSync(filePath).size,
+    gzipBytes: gzipSync(contents).byteLength,
+  }
+})
+
+const rawBytes = initialFiles.reduce((total, file) => total + file.rawBytes, 0)
+const gzipBytes = initialFiles.reduce((total, file) => total + file.gzipBytes, 0)
+const rawBudgetBytes = 350 * 1024
+const gzipBudgetBytes = 120 * 1024
+const forbiddenPreloads = [
+  /\/livekit-[^/]+\.js$/,
+  /\/tauri-[^/]+\.js$/,
+  /\/tanstack-[^/]+\.js$/,
+  /\/rnnoise-[^/]+\.js$/,
+  /\/AppShell-[^/]+\.js$/,
+  /\/UnifiedLayout-[^/]+\.js$/,
+]
+
+const failures = []
+if (rawBytes > rawBudgetBytes) {
+  failures.push(`initial JavaScript is ${formatKiB(rawBytes)} raw; budget is ${formatKiB(rawBudgetBytes)}`)
+}
+if (gzipBytes > gzipBudgetBytes) {
+  failures.push(`initial JavaScript is ${formatKiB(gzipBytes)} gzip; budget is ${formatKiB(gzipBudgetBytes)}`)
+}
+
+for (const file of initialFiles) {
+  if (forbiddenPreloads.some((pattern) => pattern.test(file.url))) {
+    failures.push(`authenticated or platform-only chunk is preloaded: ${file.url}`)
+  }
+}
+
+console.log(`Initial JavaScript: ${formatKiB(rawBytes)} raw / ${formatKiB(gzipBytes)} gzip across ${initialFiles.length} files.`)
+for (const file of initialFiles) {
+  console.log(`- ${file.url}: ${formatKiB(file.rawBytes)} raw / ${formatKiB(file.gzipBytes)} gzip`)
+}
+
+if (failures.length > 0) {
+  console.error('\nInitial bundle validation failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+function formatKiB(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,20 +4,16 @@ import { useAppStore } from './stores/app'
 import { useAuthStore, restoreSecureSession } from './stores/auth'
 import { authApi, clearStoredDesktopOAuthVerifier, getStoredDesktopOAuthVerifier, isAuthError, setAuthFailureHandler } from './api'
 import { isTauri, setSecureToken } from './secureStorage'
-import { onOpenUrl } from '@tauri-apps/plugin-deep-link'
-import { listen } from '@tauri-apps/api/event'
 import ToastViewport from './components/ToastViewport'
 import ErrorBoundary from './components/ErrorBoundary'
 import ConnectionGate from './components/ConnectionGate'
 import GlobalLoading from './components/GlobalLoading'
-import AppShell from './pages/AppShell'
-import UnifiedLayout from './pages/UnifiedLayout'
-import { preloadRnnoiseWorklet } from './webrtc/rnnoise'
 import { ROUTES } from './routes'
 import { useSocketStore } from './stores/socket'
 import { useFeatureStore } from './stores/features'
-import { bootstrapDesktopAutostartDefault } from './desktopSettings'
 
+const AppShell = lazy(() => import('./pages/AppShell'))
+const UnifiedLayout = lazy(() => import('./pages/UnifiedLayout'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const RegisterPage = lazy(() => import('./pages/RegisterPage'))
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'))
@@ -86,9 +82,11 @@ function App() {
 
   useEffect(() => {
     if (!isDesktopApp) return
-    void bootstrapDesktopAutostartDefault().catch(() => {
-      // UserBar still exposes the manual control if the OS startup registration fails.
-    })
+    void import('./desktopSettings')
+      .then(({ bootstrapDesktopAutostartDefault }) => bootstrapDesktopAutostartDefault())
+      .catch(() => {
+        // UserBar still exposes the manual control if the OS startup registration fails.
+      })
   }, [isDesktopApp])
 
   useEffect(() => {
@@ -124,6 +122,7 @@ function App() {
       // Listen for deep links (Google OAuth callback)
       let unlisten: (() => void) | undefined
       let unlistenCustom: (() => void) | undefined
+      let disposed = false
 
       const handleDeepLinkUrl = (url: string) => {
         try {
@@ -151,21 +150,30 @@ function App() {
         }
       }
 
-      onOpenUrl((urls) => {
-        for (const url of urls) {
-          handleDeepLinkUrl(url)
-        }
-      })
-        .then((fn) => { unlisten = fn })
+      void import('@tauri-apps/plugin-deep-link')
+        .then(({ onOpenUrl }) => onOpenUrl((urls) => {
+          for (const url of urls) {
+            handleDeepLinkUrl(url)
+          }
+        }))
+        .then((fn) => {
+          if (disposed) fn()
+          else unlisten = fn
+        })
         .catch(console.error)
 
-      listen<string>('custom-deep-link', (event: { payload: string }) => {
-        handleDeepLinkUrl(event.payload)
-      })
-        .then((fn: () => void) => { unlistenCustom = fn })
+      void import('@tauri-apps/api/event')
+        .then(({ listen }) => listen<string>('custom-deep-link', (event: { payload: string }) => {
+          handleDeepLinkUrl(event.payload)
+        }))
+        .then((fn) => {
+          if (disposed) fn()
+          else unlistenCustom = fn
+        })
         .catch(console.error)
 
       return () => {
+        disposed = true
         if (unlisten) unlisten()
         if (unlistenCustom) unlistenCustom()
       }
@@ -289,7 +297,9 @@ function RnnoisePreloadOnInteraction() {
     const run = () => {
       if (done.current) return
       done.current = true
-      preloadRnnoiseWorklet()
+      void import('./webrtc/rnnoise')
+        .then(({ preloadRnnoiseWorklet }) => preloadRnnoiseWorklet())
+        .catch(() => {})
       document.removeEventListener('click', run)
       document.removeEventListener('keydown', run)
     }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,33 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { setLogLevel } from 'livekit-client'
 import './index.css'
 import App from './App'
 import { registerPwaServiceWorker } from './pwa'
 
-if (import.meta.env.PROD) {
-  setLogLevel('silent')
-}
-
 registerPwaServiceWorker()
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 30000,
-      retry: 1,
-    },
-  },
-})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -5,6 +5,7 @@ import {
   RemoteParticipant,
   Room,
   RoomEvent,
+  setLogLevel,
   Track,
   type RemoteTrackPublication,
   type TrackPublishOptions,
@@ -26,6 +27,10 @@ import {
 } from './voiceInputProfile'
 import { updateVoiceDiagnostics } from './voiceDiagnostics'
 import type { RemoteMediaKind } from './remoteMediaControls'
+
+if (import.meta.env.PROD) {
+  setLogLevel('silent')
+}
 
 type PeerId = string
 type RemoteMediaStartCueKind = 'camera' | 'screen'

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,6 +54,7 @@ cargo test
 cd ../web
 npm run lint
 npm run build
+npm run check:initial-bundle
 ```
 
 ## Documentation Sync (Required)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -71,6 +71,7 @@ cargo run
 npm ci
 npm run lint
 npm run build
+npm run check:initial-bundle
 npm run dev
 ```
 
@@ -93,7 +94,7 @@ Runs on `push` and `pull_request`:
 
 - `Secret Scan (gitleaks)` (containerized CLI)
 - `Backend` (`cargo check`, then unit and integration tests against isolated PostgreSQL and Redis services)
-- `Frontend` (`npm ci`, `npm run lint`, `npm run build`)
+- `Frontend` (`npm ci`, lint, tests, Playwright smoke coverage, production build, and the initial JavaScript budget check)
 
 ### `.github/workflows/dependency-security.yml`
 


### PR DESCRIPTION
## Summary

- Lazy-load authenticated application layouts and platform-specific Tauri modules
- Defer LiveKit and RNNoise initialization until voice functionality is needed
- Remove the unused React Query dependency
- Add a CI guard for the initial JavaScript bundle budget
- Document the bundle validation workflow

## Results

- Initial JavaScript reduced from approximately 1.31 MiB to 294.9 KiB
- Initial gzip size reduced from approximately 369 KiB to 96 KiB
- Landing and authentication routes no longer preload LiveKit, Tauri, RNNoise, AppShell, or UnifiedLayout

## Validation

- `npm run lint`
- `npm run test:run` — 183 tests passed
- `npm run build`
- `npm run check:initial-bundle`
- `npm run test:e2e:ui-smoke` — 32 tests passed
- `npm run test:e2e:mobile-smoke` — 2 tests passed

Closes #240