### PR TITLE
fix: complete desktop OAuth return flow

### DIFF
--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -140,6 +140,60 @@ fn append_query_param(path: &str, key: &str, value: &str) -> String {
     out
 }
 
+fn escape_html_attribute(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn javascript_string_literal(value: &str) -> String {
+    serde_json::to_string(value)
+        .unwrap_or_else(|_| "\"voxpery://auth/\"".to_string())
+        .replace('&', "\\u0026")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+}
+
+fn desktop_oauth_handoff_html(redirect_url: &str) -> String {
+    let href = escape_html_attribute(redirect_url);
+    let app_url = javascript_string_literal(redirect_url);
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Opening Voxpery...</title>
+<style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #1e1e2e; color: #cdd6f4; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; text-align: center; }}
+    .card {{ background: #313244; padding: 2rem; border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.3); max-width: 400px; }}
+    h1 {{ color: #89b4fa; margin-bottom: 1rem; }}
+    p {{ line-height: 1.5; color: #a6adc8; }}
+    .btn {{ display: inline-block; margin-top: 1.5rem; padding: 0.75rem 1.5rem; background: #89b4fa; color: #1e1e2e; text-decoration: none; border-radius: 6px; font-weight: bold; transition: opacity 0.2s; }}
+    .btn:hover {{ opacity: 0.9; }}
+</style>
+</head>
+<body>
+<main class="card">
+    <h1>Login Successful!</h1>
+    <p>You are being redirected to the Voxpery desktop app.</p>
+    <p>If the app does not open automatically, use the button below.</p>
+    <a id="open-voxpery" href="{href}" class="btn">Open Voxpery</a>
+</main>
+<script>
+    const appUrl = {app_url};
+    window.addEventListener("load", () => {{
+        window.setTimeout(() => window.location.replace(appUrl), 100);
+    }}, {{ once: true }});
+</script>
+</body>
+</html>"#
+    )
+}
+
 fn is_valid_pkce_component(value: &str) -> bool {
     let len = value.len();
     if !(43..=128).contains(&len) {
@@ -233,8 +287,8 @@ async fn consume_desktop_oauth_code(
 #[cfg(test)]
 mod oauth_pkce_tests {
     use super::{
-        constant_time_eq, is_valid_pkce_component, normalize_oauth_username_seed,
-        pkce_s256_challenge,
+        constant_time_eq, desktop_oauth_handoff_html, is_valid_pkce_component,
+        normalize_oauth_username_seed, pkce_s256_challenge,
     };
 
     #[test]
@@ -283,6 +337,19 @@ mod oauth_pkce_tests {
             normalize_oauth_username_seed("Fran\u{00E7}ois d'\u{00C6}vreux"),
             "francois_d_aevreux"
         );
+    }
+
+    #[test]
+    fn desktop_oauth_handoff_keeps_automatic_and_manual_open_paths_safe() {
+        let html = desktop_oauth_handoff_html(
+            "voxpery://auth/servers?next=\"</script><script>alert(1)</script>&code=abc",
+        );
+
+        assert!(html.contains("id=\"open-voxpery\""));
+        assert!(html.contains("window.location.replace(appUrl)"));
+        assert!(html.contains("&quot;&lt;/script&gt;"));
+        assert!(html.contains("\\u003c/script\\u003e"));
+        assert!(!html.contains("<script>alert(1)</script>"));
     }
 }
 
@@ -1871,44 +1938,7 @@ async fn google_oauth_callback(
     };
 
     let mut response = if is_desktop {
-        // Desktop UX: Return a nice HTML page that triggers the deep link and tells user to close tab.
-        let html = format!(
-            r#"<!DOCTYPE html>
-    <html>
-    <head>
-    <title>Authenticating...</title>
-    <style>
-        body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #1e1e2e; color: #cdd6f4; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; text-align: center; }}
-        .card {{ background: #313244; padding: 2rem; border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.3); max-width: 400px; }}
-        h1 {{ color: #89b4fa; margin-bottom: 1rem; }}
-        p {{ line-height: 1.5; color: #a6adc8; }}
-        .btn {{ display: inline-block; margin-top: 1.5rem; padding: 0.75rem 1.5rem; background: #89b4fa; color: #1e1e2e; text-decoration: none; border-radius: 6px; font-weight: bold; transition: opacity 0.2s; }}
-        .btn:hover {{ opacity: 0.9; }}
-    </style>
-    </head>
-    <body>
-    <div class="card">
-        <h1>Login Successful!</h1>
-        <p>You are being redirected to the Voxpery desktop app.</p>
-        <p>If the app doesn't open, you can click the button below or safely close this tab.</p>
-        <div style="display: flex; gap: 1rem; justify-content: center; margin-top: 1.5rem;">
-            <a href="{}" class="btn" style="margin-top: 0;">Back to App</a>
-        </div>
-    </div>
-    <script>
-        // Try to redirect automatically
-        window.location.href = "{}";
-        // Close window after a delay (often blocked by browsers but worth a try)
-        setTimeout(() => {{
-            // Some browsers allow closing if opened via script, though OAuth is usually not the case.
-            // window.close();
-        }}, 3000);
-    </script>
-    </body>
-    </html>"#,
-            redirect_url, redirect_url
-        );
-        Html(html).into_response()
+        Html(desktop_oauth_handoff_html(&redirect_url)).into_response()
     } else {
         Redirect::temporary(&redirect_url).into_response()
     };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
-import { Routes, Route, Navigate, useLocation, useParams } from 'react-router'
+import { Routes, Route, Navigate, useLocation, useNavigate, useParams } from 'react-router'
 import { useAppStore } from './stores/app'
 import { useAuthStore, restoreSecureSession } from './stores/auth'
 import { authApi, clearStoredDesktopOAuthVerifier, getStoredDesktopOAuthVerifier, isAuthError, setAuthFailureHandler } from './api'
@@ -11,6 +11,7 @@ import GlobalLoading from './components/GlobalLoading'
 import { ROUTES } from './routes'
 import { useSocketStore } from './stores/socket'
 import { useFeatureStore } from './stores/features'
+import { createDesktopOAuthDeepLinkHandler, registerDesktopOAuthDeepLinks } from './desktopOAuth'
 
 const AppShell = lazy(() => import('./pages/AppShell'))
 const UnifiedLayout = lazy(() => import('./pages/UnifiedLayout'))
@@ -75,6 +76,7 @@ function App() {
   const validatedSessionRef = useRef(false)
   const authFailureHandledRef = useRef(false)
   const isDesktopApp = isTauri()
+  const navigate = useNavigate()
 
   useEffect(() => {
     void loadFeatures()
@@ -114,74 +116,58 @@ function App() {
     useAppStore.getState().resetSessionState()
   }, [restoring, user])
 
-  // Desktop: restore from secure storage. Web: zustand persist handles restoration.
+  // Desktop: restore secure storage, then collect cold-start and runtime OAuth deep links.
   useEffect(() => {
-    if (isTauri()) {
-      restoreSecureSession().finally(() => setRestoring(false))
-
-      // Listen for deep links (Google OAuth callback)
-      let unlisten: (() => void) | undefined
-      let unlistenCustom: (() => void) | undefined
+    if (isDesktopApp) {
+      let disposeDeepLinks: (() => void) | undefined
       let disposed = false
+      const handleDeepLinkUrl = createDesktopOAuthDeepLinkHandler({
+        getCodeVerifier: getStoredDesktopOAuthVerifier,
+        clearCodeVerifier: clearStoredDesktopOAuthVerifier,
+        exchangeCode: authApi.exchangeDesktopOAuthCode,
+        setAuth: (authToken, authUser) => useAuthStore.getState().setAuth(authToken, authUser),
+        persistToken: setSecureToken,
+        navigate: (path) => navigate(path, { replace: true }),
+        onError: (error) => console.error('Desktop OAuth return failed:', error),
+      })
 
-      const handleDeepLinkUrl = (url: string) => {
-        try {
-          const parsed = new URL(url)
-          const code = parsed.searchParams.get('code')
-          if (code) {
-            const codeVerifier = getStoredDesktopOAuthVerifier()
-            if (!codeVerifier) {
-              console.error('Missing desktop OAuth code verifier; restart login flow.')
-              return
-            }
-            authApi
-              .exchangeDesktopOAuthCode(code, codeVerifier)
-              .then((auth) => {
-                useAuthStore.getState().setAuth(auth.token, auth.user)
-                setSecureToken(auth.token).catch(() => {})
-                clearStoredDesktopOAuthVerifier()
-              })
-              .catch((err) => {
-                 console.error("Deep link auth error:", err)
-              })
-          }
-        } catch (err) {
-          console.error("Deep link URL parse error:", err)
-        }
+      const bootstrapDesktopSession = async () => {
+        await restoreSecureSession()
+        const [deepLink, event] = await Promise.all([
+          import('@tauri-apps/plugin-deep-link'),
+          import('@tauri-apps/api/event'),
+        ])
+        const cleanup = await registerDesktopOAuthDeepLinks(
+          {
+            getCurrent: deepLink.getCurrent,
+            onOpenUrl: deepLink.onOpenUrl,
+            listenCustom: (handler) => event.listen<string>(
+              'custom-deep-link',
+              (received) => handler(received.payload),
+            ),
+          },
+          handleDeepLinkUrl,
+          (error) => console.error('Desktop deep-link setup failed:', error),
+        )
+        if (disposed) cleanup()
+        else disposeDeepLinks = cleanup
       }
 
-      void import('@tauri-apps/plugin-deep-link')
-        .then(({ onOpenUrl }) => onOpenUrl((urls) => {
-          for (const url of urls) {
-            handleDeepLinkUrl(url)
-          }
-        }))
-        .then((fn) => {
-          if (disposed) fn()
-          else unlisten = fn
+      void bootstrapDesktopSession()
+        .catch((error) => console.error('Desktop session bootstrap failed:', error))
+        .finally(() => {
+          if (!disposed) setRestoring(false)
         })
-        .catch(console.error)
-
-      void import('@tauri-apps/api/event')
-        .then(({ listen }) => listen<string>('custom-deep-link', (event: { payload: string }) => {
-          handleDeepLinkUrl(event.payload)
-        }))
-        .then((fn) => {
-          if (disposed) fn()
-          else unlistenCustom = fn
-        })
-        .catch(console.error)
 
       return () => {
         disposed = true
-        if (unlisten) unlisten()
-        if (unlistenCustom) unlistenCustom()
+        disposeDeepLinks?.()
       }
     } else {
       // Web: wait for zustand persist to rehydrate, then mark as ready
       queueMicrotask(() => setRestoring(false))
     }
-  }, [])
+  }, [isDesktopApp, navigate])
 
   // Web: cookie-based session restore/validation.
   useEffect(() => {

--- a/apps/web/src/desktopOAuth.test.ts
+++ b/apps/web/src/desktopOAuth.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createDesktopOAuthDeepLinkHandler,
+  parseDesktopOAuthDeepLink,
+  registerDesktopOAuthDeepLinks,
+  type DesktopOAuthDeepLinkSources,
+} from './desktopOAuth'
+import { ROUTES } from './routes'
+import type { UserPublic } from './api'
+
+const user = { id: 'user-1', username: 'desktop-user' } as UserPublic
+const code = '0123456789abcdef0123456789abcdef'
+
+describe('desktop OAuth deep links', () => {
+  it('accepts only the Voxpery auth scheme and strips OAuth parameters from the destination', () => {
+    expect(parseDesktopOAuthDeepLink(`voxpery://auth/social/dm?room=1&code=${code}#latest`)).toEqual({
+      code,
+      error: null,
+      redirectTo: '/social/dm?room=1#latest',
+    })
+    expect(parseDesktopOAuthDeepLink(`voxpery://auth/?code=${code}`)?.redirectTo).toBe(ROUTES.servers)
+    expect(parseDesktopOAuthDeepLink(`https://auth/social?code=${code}`)).toBeNull()
+    expect(parseDesktopOAuthDeepLink(`voxpery://other/social?code=${code}`)).toBeNull()
+    expect(parseDesktopOAuthDeepLink('voxpery://auth/social?code=invalid')).toBeNull()
+  })
+
+  it('exchanges a valid startup code once and navigates to the requested app route', async () => {
+    const exchangeCode = vi.fn().mockResolvedValue({ token: 'desktop-token', user })
+    const setAuth = vi.fn()
+    const persistToken = vi.fn().mockResolvedValue(undefined)
+    const clearCodeVerifier = vi.fn()
+    const navigate = vi.fn()
+    const handler = createDesktopOAuthDeepLinkHandler({
+      getCodeVerifier: () => 'pkce-verifier',
+      clearCodeVerifier,
+      exchangeCode,
+      setAuth,
+      persistToken,
+      navigate,
+    })
+    const url = `voxpery://auth/servers?code=${code}`
+
+    await handler(url)
+    await handler(url)
+
+    expect(exchangeCode).toHaveBeenCalledTimes(1)
+    expect(exchangeCode).toHaveBeenCalledWith(code, 'pkce-verifier')
+    expect(setAuth).toHaveBeenCalledWith('desktop-token', user)
+    expect(persistToken).toHaveBeenCalledWith('desktop-token')
+    expect(clearCodeVerifier).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/servers')
+  })
+
+  it('returns to login when the callback cannot be completed', async () => {
+    const navigate = vi.fn()
+    const onError = vi.fn()
+    const handler = createDesktopOAuthDeepLinkHandler({
+      getCodeVerifier: () => null,
+      clearCodeVerifier: vi.fn(),
+      exchangeCode: vi.fn(),
+      setAuth: vi.fn(),
+      persistToken: vi.fn(),
+      navigate,
+      onError,
+    })
+
+    await handler(`voxpery://auth/servers?code=${code}`)
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/login?error=oauth_failed&redirect=%2Fservers')
+  })
+
+  it('registers runtime listeners and processes the cold-start URL from getCurrent', async () => {
+    let opened: ((urls: string[]) => void) | undefined
+    let custom: ((url: string) => void) | undefined
+    const disposeOpen = vi.fn()
+    const disposeCustom = vi.fn()
+    const sources: DesktopOAuthDeepLinkSources = {
+      getCurrent: vi.fn().mockResolvedValue([`voxpery://auth/servers?code=${code}`]),
+      onOpenUrl: vi.fn(async (handler) => {
+        opened = handler
+        return disposeOpen
+      }),
+      listenCustom: vi.fn(async (handler) => {
+        custom = handler
+        return disposeCustom
+      }),
+    }
+    const handler = vi.fn().mockResolvedValue(true)
+
+    const dispose = await registerDesktopOAuthDeepLinks(sources, handler)
+    expect(handler).toHaveBeenCalledWith(`voxpery://auth/servers?code=${code}`)
+
+    opened?.(['voxpery://auth/social?error=oauth_failed'])
+    custom?.('voxpery://auth/social?error=oauth_failed')
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(3))
+
+    dispose()
+    expect(disposeOpen).toHaveBeenCalledTimes(1)
+    expect(disposeCustom).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/desktopOAuth.ts
+++ b/apps/web/src/desktopOAuth.ts
@@ -1,0 +1,154 @@
+import type { UserPublic } from './api'
+import { resolvePostAuthRoute } from './authRedirect'
+import { ROUTES } from './routes'
+
+const DESKTOP_OAUTH_PROTOCOL = 'voxpery:'
+const DESKTOP_OAUTH_HOST = 'auth'
+const DESKTOP_OAUTH_CODE_PATTERN = /^[0-9a-f]{32}$/i
+
+interface DesktopOAuthDeepLink {
+  code: string | null
+  error: string | null
+  redirectTo: string
+}
+
+interface DesktopOAuthHandlerDependencies {
+  getCodeVerifier: () => string | null
+  clearCodeVerifier: () => void
+  exchangeCode: (code: string, codeVerifier: string) => Promise<{ token: string; user: UserPublic }>
+  setAuth: (token: string, user: UserPublic) => void
+  persistToken: (token: string) => Promise<void>
+  navigate: (path: string) => void
+  onError?: (error: unknown) => void
+}
+
+export interface DesktopOAuthDeepLinkSources {
+  getCurrent: () => Promise<string[] | null>
+  onOpenUrl: (handler: (urls: string[]) => void) => Promise<() => void>
+  listenCustom: (handler: (url: string) => void) => Promise<() => void>
+}
+
+function resolveDesktopRedirect(parsed: URL): string {
+  const search = new URLSearchParams(parsed.search)
+  search.delete('code')
+  search.delete('error')
+
+  const suffix = search.size > 0 ? `?${search.toString()}` : ''
+  const candidate = `${parsed.pathname || '/'}${suffix}${parsed.hash}`
+  if (!candidate.startsWith('/') || candidate.startsWith('//')) {
+    return resolvePostAuthRoute()
+  }
+  return candidate === '/' ? resolvePostAuthRoute() : resolvePostAuthRoute(candidate)
+}
+
+export function parseDesktopOAuthDeepLink(url: string): DesktopOAuthDeepLink | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+
+  if (
+    parsed.protocol !== DESKTOP_OAUTH_PROTOCOL
+    || parsed.hostname !== DESKTOP_OAUTH_HOST
+    || parsed.username
+    || parsed.password
+    || parsed.port
+  ) {
+    return null
+  }
+
+  const code = parsed.searchParams.get('code')?.trim() || null
+  const error = parsed.searchParams.get('error')?.trim() || null
+  if (code && !DESKTOP_OAUTH_CODE_PATTERN.test(code)) return null
+  if (!code && !error) return null
+
+  return {
+    code,
+    error,
+    redirectTo: resolveDesktopRedirect(parsed),
+  }
+}
+
+function oauthFailureRoute(redirectTo: string): string {
+  const search = new URLSearchParams({
+    error: 'oauth_failed',
+    redirect: redirectTo,
+  })
+  return `${ROUTES.login}?${search.toString()}`
+}
+
+export function createDesktopOAuthDeepLinkHandler(deps: DesktopOAuthHandlerDependencies) {
+  const handledCodes = new Set<string>()
+
+  return async (url: string): Promise<boolean> => {
+    const deepLink = parseDesktopOAuthDeepLink(url)
+    if (!deepLink) return false
+
+    if (deepLink.error || !deepLink.code) {
+      deps.navigate(oauthFailureRoute(deepLink.redirectTo))
+      return true
+    }
+
+    if (handledCodes.has(deepLink.code)) return true
+    handledCodes.add(deepLink.code)
+
+    const codeVerifier = deps.getCodeVerifier()
+    if (!codeVerifier) {
+      deps.onError?.(new Error('Desktop OAuth code verifier is missing'))
+      deps.navigate(oauthFailureRoute(deepLink.redirectTo))
+      return true
+    }
+
+    try {
+      const auth = await deps.exchangeCode(deepLink.code, codeVerifier)
+      deps.setAuth(auth.token, auth.user)
+      await deps.persistToken(auth.token)
+      deps.clearCodeVerifier()
+      deps.navigate(deepLink.redirectTo)
+    } catch (error) {
+      deps.clearCodeVerifier()
+      deps.onError?.(error)
+      deps.navigate(oauthFailureRoute(deepLink.redirectTo))
+    }
+
+    return true
+  }
+}
+
+export async function registerDesktopOAuthDeepLinks(
+  sources: DesktopOAuthDeepLinkSources,
+  handler: (url: string) => Promise<boolean>,
+  onError: (error: unknown) => void = console.error,
+): Promise<() => void> {
+  const cleanup: Array<() => void> = []
+  const dispatch = (url: string) => {
+    void handler(url).catch(onError)
+  }
+
+  try {
+    cleanup.push(await sources.onOpenUrl((urls) => urls.forEach(dispatch)))
+  } catch (error) {
+    onError(error)
+  }
+
+  try {
+    cleanup.push(await sources.listenCustom(dispatch))
+  } catch (error) {
+    onError(error)
+  }
+
+  try {
+    const currentUrls = await sources.getCurrent()
+    for (const url of currentUrls ?? []) {
+      await handler(url)
+    }
+  } catch (error) {
+    onError(error)
+  }
+
+  return () => {
+    for (const dispose of cleanup) dispose()
+  }
+}

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -23,6 +23,9 @@ This document defines Voxpery desktop release hardening policy for metadata, dee
 - Desktop OAuth callback origin is `voxpery://auth`.
 - Backend CORS allowlist must include `voxpery://auth`.
 - Desktop deep-link scheme in Tauri config must include `voxpery`.
+- The desktop client must process both cold-start URLs from the deep-link plugin's `getCurrent()` API and runtime URLs from `onOpenUrl`/single-instance events.
+- OAuth callback codes are single-use. Duplicate delivery through multiple desktop event sources must be deduplicated before exchange.
+- The browser handoff page must attempt to open Voxpery automatically, keep an explicit user-gesture fallback, and safely encode the generated deep-link URL.
 - Release preflight validates:
   - deep-link scheme setup
   - frontend OAuth origin behavior
@@ -73,7 +76,7 @@ Before publishing or announcing a desktop release:
 Before publishing a desktop release:
 
 1. Complete `docs/RELEASE_SMOKE_TEST_CHECKLIST.md`.
-2. Confirm OAuth deep-link roundtrip works from browser back to desktop app.
+2. Confirm OAuth deep-link roundtrip works from browser back to both a closed and an already-running desktop app.
 3. Confirm installer uses Voxpery icon/name (not default NSIS icon).
 4. Confirm update check UX:
    - no-update state is understandable

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -87,8 +87,10 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Windows startup launch keeps Voxpery in the background/tray, and opening it from the tray shows a maximized window.
 - [ ] Production desktop build connects only to the official API and does not allow localhost API scopes.
 - [ ] Desktop register screen renders CAPTCHA and new account registration succeeds when production CAPTCHA is enabled.
-- [ ] Google OAuth opens browser and returns to desktop app via `voxpery://` deep link.
-- [ ] Session is restored after OAuth callback (user ends in authenticated app state).
+- [ ] With Voxpery closed, Google OAuth opens the browser, starts the desktop app via `voxpery://`, and completes sign-in without requiring a second callback click.
+- [ ] With Voxpery already running, Google OAuth returns to and focuses the existing desktop instance.
+- [ ] If the browser blocks automatic external-protocol navigation, the `Open Voxpery` fallback completes the same sign-in flow.
+- [ ] Session is restored after OAuth callback, the one-time code is not exchanged twice, and the user lands on the requested authenticated route.
 - [ ] If updater artifacts are enabled, signing keys and updater pubkey are configured (see `docs/DESKTOP_RELEASE_HARDENING.md`).
 - [ ] Desktop release workflow ran against the exact release tag/ref, with `smoke_checklist_confirmed=yes`.
 - [ ] Production desktop releases used `platform=all`; single-platform workflow runs are recorded as test/hotfix-only.


### PR DESCRIPTION
## Summary

- handle desktop Google OAuth deep links during both cold start and runtime
- deduplicate one-time OAuth code delivery across deep-link event sources
- validate callback scheme, host, code, and post-auth redirect routes
- improve the browser handoff page with automatic launch and a safe manual fallback
- document closed-app and running-app OAuth smoke scenarios

## Validation

- `npm run lint`
- `npm run test:run` (192 passed)
- `npm run build`
- `cargo test --manifest-path apps/server/Cargo.toml --lib` (84 passed, 4 ignored)
- `cargo check --locked --manifest-path apps/desktop/src-tauri/Cargo.toml`