### PR TITLE
security: update dependency audit cadence

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 4 * * 1'
 
 permissions:
   contents: read

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1108,11 +1108,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -267,15 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,11 +586,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Migrated declarative routing imports to React Router 8 and updated the frontend lint dependency chain to ESLint 10.
 - Preserved original error causes when wrapping network and microphone-access failures for clearer diagnostics.
+- Reduced scheduled dependency audits from daily to weekly while retaining audits on every pull request and manual dispatch.
 
 ### Security
 - Updated React Router to `8.3.0` to address `GHSA-qwww-vcr4-c8h2`.
 - Updated `brace-expansion` to `5.0.8` through the supported ESLint dependency chain to address `GHSA-3jxr-9vmj-r5cp` and `GHSA-mh99-v99m-4gvg`.
+- Updated server and desktop `event-listener` lockfile entries to patched `5.4.2` releases that address `RUSTSEC-2026-0221`.
 
 ## [0.2.4] - 2026-07-19
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,7 +98,7 @@ Runs on `push` and `pull_request`:
 
 ### `.github/workflows/dependency-security.yml`
 
-Runs on schedule, manual dispatch, and PR:
+Runs every Monday at 04:00 UTC, on manual dispatch, and on every PR:
 
 - Rust dependency audit (`cargo audit`)
 - Web production dependency audit (`npm audit --omit=dev --audit-level=high`)
@@ -110,4 +110,4 @@ Runs on schedule, manual dispatch, and PR:
 
 ---
 
-Last verified against code on 2026-07-18.
+Last verified against code on 2026-08-02.


### PR DESCRIPTION
## Summary
- update server and desktop `event-listener` lockfile entries to patched version 5.4.2
- reduce scheduled dependency audits from daily to weekly
- retain dependency audits on every pull request and manual dispatch
- update development and changelog documentation

## Security
- resolves RUSTSEC-2026-0221

## Validation
- `cargo test --locked` — 125 passed
- desktop `cargo check --locked`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- verified server and desktop dependency trees resolve `event-listener 5.4.2`