### PR TITLE
fix: correct landing auth routes

### DIFF
--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -6,7 +6,12 @@ test.describe('App Navigation', () => {
 
     await expect(page).toHaveURL(/\/$/)
     await expect(page.getByRole('heading', { name: 'Voxpery', level: 1 })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Login' })).toHaveAttribute('href', '/login')
     await expect(page.getByRole('link', { name: /join voxpery community/i })).toHaveAttribute('href', '/register')
+    await expect(page.getByRole('link', { name: 'Source' })).toHaveAttribute(
+      'href',
+      'https://github.com/emircanagac/voxpery',
+    )
     await expect(page.getByRole('link', { name: /self-host with docker/i })).toBeVisible()
   })
 

--- a/apps/web/src/pages/AboutPage.test.tsx
+++ b/apps/web/src/pages/AboutPage.test.tsx
@@ -37,7 +37,24 @@ describe('AboutPage', () => {
 
     expect(screen.getByRole('heading', { name: 'Voxpery', level: 1 })).toBeInTheDocument()
     expect(screen.getByText(/a discord alternative for communities/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', '/login')
     expect(screen.getByRole('link', { name: /join voxpery community/i })).toHaveAttribute('href', '/register')
+    expect(screen.getByRole('link', { name: 'Source' })).toHaveAttribute(
+      'href',
+      'https://github.com/emircanagac/voxpery',
+    )
+    expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
+      'href',
+      'https://github.com/emircanagac/voxpery/releases/latest',
+    )
+    expect(screen.getByRole('link', { name: 'Contributors' })).toHaveAttribute(
+      'href',
+      'https://github.com/emircanagac/voxpery/graphs/contributors',
+    )
+    expect(screen.getByRole('link', { name: 'Security' })).toHaveAttribute(
+      'href',
+      'https://github.com/emircanagac/voxpery/blob/main/SECURITY.md',
+    )
     expect(screen.getByText(/new accounts join the live community automatically/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /self-host with docker/i })).toHaveAttribute(
       'href',
@@ -45,5 +62,30 @@ describe('AboutPage', () => {
     )
     expect(screen.getByText('Inspectable by design')).toBeInTheDocument()
     expect(screen.getByText('Your deployment choice')).toBeInTheDocument()
+  })
+
+  it('routes authenticated visitors back into the app', () => {
+    vi.mocked(releaseApi.getLatest).mockRejectedValue(new Error('release unavailable'))
+    useAuthStore.setState({
+      token: 'test-token',
+      user: {
+        id: 'user-1',
+        username: 'tester',
+        email: 'tester@example.com',
+        email_verified: true,
+        status: 'online',
+      },
+      loggingOut: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Go to app' })).toHaveAttribute('href', '/social')
+    expect(screen.getByRole('link', { name: /open voxpery/i })).toHaveAttribute('href', '/social')
+    expect(screen.queryByRole('link', { name: 'Login' })).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/pages/AboutPage.tsx
+++ b/apps/web/src/pages/AboutPage.tsx
@@ -79,6 +79,7 @@ export default function AboutPage() {
   const detectedDownload = platform !== 'unknown' ? downloads[platform] : null
   const primaryDownloadUrl = detectedDownload ?? releaseUrl
   const primaryDownloadLabel = platform === 'unknown' ? 'Download desktop app' : `Download for ${PLATFORM_LABELS[platform]}`
+  const loginRoute = isAuthenticated ? ROUTES.home : ROUTES.login
   const appEntryRoute = isAuthenticated ? ROUTES.home : ROUTES.register
   const appEntryLabel = isAuthenticated ? 'Open Voxpery' : 'Join Voxpery Community'
   const releaseMeta = [releaseTag, releaseDate].filter(Boolean).join(' - ')
@@ -110,7 +111,7 @@ export default function AboutPage() {
         </nav>
 
         <div className="about-topbar-actions">
-          <Link to={appEntryRoute} className="about-btn about-btn--login">
+          <Link to={loginRoute} className="about-btn about-btn--login">
             {isAuthenticated ? 'Go to app' : 'Login'}
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- correct the landing page Login route
- keep the community signup CTA routed to registration
- preserve authenticated app-entry behavior
- add regression coverage for landing authentication and external links

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`
- landing navigation tests in Chromium