### PR TITLE
fix: reconcile LiveKit voice presence

### DIFF
--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -39,6 +39,8 @@ pub struct AppState {
     pub sessions: DashMap<uuid::Uuid, Vec<tokio::sync::mpsc::UnboundedSender<ws::WsEvent>>>,
     /// Voice sessions: user_id -> channel_id
     pub voice_sessions: DashMap<uuid::Uuid, uuid::Uuid>,
+    /// Active LiveKit participant SID per user, used to reject stale leave webhooks after rejoin.
+    pub voice_participant_sids: DashMap<uuid::Uuid, String>,
     /// Voice channel active start times: channel_id -> epoch milliseconds while at least one participant is connected
     pub voice_channel_active_since_ms: DashMap<uuid::Uuid, u64>,
     /// Voice controls: user_id -> (self_muted, self_deafened, server_muted, server_deafened, screen_sharing, camera_on)

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -99,6 +99,7 @@ async fn main() {
         tx,
         sessions: dashmap::DashMap::new(),
         voice_sessions: dashmap::DashMap::new(),
+        voice_participant_sids: dashmap::DashMap::new(),
         voice_channel_active_since_ms: dashmap::DashMap::new(),
         voice_controls: dashmap::DashMap::new(),
         auth_rate_limit_max: config.auth_rate_limit_max,

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -2827,6 +2827,7 @@ async fn delete_my_account(
     }
 
     state.sessions.remove(&claims.sub);
+    state.voice_participant_sids.remove(&claims.sub);
     if let Some((_, previous_channel_id)) = state.voice_sessions.remove(&claims.sub) {
         let channel_still_has_participants = state
             .voice_sessions

--- a/apps/server/src/routes/webrtc.rs
+++ b/apps/server/src/routes/webrtc.rs
@@ -1,16 +1,19 @@
 //! WebRTC-related API: TURN credentials from server env (not in frontend bundle).
 
 use axum::{
-    extract::{Query, State},
+    body::Bytes,
+    extract::{DefaultBodyLimit, Query, State},
+    http::{header::AUTHORIZATION, HeaderMap, StatusCode},
     middleware,
-    routing::get,
+    routing::{get, post},
     Extension, Json, Router,
 };
 use base64::Engine;
 use hmac::{Hmac, Mac};
-use jsonwebtoken::{encode, EncodingKey, Header};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -18,6 +21,7 @@ use crate::{
     errors::AppError,
     middleware::auth::{require_auth, Claims},
     services::rate_limit::enforce_rate_limit,
+    services::voice_revoke::clear_local_voice_session,
     ws::access::can_join_voice_channel,
     AppState,
 };
@@ -26,6 +30,7 @@ const TURN_CREDENTIAL_RATE_LIMIT_MAX: usize = 30;
 const LIVEKIT_TOKEN_USER_RATE_LIMIT_MAX: usize = 30;
 const LIVEKIT_TOKEN_RATE_LIMIT_MAX: usize = 20;
 const MEDIA_TOKEN_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+const LIVEKIT_WEBHOOK_BODY_LIMIT: usize = 256 * 1024;
 
 #[derive(Debug, Serialize)]
 pub struct TurnCredentialsResponse {
@@ -37,10 +42,16 @@ pub struct TurnCredentialsResponse {
 }
 
 pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
-    Router::new()
+    let authenticated = Router::new()
         .route("/turn-credentials", get(turn_credentials))
         .route("/livekit-token", get(livekit_token))
-        .route_layer(middleware::from_fn_with_state(state, require_auth))
+        .route_layer(middleware::from_fn_with_state(state, require_auth));
+
+    let webhook = Router::new()
+        .route("/livekit-webhook", post(livekit_webhook))
+        .layer(DefaultBodyLimit::max(LIVEKIT_WEBHOOK_BODY_LIMIT));
+
+    Router::new().merge(webhook).merge(authenticated)
 }
 
 type HmacSha1 = Hmac<Sha1>;
@@ -152,6 +163,127 @@ struct LivekitClaims {
     video: LivekitVideoGrant,
 }
 
+#[derive(Debug, Deserialize)]
+struct LivekitWebhookClaims {
+    sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LivekitWebhookEvent {
+    event: String,
+    room: Option<LivekitWebhookRoom>,
+    participant: Option<LivekitWebhookParticipant>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LivekitWebhookRoom {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LivekitWebhookParticipant {
+    identity: String,
+    sid: Option<String>,
+}
+
+fn webhook_matches_active_participant(
+    active_participant_sid: Option<&str>,
+    event_participant_sid: Option<&str>,
+) -> bool {
+    active_participant_sid.is_some() && active_participant_sid == event_participant_sid
+}
+
+fn verify_livekit_webhook(
+    body: &[u8],
+    authorization: &str,
+    api_key: &str,
+    api_secret: &str,
+) -> Result<LivekitWebhookEvent, AppError> {
+    let token = authorization
+        .strip_prefix("Bearer ")
+        .unwrap_or(authorization)
+        .trim();
+    if token.is_empty() {
+        return Err(AppError::Unauthorized);
+    }
+
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_issuer(&[api_key]);
+    validation.set_required_spec_claims(&["exp", "iss", "sha256"]);
+    validation.validate_nbf = true;
+    let claims = decode::<LivekitWebhookClaims>(
+        token,
+        &DecodingKey::from_secret(api_secret.as_bytes()),
+        &validation,
+    )
+    .map_err(|_| AppError::Unauthorized)?
+    .claims;
+
+    let signed_hash = base64::engine::general_purpose::STANDARD
+        .decode(claims.sha256)
+        .map_err(|_| AppError::Unauthorized)?;
+    let body_hash = Sha256::digest(body);
+    if signed_hash.as_slice() != &body_hash[..] {
+        return Err(AppError::Unauthorized);
+    }
+
+    serde_json::from_slice(body).map_err(|_| AppError::Unauthorized)
+}
+
+async fn livekit_webhook(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<StatusCode, AppError> {
+    let api_key = state
+        .livekit_api_key
+        .as_deref()
+        .ok_or_else(|| AppError::FeatureDisabled("Voice service is not configured.".into()))?;
+    let api_secret = state
+        .livekit_api_secret
+        .as_deref()
+        .ok_or_else(|| AppError::FeatureDisabled("Voice service is not configured.".into()))?;
+    let authorization = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(AppError::Unauthorized)?;
+    let event = verify_livekit_webhook(&body, authorization, api_key, api_secret)?;
+
+    if event.event != "participant_left" {
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
+    let (Some(room), Some(participant)) = (event.room, event.participant) else {
+        tracing::warn!("Ignoring incomplete LiveKit participant_left webhook");
+        return Ok(StatusCode::NO_CONTENT);
+    };
+    let Ok(channel_id) = uuid::Uuid::parse_str(&room.name) else {
+        tracing::warn!("Ignoring LiveKit participant_left webhook with a non-Voxpery room");
+        return Ok(StatusCode::NO_CONTENT);
+    };
+    let Ok(user_id) = uuid::Uuid::parse_str(&participant.identity) else {
+        tracing::warn!("Ignoring LiveKit participant_left webhook with an invalid identity");
+        return Ok(StatusCode::NO_CONTENT);
+    };
+    let active_participant_sid = state
+        .voice_participant_sids
+        .get(&user_id)
+        .map(|entry| entry.clone());
+    if !webhook_matches_active_participant(
+        active_participant_sid.as_deref(),
+        participant.sid.as_deref(),
+    ) {
+        tracing::debug!(
+            "Ignoring stale LiveKit participant_left webhook for rejoined user {}",
+            user_id
+        );
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
+    clear_local_voice_session(&state, user_id, channel_id, "LiveKit participant left").await;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// GET /api/webrtc/livekit-token?channel_id=... — returns LiveKit access token (auth required).
 async fn livekit_token(
     State(state): State<Arc<AppState>>,
@@ -237,4 +369,103 @@ async fn livekit_token(
         room,
         identity,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{verify_livekit_webhook, webhook_matches_active_participant};
+    use base64::Engine;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde::Serialize;
+    use sha2::{Digest, Sha256};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use uuid::Uuid;
+
+    #[derive(Serialize)]
+    struct TestWebhookClaims {
+        iss: String,
+        sha256: String,
+        nbf: usize,
+        exp: usize,
+    }
+
+    fn signed_webhook(body: &[u8], api_key: &str, api_secret: &str) -> String {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs() as usize;
+        let sha256 = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(body));
+        encode(
+            &Header::default(),
+            &TestWebhookClaims {
+                iss: api_key.to_string(),
+                sha256,
+                nbf: now.saturating_sub(1),
+                exp: now + 60,
+            },
+            &EncodingKey::from_secret(api_secret.as_bytes()),
+        )
+        .expect("test webhook token should encode")
+    }
+
+    #[test]
+    fn verifies_signed_livekit_webhook_and_decodes_event() {
+        let api_key = format!("test-key-{}", Uuid::new_v4());
+        let api_secret = format!("test-secret-{}", Uuid::new_v4());
+        let body = br#"{"event":"participant_left","room":{"name":"room"},"participant":{"identity":"user","sid":"PA_test"}}"#;
+        let token = signed_webhook(body, &api_key, &api_secret);
+
+        let event = verify_livekit_webhook(
+            body,
+            &format!("Bearer {token}"),
+            &api_key,
+            &api_secret,
+        )
+        .expect("signed webhook should verify");
+
+        assert_eq!(event.event, "participant_left");
+        assert_eq!(event.room.expect("room").name, "room");
+        let participant = event.participant.expect("participant");
+        assert_eq!(participant.identity, "user");
+        assert_eq!(participant.sid.as_deref(), Some("PA_test"));
+    }
+
+    #[test]
+    fn rejects_livekit_webhook_when_body_is_tampered() {
+        let api_key = format!("test-key-{}", Uuid::new_v4());
+        let api_secret = format!("test-secret-{}", Uuid::new_v4());
+        let original = br#"{"event":"participant_left"}"#;
+        let tampered = br#"{"event":"participant_joined"}"#;
+        let token = signed_webhook(original, &api_key, &api_secret);
+
+        assert!(verify_livekit_webhook(tampered, &token, &api_key, &api_secret).is_err());
+    }
+
+    #[test]
+    fn rejects_livekit_webhook_signed_for_another_api_key() {
+        let api_key = format!("test-key-{}", Uuid::new_v4());
+        let other_api_key = format!("other-key-{}", Uuid::new_v4());
+        let api_secret = format!("test-secret-{}", Uuid::new_v4());
+        let body = br#"{"event":"participant_left"}"#;
+        let token = signed_webhook(body, &other_api_key, &api_secret);
+
+        assert!(verify_livekit_webhook(body, &token, &api_key, &api_secret).is_err());
+    }
+
+    #[test]
+    fn ignores_leave_webhook_for_an_older_participant_session() {
+        assert!(!webhook_matches_active_participant(None, Some("PA_old")));
+        assert!(webhook_matches_active_participant(
+            Some("PA_current"),
+            Some("PA_current")
+        ));
+        assert!(!webhook_matches_active_participant(
+            Some("PA_current"),
+            Some("PA_old")
+        ));
+        assert!(!webhook_matches_active_participant(
+            Some("PA_current"),
+            None
+        ));
+    }
 }

--- a/apps/server/src/services/voice_revoke.rs
+++ b/apps/server/src/services/voice_revoke.rs
@@ -75,7 +75,7 @@ fn voice_control_event_from_state(
     }
 }
 
-async fn clear_local_voice_session(
+pub(crate) async fn clear_local_voice_session(
     state: &Arc<AppState>,
     user_id: Uuid,
     channel_id: Uuid,
@@ -91,6 +91,7 @@ async fn clear_local_voice_session(
         return;
     }
 
+    state.voice_participant_sids.remove(&user_id);
     let server_id = server_id_for_channel_from_state(state, channel_id).await;
     let _ = state.voice_controls.remove(&user_id);
     cleanup_voice_channel_active_since_if_empty(state, channel_id);

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -725,7 +725,10 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                     .await;
                                 }
                             }
-                            WsClientMessage::JoinVoice { channel_id } => {
+                            WsClientMessage::JoinVoice {
+                                channel_id,
+                                participant_sid,
+                            } => {
                                 match can_join_voice_channel(&recv_state.db, user_id, channel_id)
                                     .await
                                 {
@@ -743,6 +746,20 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                         // 1. Update voice session
                                         let previous_channel_id =
                                             recv_state.voice_sessions.insert(user_id, channel_id);
+                                        if let Some(participant_sid) = participant_sid.filter(|sid| {
+                                            !sid.is_empty()
+                                                && sid.len() <= 128
+                                                && sid.bytes().all(|byte| {
+                                                    byte.is_ascii_alphanumeric()
+                                                        || matches!(byte, b'_' | b'-')
+                                                })
+                                        }) {
+                                            recv_state
+                                                .voice_participant_sids
+                                                .insert(user_id, participant_sid);
+                                        } else {
+                                            recv_state.voice_participant_sids.remove(&user_id);
+                                        }
                                         if let Some(previous_channel_id) = previous_channel_id {
                                             if previous_channel_id != channel_id {
                                                 cleanup_voice_channel_active_since_if_empty(
@@ -820,6 +837,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                 if let Some((_, previous_channel_id)) =
                                     recv_state.voice_sessions.remove(&user_id)
                                 {
+                                    recv_state.voice_participant_sids.remove(&user_id);
                                     let previous_server_id =
                                         server_id_for_channel(&recv_state.db, previous_channel_id)
                                             .await;
@@ -1109,6 +1127,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
     if last_session_gone {
         let removed_voice = state.voice_sessions.remove(&user_id);
         if let Some((_, previous_channel_id)) = removed_voice {
+            state.voice_participant_sids.remove(&user_id);
             let previous_server_id = server_id_for_channel(&state.db, previous_channel_id).await;
             let _ = state.voice_controls.remove(&user_id);
             cleanup_voice_channel_active_since_if_empty(&state, previous_channel_id);

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -120,7 +120,11 @@ pub enum WsClientMessage {
     /// Typing indicator.
     Typing { channel_id: Uuid, is_typing: bool },
     /// Join a voice channel.
-    JoinVoice { channel_id: Uuid },
+    JoinVoice {
+        channel_id: Uuid,
+        #[serde(default)]
+        participant_sid: Option<String>,
+    },
     /// Leave voice channel.
     LeaveVoice,
     /// Disconnect another member from voice (server moderation).

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -97,6 +97,7 @@ async fn setup_app_with_auth_features(
         tx,
         sessions: DashMap::new(),
         voice_sessions: DashMap::new(),
+        voice_participant_sids: DashMap::new(),
         voice_channel_active_since_ms: DashMap::new(),
         voice_controls: DashMap::new(),
         auth_rate_limit_max: 100,

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   clearRemoteMediaStartCue,
   getMicrophonePublishOptions,
+  reconcileFinalMediaDisconnect,
   remoteMediaKindForSource,
   remoteMediaStartCueKey,
   resyncVoiceStateAfterReconnect,
@@ -52,6 +53,7 @@ describe('resyncVoiceStateAfterReconnect', () => {
     resyncVoiceStateAfterReconnect({
       channelId: 'voice-channel-1',
       roomState: 'connected',
+      participantSid: 'PA_current',
       control: {
         muted: true,
         deafened: false,
@@ -63,6 +65,7 @@ describe('resyncVoiceStateAfterReconnect', () => {
 
     expect(send).toHaveBeenNthCalledWith(1, 'JoinVoice', {
       channel_id: 'voice-channel-1',
+      participant_sid: 'PA_current',
     })
     expect(send).toHaveBeenNthCalledWith(2, 'SetVoiceControl', {
       muted: true,
@@ -127,6 +130,61 @@ describe('resyncVoiceStateAfterReconnect', () => {
     })
 
     expect(send).not.toHaveBeenCalled()
+  })
+})
+
+describe('final LiveKit disconnect reconciliation', () => {
+  it('leaves signaling presence after the media room is permanently disconnected', () => {
+    const leaveVoice = vi.fn()
+
+    expect(reconcileFinalMediaDisconnect({
+      channelId: 'voice-channel-1',
+      alreadyReconciled: false,
+      isCurrentRoom: true,
+      leaveVoice,
+    })).toBe(true)
+
+    expect(leaveVoice).toHaveBeenCalledOnce()
+    expect(leaveVoice).toHaveBeenCalledWith({
+      skipLeaveSound: true,
+      skipRoomDisconnect: true,
+    })
+  })
+
+  it('does not emit duplicate leave events for the same disconnect', () => {
+    const leaveVoice = vi.fn()
+
+    expect(reconcileFinalMediaDisconnect({
+      channelId: 'voice-channel-1',
+      alreadyReconciled: true,
+      isCurrentRoom: true,
+      leaveVoice,
+    })).toBe(false)
+    expect(leaveVoice).not.toHaveBeenCalled()
+  })
+
+  it('does not emit leave when no voice presence is active', () => {
+    const leaveVoice = vi.fn()
+
+    expect(reconcileFinalMediaDisconnect({
+      channelId: null,
+      alreadyReconciled: false,
+      isCurrentRoom: true,
+      leaveVoice,
+    })).toBe(false)
+    expect(leaveVoice).not.toHaveBeenCalled()
+  })
+
+  it('ignores a delayed disconnect event from a previous room', () => {
+    const leaveVoice = vi.fn()
+
+    expect(reconcileFinalMediaDisconnect({
+      channelId: 'voice-channel-2',
+      alreadyReconciled: false,
+      isCurrentRoom: false,
+      leaveVoice,
+    })).toBe(false)
+    expect(leaveVoice).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -70,19 +70,43 @@ export function remoteMediaKindForSource(source: Track.Source): RemoteMediaKind 
 interface VoiceReconnectResyncOptions {
   channelId: string | null
   roomState: string | null
+  participantSid?: string | null
   control: VoiceControlState
   send: (type: string, data: unknown) => void
+}
+
+interface FinalMediaDisconnectReconcileOptions {
+  channelId: string | null
+  alreadyReconciled: boolean
+  isCurrentRoom: boolean
+  leaveVoice: (options: { skipLeaveSound: boolean; skipRoomDisconnect: boolean }) => void
+}
+
+export function reconcileFinalMediaDisconnect({
+  channelId,
+  alreadyReconciled,
+  isCurrentRoom,
+  leaveVoice,
+}: FinalMediaDisconnectReconcileOptions): boolean {
+  if (!channelId || alreadyReconciled || !isCurrentRoom) return false
+
+  leaveVoice({ skipLeaveSound: true, skipRoomDisconnect: true })
+  return true
 }
 
 export function resyncVoiceStateAfterReconnect({
   channelId,
   roomState,
+  participantSid,
   control,
   send,
 }: VoiceReconnectResyncOptions): void {
   if (!channelId || !roomState || roomState === 'disconnected') return
 
-  send('JoinVoice', { channel_id: channelId })
+  send('JoinVoice', {
+    channel_id: channelId,
+    ...(participantSid ? { participant_sid: participantSid } : {}),
+  })
   send('SetVoiceControl', {
     muted: !!control?.muted,
     deafened: !!control?.deafened,
@@ -171,6 +195,8 @@ export function useLiveKitVoice() {
   const userHiddenRemoteMediaKeysRef = useRef<Set<string>>(new Set())
   const resumedTrackSidsRef = useRef<Set<string>>(new Set())
   const joinedChannelIdRef = useRef<string | null>(null)
+  const finalMediaDisconnectReconciledRef = useRef(false)
+  const finalMediaDisconnectHandlerRef = useRef<(isCurrentRoom: boolean) => void>(() => undefined)
   const desiredMicMutedRef = useRef(false)
   const activeInputDeviceIdRef = useRef(getStoredVoiceInputDeviceId())
 
@@ -535,6 +561,7 @@ export function useLiveKitVoice() {
     }
 
     setLastError(null)
+    finalMediaDisconnectReconciledRef.current = false
     isJoiningRef.current = true
     setIsJoining(true)
     let preflightStream: MediaStream | null = options?.preflightStream ?? null
@@ -743,8 +770,7 @@ export function useLiveKitVoice() {
             console.warn('[useLiveKitVoice] LiveKit Room disconnected, reason:', reason)
           }
           updateRoomStats()
-          // If the room disconnects unexpectedly, clean up local state
-          // but do NOT call leaveVoice() — the WS resync effect handles re-join
+          finalMediaDisconnectHandlerRef.current(roomRef.current === room)
         })
 
       const connectPromise = room.connect(ws_url, lkToken, {
@@ -785,6 +811,10 @@ export function useLiveKitVoice() {
         },
       })
 
+      if (String(room.state) !== 'connected') {
+        throw new Error('LiveKit disconnected before voice presence was registered')
+      }
+
       micPublished = true
       localAudioTrackRef.current = pub.track as LocalAudioTrack
       await setLocalMicMuted(desiredMicMutedRef.current)
@@ -800,7 +830,10 @@ export function useLiveKitVoice() {
       }
 
       joinedChannelIdRef.current = channelId
-      send('JoinVoice', { channel_id: channelId })
+      send('JoinVoice', {
+        channel_id: channelId,
+        participant_sid: room.localParticipant.sid,
+      })
       setJoinedChannelId(channelId)
       useAppStore.getState().setJoinedVoiceChannelId(channelId)
       send('SetVoiceControl', { muted: desiredMicMutedRef.current, deafened: false, screen_sharing: false, camera_on: false })
@@ -818,7 +851,7 @@ export function useLiveKitVoice() {
     }
     }, [applyLocalMicSettings, buildMicSendTrack, cleanupLocalMedia, closePeer, getAudioContext, getMicrophoneStream, getScreenShareEncoding, getInputVolumeFactor, isConnected, playRemoteMediaStartCue, playVoiceCue, refreshLocalStreams, rememberExistingRemoteMedia, remoteMediaSubscriptionKey, send, setLocalMicMuted, startLocalSpeakingMonitor, syncParticipantMediaState, syncRemotePublicationSubscription, syncRemoteSubscriptions, token, updateRoomStats, userId, voiceMode])
 
-    const leaveVoice = useCallback((options?: { skipLeaveSound?: boolean }) => {
+    const leaveVoice = useCallback((options?: { skipLeaveSound?: boolean; skipRoomDisconnect?: boolean }) => {
     isJoiningRef.current = false
     if (joinedChannelIdRef.current && !options?.skipLeaveSound) playVoiceCue('leave')
     setLastError(null)
@@ -851,7 +884,7 @@ export function useLiveKitVoice() {
     localCameraTrackRef.current = null
     localScreenTracksRef.current = []
 
-    if (room) room.disconnect()
+    if (room && !options?.skipRoomDisconnect) room.disconnect()
 
     setRoomState('disconnected')
     setParticipantCount(0)
@@ -864,6 +897,18 @@ export function useLiveKitVoice() {
     setScreenStream(null)
     setCameraStream(null)
   }, [cleanupLocalMedia, destroyRnnoise, playVoiceCue, send, stopLocalSpeakingMonitor, userId])
+
+  useEffect(() => {
+    finalMediaDisconnectHandlerRef.current = (isCurrentRoom) => {
+      const reconciled = reconcileFinalMediaDisconnect({
+        channelId: joinedChannelIdRef.current,
+        alreadyReconciled: finalMediaDisconnectReconciledRef.current,
+        isCurrentRoom,
+        leaveVoice,
+      })
+      if (reconciled) finalMediaDisconnectReconciledRef.current = true
+    }
+  }, [leaveVoice])
 
   const stopScreenShare = useCallback(() => {
     const room = roomRef.current
@@ -1112,6 +1157,7 @@ export function useLiveKitVoice() {
       resyncVoiceStateAfterReconnect({
         channelId,
         roomState: room ? String(room.state) : null,
+        participantSid: room?.localParticipant.sid ?? null,
         control,
         send,
       })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,3 +148,8 @@ configs:
 
       keys:
         "${LIVEKIT_API_KEY:-devkey}": "${LIVEKIT_API_SECRET}"
+
+      webhook:
+        api_key: "${LIVEKIT_API_KEY:-devkey}"
+        urls:
+          - "http://server:3001/api/webrtc/livekit-webhook"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -153,6 +153,7 @@ Security defaults in compose:
 Important:
 
 - The default `docker-compose.yml` applies conservative LiveKit limits even if you do not customize `.env`.
+- The bundled LiveKit config sends signed participant lifecycle webhooks to the internal server service. It reuses `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET`; no extra public webhook URL or secret is required for Compose deployments.
 - Default values are:
   - `LIVEKIT_CPUS_LIMIT=2.0`
   - `LIVEKIT_MEM_LIMIT=1500m`

--- a/docs/WEBSOCKET_EVENTS.md
+++ b/docs/WEBSOCKET_EVENTS.md
@@ -67,7 +67,13 @@ Note:
 ### `JoinVoice`
 
 ```json
-{ "type": "JoinVoice", "data": { "channel_id": "voice-channel-uuid" } }
+{
+  "type": "JoinVoice",
+  "data": {
+    "channel_id": "voice-channel-uuid",
+    "participant_sid": "PA_livekit-session"
+  }
+}
 ```
 
 Authorization:
@@ -167,20 +173,23 @@ Legacy custom signaling event.
 
 ## Voice + LiveKit Flow
 
-1. Client sends `JoinVoice` over WS.
-2. Backend validates effective permission and updates process-local `voice_sessions`.
-3. Backend broadcasts voice state/control events.
-4. Client requests `GET /api/webrtc/livekit-token`.
-5. Client connects to LiveKit room.
+1. Client requests `GET /api/webrtc/livekit-token`; the backend validates effective voice permissions.
+2. Client connects to the LiveKit room and publishes its microphone.
+3. Client sends `JoinVoice` over WS only after the media connection succeeds.
+4. Backend updates process-local `voice_sessions` and broadcasts voice state/control events.
+5. LiveKit owns the reconnect grace window, so temporary `Reconnecting` state keeps sidebar presence intact.
+6. A final room `Disconnected` event sends `LeaveVoice` over the application WebSocket and clears local media state.
+7. The signed LiveKit `participant_left` webhook idempotently clears the same backend voice session for suspended or unreachable clients. The participant SID prevents a delayed leave event from removing a newer rejoin. Backend WebSocket cleanup remains the fallback when both connections are lost.
 
 ## Security Notes
 
 - `Subscribe` uses permission-aware channel access checks.
 - Broadcast delivery performs current-access re-checks before sending channel events.
 - `JoinVoice` uses permission-aware voice checks.
+- LiveKit webhook payloads require a matching API-key issuer, HS256 signature, expiration, and raw-body SHA-256 claim before they can clear voice state.
 - Voice state/control events are filtered by current server membership.
 - `Signal` forwarding is constrained to same voice channel participants.
 
 ---
 
-Last verified against code on 2026-05-09.
+Last verified against code on 2026-08-07.


### PR DESCRIPTION
## Summary
- reconcile final LiveKit disconnects with WebSocket voice presence
- add signed `participant_left` webhook cleanup for suspended clients
- track participant SIDs to prevent delayed events from removing newer rejoins
- clear voice controls, media state, and channel duration consistently
- document the updated LiveKit and WebSocket lifecycle

## Validation
- `cargo check --locked`
- `cargo test --locked`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- Graphify knowledge graph refreshed

Closes #274