### PR TITLE
chore: prepare v0.2.4 release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
           - main-candidate
           - custom
       image_tag:
-        description: 'Custom mode only: immutable Docker image tag, for example sha-abc123def456 or v0.2.0'
+        description: 'Custom mode only: immutable Docker image tag, for example sha-abc123def456 or v1.2.3'
         required: false
         type: string
       git_ref:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -12,11 +12,11 @@ on:
         required: true
         type: string
       expected_version:
-        description: Expected semantic release version, for example 0.2.3 or v0.2.3
+        description: Expected semantic release version, for example 1.2.3 or v1.2.3
         required: false
         type: string
       expected_image_tag:
-        description: Expected immutable Docker image tag, for example v0.2.3 or sha-abc123def456
+        description: Expected immutable Docker image tag, for example v1.2.3 or sha-abc123def456
         required: false
         type: string
       require_security_headers:

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5390,7 +5390,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3141,7 +3141,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,18 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-07-19
+
+### Added
+- Added a default onboarding guide to the official Voxpery Community so new users can discover messaging, voice, and project contribution paths immediately.
+
 ### Changed
-- Send default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
-- Seed the official Voxpery Community with an enabled onboarding guide that points new users toward first message, voice, and GitHub discovery actions.
-- Defer browser and desktop notification permission requests until the authenticated app is ready and the user accepts a non-blocking in-app prompt.
-- Serialize critical DM creation, server bootstrap, member-role replacement, and channel deletion writes so concurrent requests cannot leave duplicate or partial state.
-- Run backend integration and concurrency tests in CI against isolated PostgreSQL and Redis services instead of silently skipping database coverage.
-- Register macOS microphone, camera, screen-recording, and shared-audio permission metadata in desktop bundles and keep remote call playback active across the screen-share picker and app focus changes.
+- Bumped web, server, and desktop package metadata to `0.2.4`.
+- Sent default login and registration completions to the server/community surface so new users land closer to the official Voxpery Community experience.
+- Deferred browser and desktop notification permission requests until the authenticated app is ready and the user accepts a non-blocking in-app prompt.
+- Serialized critical DM creation, server bootstrap, member-role replacement, and channel deletion writes so concurrent requests cannot leave duplicate or partial state.
+- Ran backend integration and concurrency tests in CI against isolated PostgreSQL and Redis services instead of silently skipping database coverage.
+- Registered macOS microphone, camera, screen-recording, and shared-audio permission metadata in desktop bundles and kept remote call playback active across the screen-share picker and app focus changes.
+- Clarified the README and hosted landing page around Voxpery's open-source, self-hostable, privacy-focused positioning.
+- Deferred authenticated, voice, RNNoise, and desktop-only JavaScript from public routes, reducing initial JavaScript by roughly 75%, with a CI bundle budget to prevent regressions.
+
+### Fixed
+- Made attachment uploads, reaction/report/pin limits, and critical multi-table writes rollback safely under failures and concurrent requests.
+- Made retryable DM, message, reaction, report, and pin writes idempotent so transport retries cannot create duplicate side effects.
+- Preserved message and reaction integrity when concurrent edits, deletes, pins, reports, and channel operations race.
 
 ### Security
 - Updated Rust `anyhow` lockfile entries to patched `1.0.103` releases that address `RUSTSEC-2026-0190`.
 - Updated the server `spin` lockfile entry from yanked `0.9.8` to `0.9.9`.
-- Re-check permissions inside locked database transactions and commit matching audit entries atomically with role and channel mutations.
+- Re-checked permissions inside locked database transactions and committed matching audit entries atomically with role and channel mutations.
+- Added strict attachment content-signature validation and hardened cookie authentication against cross-site request forgery.
+- Required explicit trusted-proxy configuration before accepting forwarded client IP headers.
+- Added rate limits for abuse-sensitive authentication, reporting, reaction, pin, and invitation paths.
+- Enforced web, API, and desktop security-header policies in CI, including restrictive CSP regression checks.
+- Updated vulnerable or yanked Rust and web dependency paths, including `quick-xml`, `anyhow`, and `spin`.
 
 ## [0.2.3] - 2026-06-23
 


### PR DESCRIPTION
## Summary

- Bump web, server, and desktop version metadata to `0.2.4`
- Add the complete v0.2.4 changelog covering onboarding, reliability, security, macOS media, positioning, and frontend performance improvements
- Replace stale version-specific workflow examples with reusable semantic version examples

## Validation

- Release version synchronization passed
- Security policy validation passed
- Server: 79 unit tests and 46 integration tests passed
- Desktop: `cargo check --locked` passed
- Frontend: 183 tests passed
- Production frontend build passed
- Initial bundle budget passed
- Playwright desktop UI smoke: 32 tests passed
- Playwright mobile smoke: 2 tests passed

## Release Note

Desktop signing and updater secrets are intentionally validated by the tag-triggered GitHub Actions workflow because they are not stored in the repository.