### PR TITLE
fix: stabilize first chat message layout

### DIFF
--- a/apps/web/e2e/core-ui-smoke.spec.ts
+++ b/apps/web/e2e/core-ui-smoke.spec.ts
@@ -98,7 +98,9 @@ test.describe('mocked core UI smoke', () => {
       channelsByServerId: { [server.id]: channels },
       membersByServerId: { [server.id]: buildCoreMembers() },
       messagesByChannelId: {
-        [general.id]: [buildServerMessage(general.id, 'Pinned release note')],
+        [general.id]: [buildServerMessage(general.id, 'Pinned release note', {
+          created_at: new Date().toISOString(),
+        })],
         [announcements.id]: [buildServerMessage(announcements.id, 'Announcements stay visible')],
       },
     })
@@ -119,7 +121,16 @@ test.describe('mocked core UI smoke', () => {
     await messageInput.press('Enter')
 
     await expect(page.getByText(content)).toBeVisible()
+    await expectVirtualMessageHeight(page.locator('.virtual-list-item', { hasText: content }), 53)
     expect(state.messagesByChannelId[general.id]?.some((message) => message.content === content)).toBe(true)
+
+    const continuation = `Server smoke continuation ${Date.now()}`
+    await messageInput.fill(continuation)
+    await messageInput.press('Enter')
+
+    await expect(page.getByText(continuation)).toBeVisible()
+    await expectVirtualMessageHeight(page.locator('.virtual-list-item', { hasText: continuation }), 23)
+    expect(state.messagesByChannelId[general.id]?.some((message) => message.content === continuation)).toBe(true)
 
     await page.locator('.channel-item', { hasText: 'announcements' }).click()
     await expect(page.locator('.chat-header .channel-title')).toHaveText('announcements')
@@ -412,4 +423,10 @@ async function expectScrollable(locator: Locator) {
   await expect.poll(async () => {
     return locator.evaluate((element) => element.scrollHeight > element.clientHeight)
   }).toBe(true)
+}
+
+async function expectVirtualMessageHeight(locator: Locator, expectedHeight: number) {
+  await expect.poll(async () => {
+    return locator.evaluate((element) => Math.round(element.getBoundingClientRect().height))
+  }).toBe(expectedHeight)
 }

--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -63,6 +63,7 @@ test.describe('mocked mobile web smoke', () => {
             'Mobile smoke baseline message\n![gif](https://media.example.test/mobile.gif)',
             {
               id: 'mobile-media-reaction-message',
+              created_at: new Date().toISOString(),
               attachments: [
                 {
                   url: 'https://cdn.example.test/mobile.png',
@@ -101,7 +102,15 @@ test.describe('mocked mobile web smoke', () => {
     await messageInput.fill(content)
     await messageInput.press('Enter')
     await expect(page.getByText(content)).toBeVisible()
+    await expectVirtualMessageHeight(page.locator('.virtual-list-item', { hasText: content }), 44)
     expect(state.messagesByChannelId[general.id]?.some((message) => message.content === content)).toBe(true)
+
+    const continuation = `Mobile smoke continuation ${Date.now()}`
+    await messageInput.fill(continuation)
+    await messageInput.press('Enter')
+    await expect(page.getByText(continuation)).toBeVisible()
+    await expectVirtualMessageHeight(page.locator('.virtual-list-item', { hasText: continuation }), 23)
+    expect(state.messagesByChannelId[general.id]?.some((message) => message.content === continuation)).toBe(true)
 
     await page.getByRole('button', { name: 'View members' }).click()
     const sheet = page.locator('.mobile-member-sheet')
@@ -117,6 +126,12 @@ async function expectScrollable(locator: Locator) {
   await expect.poll(async () => {
     return locator.evaluate((element) => element.scrollHeight > element.clientHeight)
   }).toBe(true)
+}
+
+async function expectVirtualMessageHeight(locator: Locator, expectedHeight: number) {
+  await expect.poll(async () => {
+    return locator.evaluate((element) => Math.round(element.getBoundingClientRect().height))
+  }).toBe(expectedHeight)
 }
 
 async function expectNoHorizontalOverflow(locator: Locator) {

--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -4,25 +4,31 @@ import type { Channel } from '../api'
 import ChatArea from './ChatArea'
 
 const scrollToIndex = vi.fn()
+let estimateVirtualRow: ((index: number) => number) | undefined
 
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: ({
     count,
     getItemKey,
+    estimateSize,
   }: {
     count: number
     getItemKey: (index: number) => string | number
-  }) => ({
-    getTotalSize: () => count * 120,
-    getVirtualItems: () =>
-      Array.from({ length: count }, (_, index) => ({
-        index,
-        key: getItemKey(index),
-        start: index * 120,
-      })),
-    measureElement: vi.fn(),
-    scrollToIndex,
-  }),
+    estimateSize: (index: number) => number
+  }) => {
+    estimateVirtualRow = estimateSize
+    return {
+      getTotalSize: () => count * 120,
+      getVirtualItems: () =>
+        Array.from({ length: count }, (_, index) => ({
+          index,
+          key: getItemKey(index),
+          start: index * 120,
+        })),
+      measureElement: vi.fn(),
+      scrollToIndex,
+    }
+  },
 }))
 
 const channel = (id: string, name: string): Channel =>
@@ -99,11 +105,52 @@ describe('ChatArea regressions', () => {
   beforeEach(() => {
     vi.useRealTimers()
     scrollToIndex.mockClear()
+    estimateVirtualRow = undefined
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 })
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
+  })
+
+  it('matches desktop CSS heights for the first avatar row and compact continuation rows', () => {
+    const rows = [
+      message('message-1', 'first author', 0),
+      {
+        ...message('message-2', 'new author', 1),
+        author: { user_id: 'user-2', username: 'friend' },
+      },
+      {
+        ...message('message-3', 'compact continuation', 2),
+        author: { user_id: 'user-2', username: 'friend' },
+      },
+    ]
+
+    renderChatArea({ messages: rows })
+
+    expect(estimateVirtualRow?.(1)).toBe(53)
+    expect(estimateVirtualRow?.(2)).toBe(23)
+  })
+
+  it('matches mobile CSS heights before the first virtualizer measurement', () => {
+    const rows = [
+      message('message-1', 'first author', 0),
+      {
+        ...message('message-2', 'new author', 1),
+        author: { user_id: 'user-2', username: 'friend' },
+      },
+      {
+        ...message('message-3', 'compact continuation', 2),
+        author: { user_id: 'user-2', username: 'friend' },
+      },
+    ]
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 500 })
+
+    renderChatArea({ messages: rows })
+
+    expect(estimateVirtualRow?.(1)).toBe(44)
+    expect(estimateVirtualRow?.(2)).toBe(23)
   })
 
   it('re-anchors switched channels to their latest rendered message', async () => {

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -38,10 +38,26 @@ const MENTION_ALL: MentionUser = { user_id: '__all__', username: 'all' }
 const TOP_AUTO_LOAD_THRESHOLD_PX = 96
 const USER_SCROLL_INTENT_WINDOW_MS = 1200
 const MESSAGE_GROUP_WINDOW_MS = 5 * 60 * 1000
-const ESTIMATED_GROUPED_MESSAGE_ROW_PX = 24
-const ESTIMATED_MESSAGE_GROUP_ROW_PX = 52
-const ESTIMATED_DAY_DIVIDER_PX = 36
-const ESTIMATED_UNREAD_DIVIDER_PX = 30
+// Includes the virtual item's 1px bottom padding. Keep these values aligned with
+// the desktop and max-width: 700px message/divider rules in index.css.
+const MESSAGE_ROW_METRICS = {
+    desktop: {
+        grouped: 23,
+        group: 53,
+        firstDayDivider: 34,
+        dayDivider: 46,
+        unreadDivider: 38,
+        typing: 27,
+    },
+    mobile: {
+        grouped: 23,
+        group: 44,
+        firstDayDivider: 28,
+        dayDivider: 24,
+        unreadDivider: 28,
+        typing: 27,
+    },
+} as const
 const ESTIMATED_ATTACHMENT_ROW_PX = 36
 const ESTIMATED_MEDIA_ROW_PX = 228
 const ESTIMATED_STICKER_ROW_PX = 128
@@ -291,20 +307,29 @@ function parseReplyContent(content: string): { replyUsername: string; replyQuote
     return { replyUsername: match[1].trim(), replyQuote: cleanReplyQuotePreview(match[2]), replyBody }
 }
 
-function estimateMessageRowHeight(messages: UiMessage[], index: number, firstUnreadIndex: number, hasTypingRow: boolean) {
-    if (hasTypingRow && index === messages.length) return 34
+function estimateMessageRowHeight(
+    messages: UiMessage[],
+    index: number,
+    firstUnreadIndex: number,
+    hasTypingRow: boolean,
+    mobileLayout: boolean = false,
+) {
+    const metrics = mobileLayout ? MESSAGE_ROW_METRICS.mobile : MESSAGE_ROW_METRICS.desktop
+    if (hasTypingRow && index === messages.length) return metrics.typing
     const message = messages[index]
-    if (!message) return ESTIMATED_MESSAGE_GROUP_ROW_PX
+    if (!message) return metrics.group
 
     const isGrouped = isMessageGroupedAt(messages, index, firstUnreadIndex)
-    let estimate = isGrouped ? ESTIMATED_GROUPED_MESSAGE_ROW_PX : ESTIMATED_MESSAGE_GROUP_ROW_PX
-    if (isNewMessageDayAt(messages, index)) estimate += ESTIMATED_DAY_DIVIDER_PX
-    if (firstUnreadIndex >= 0 && index === firstUnreadIndex) estimate += ESTIMATED_UNREAD_DIVIDER_PX
+    let estimate = isGrouped ? metrics.grouped : metrics.group
+    if (isNewMessageDayAt(messages, index)) {
+        estimate += index === 0 ? metrics.firstDayDivider : metrics.dayDivider
+    }
+    if (firstUnreadIndex >= 0 && index === firstUnreadIndex) estimate += metrics.unreadDivider
     if (message.edited_at || message.clientStatus === 'failed') estimate += 8
     estimate += estimateTextExtraHeight(message.content ?? '')
     estimate += estimateEmbeddedMediaHeight(message.content ?? '')
     estimate += estimateAttachmentHeight(message.attachments)
-    return Math.max(ESTIMATED_GROUPED_MESSAGE_ROW_PX, estimate)
+    return Math.max(metrics.grouped, estimate)
 }
 
 function AttachmentLink({ attachment, index }: { attachment: Attachment; index: number }) {
@@ -627,6 +652,9 @@ export default function ChatArea({
     const [useCompactMobileTimestamp, setUseCompactMobileTimestamp] = useState(
         () => typeof window !== 'undefined' ? window.innerWidth <= 520 : false
     )
+    const [useMobileMessageLayout, setUseMobileMessageLayout] = useState(
+        () => typeof window !== 'undefined' ? window.innerWidth <= 700 : false
+    )
     const chatAreaRef = useRef<HTMLDivElement | null>(null)
     const messagesScrollRef = useRef<HTMLDivElement>(null)
     const virtualListSpacerRef = useRef<HTMLDivElement | null>(null)
@@ -867,7 +895,13 @@ export default function ChatArea({
         getItemKey: (index) => messages[index]?.id ?? (index === messages.length ? 'typing-indicator' : index),
         // Keep newly-added rows close to their final measured height so bottom-locked
         // chats do not visibly settle after the virtualizer's first measurement.
-        estimateSize: (index) => estimateMessageRowHeight(messages, index, firstUnreadIndex, !!typingIndicatorLabel),
+        estimateSize: (index) => estimateMessageRowHeight(
+            messages,
+            index,
+            firstUnreadIndex,
+            !!typingIndicatorLabel,
+            useMobileMessageLayout,
+        ),
         measureElement: (el) => el?.getBoundingClientRect().height ?? 64,
         overscan: 8,
     })
@@ -1693,7 +1727,10 @@ export default function ChatArea({
 
     useEffect(() => {
         if (typeof window === 'undefined') return
-        const onResize = () => setUseCompactMobileTimestamp(window.innerWidth <= 520)
+        const onResize = () => {
+            setUseCompactMobileTimestamp(window.innerWidth <= 520)
+            setUseMobileMessageLayout(window.innerWidth <= 700)
+        }
         onResize()
         window.addEventListener('resize', onResize)
         return () => window.removeEventListener('resize', onResize)

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4533,6 +4533,7 @@ body {
   align-items: flex-start;
   gap: 16px;
   padding: 4px 16px;
+  min-height: 52px;
   border-radius: var(--border-radius-sm);
   position: relative;
   min-width: 0;
@@ -4587,6 +4588,7 @@ body {
 .message.message-compact {
   padding-top: 1px;
   padding-bottom: 1px;
+  min-height: 22px;
 }
 
 .message.message-compact .message-avatar {
@@ -13946,6 +13948,7 @@ textarea {
   .message {
     gap: 12px;
     padding: 2px 12px;
+    min-height: 43px;
   }
 
   .message-avatar {


### PR DESCRIPTION
## Summary
- align virtualized chat row estimates with desktop and mobile CSS dimensions
- stabilize first author and compact continuation message heights
- add unit and Playwright regression coverage for layout shifts

## Validation
- npm run lint
- npm run test:run (194 tests)
- npm run build
- desktop Chromium chat smoke test
- mobile Chromium chat smoke test