### PR TITLE
feat: add privacy-safe operational observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,12 @@ ADMIN_USERNAME=admin
 # ATTACHMENTS_CLAMAV_ENABLED=1
 # ATTACHMENTS_CLAMAV_FAIL_CLOSED=1
 
+## Privacy-safe operational observability. Disabled by default for self-hosting.
+## When enabled, the backend logs only allowlisted event codes and coarse client/status fields.
+# OBSERVABILITY_ENABLED=true
+# OBSERVABILITY_RATE_LIMIT_MAX=120
+# OBSERVABILITY_RATE_LIMIT_WINDOW_SECS=60
+
 ## External TURN server. Usually not needed for local/dev.
 # TURN_URLS=turn:turn.example.com:3478?transport=udp
 # TURN_SHARED_SECRET=CHANGE_ME_TO_A_STRONG_TURN_SECRET

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Choose Voxpery when you want:
 Voxpery is open source, so the hosted app and self-hosted version are built from public, reviewable code. You can inspect how authentication, attachments, voice, moderation, and data export/delete work instead of relying on a closed client.
 
 - **Google sign-in does not give Voxpery your Google password.** Google OAuth only confirms your identity and returns the account information needed to sign you in.
-- **No ads or analytics by default.** Voxpery is not built around tracking users or selling attention.
+- **No ads or behavioral analytics.** Optional operational counters contain only allowlisted event codes, are disabled by default for self-hosting, and never include message content or user identifiers.
 - **Self-hostable by design.** Communities that want full control can run the same stack on their own server.
 - **Data controls are built in.** Users can export their account data and permanently delete their account.
 - **Attachments are scoped.** Uploaded files use signed access and server/DM viewer authorization instead of public permanent links.
@@ -51,7 +51,7 @@ Voxpery is open source, so the hosted app and self-hosted version are built from
 |---------|---------|---------|-------|-----------|
 | **Open-source model** | Yes: AGPL-3.0 | No: proprietary | No: proprietary | Partial: open-core |
 | **Self-hostable** | Yes: full stack | No | No | Yes |
-| **Data control / privacy** | Yes: self-host + no telemetry by default | SaaS data collection policies | SaaS data collection policies | Strong self-host control |
+| **Data control / privacy** | Yes: self-host + operational observability off by default | SaaS data collection policies | SaaS data collection policies | Strong self-host control |
 | **Voice calling** | LiveKit SFU | Native voice | Huddles (free plan limits) | Calls plugin |
 | **Desktop app stack** | Tauri | Proprietary desktop client | Electron desktop client | Electron desktop client |
 | **Pricing model** | OSS / self-host free | Freemium (Nitro) | Freemium + paid tiers | OSS + paid enterprise tiers |
@@ -59,7 +59,7 @@ Voxpery is open source, so the hosted app and self-hosted version are built from
 
 Voxpery is not trying to beat mature commercial platforms on every enterprise feature today. Discord and Slack still have bigger ecosystems, polished mobile apps, app directories, and years of edge-case hardening. Mattermost is more mature for enterprise compliance and large deployments.
 
-Voxpery is strongest when you want a smaller, inspectable, self-hostable community platform with hosted access available now, modern voice through LiveKit, no analytics by default, and a roadmap focused on open community ownership.
+Voxpery is strongest when you want a smaller, inspectable, self-hostable community platform with hosted access available now, modern voice through LiveKit, no behavioral analytics, and a roadmap focused on open community ownership.
 
 ---
 
@@ -74,7 +74,7 @@ Voxpery is strongest when you want a smaller, inspectable, self-hostable communi
 
 ### Security & Privacy
 - **Secure auth defaults** - JWT + Argon2id, httpOnly cookies, Google OAuth support
-- **No tracking** - Zero analytics, zero telemetry, zero ads
+- **No behavioral tracking** - No ads or analytics; optional content-free operational counters are documented and off by default for self-hosting
 - **Self-hosted** - Full control of your data, run on your server
 - **Scoped attachment access** - Signed URLs + server/DM viewer authorization
 - **Open source** - Audit-ready code, AGPL license
@@ -105,7 +105,7 @@ Voxpery is strongest when you want a smaller, inspectable, self-hostable communi
 
 **Use the hosted app:** [voxpery.com](https://voxpery.com)
 - Sign up -> Create/join servers -> Start voice
-- No credit card, no data collection
+- No credit card, no ads or behavioral tracking
 - Same open-source code as self-hosted version
 
 ### For Self-Hosters: Deploy Your Own

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -24,6 +24,10 @@ pub struct Config {
     pub trusted_proxies: TrustedProxySet,
     pub message_rate_limit_max: usize,
     pub message_rate_limit_window_secs: u64,
+    /// Emit allowlisted, privacy-safe operational events. Disabled by default.
+    pub observability_enabled: bool,
+    pub observability_rate_limit_max: usize,
+    pub observability_rate_limit_window_secs: u64,
     /// Optional admin account for default setup. If all three are set, a user is created at startup (if none with that email exists) and becomes owner of the default Voxpery server.
     pub admin_email: Option<String>,
     pub admin_username: Option<String>,
@@ -183,6 +187,19 @@ impl Config {
                 .unwrap_or_else(|_| "10".into())
                 .parse()
                 .expect("MESSAGE_RATE_LIMIT_WINDOW_SECS must be a number"),
+            observability_enabled: std::env::var("OBSERVABILITY_ENABLED")
+                .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
+            observability_rate_limit_max: std::env::var("OBSERVABILITY_RATE_LIMIT_MAX")
+                .unwrap_or_else(|_| "120".into())
+                .parse()
+                .expect("OBSERVABILITY_RATE_LIMIT_MAX must be a number"),
+            observability_rate_limit_window_secs: std::env::var(
+                "OBSERVABILITY_RATE_LIMIT_WINDOW_SECS",
+            )
+            .unwrap_or_else(|_| "60".into())
+            .parse()
+            .expect("OBSERVABILITY_RATE_LIMIT_WINDOW_SECS must be a number"),
             admin_email: std::env::var("ADMIN_EMAIL").ok().filter(|s| !s.is_empty()),
             admin_username: std::env::var("ADMIN_USERNAME")
                 .ok()

--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 
 use axum::{
     body::{to_bytes, Body},
-    extract::{DefaultBodyLimit, State},
+    extract::{DefaultBodyLimit, Request, State},
     http::{header, Method, StatusCode},
-    middleware::{from_fn_with_state, map_response},
+    middleware::{from_fn_with_state, map_response, Next},
     response::{IntoResponse, Response},
     routing::get,
     Json, Router,
@@ -53,6 +53,9 @@ pub struct AppState {
     pub trusted_proxies: services::client_ip::TrustedProxySet,
     pub message_rate_limit_max: usize,
     pub message_rate_limit_window_secs: u64,
+    pub observability_enabled: bool,
+    pub observability_rate_limit_max: usize,
+    pub observability_rate_limit_window_secs: u64,
     pub cookie_secure: bool,
     pub cookie_name: String,
     pub cors_origins: Vec<String>,
@@ -213,6 +216,21 @@ pub fn validate_security_config(
     Ok(())
 }
 
+async fn observe_backend_server_errors(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let response = next.run(request).await;
+    if services::observability::should_observe_backend_response(
+        state.observability_enabled,
+        response.status(),
+    ) {
+        services::observability::log_backend_5xx(response.status());
+    }
+    response
+}
+
 /// Validates optional integrations that can be disabled for self-hosted deployments.
 pub fn validate_optional_integration_config(config: &config::Config) -> Result<(), String> {
     if config.google_client_id.is_some() != config.google_client_secret.is_some() {
@@ -297,6 +315,10 @@ pub fn build_app(state: Arc<AppState>, cors_origins: Vec<String>) -> Router {
         .layer(from_fn_with_state(
             cookie_csrf,
             middleware::csrf::protect_cookie_authenticated_writes,
+        ))
+        .layer(from_fn_with_state(
+            state.clone(),
+            observe_backend_server_errors,
         ))
         .layer(TraceLayer::new_for_http())
         .layer(cors)
@@ -397,6 +419,9 @@ mod tests {
             trusted_proxies: crate::services::client_ip::TrustedProxySet::default(),
             message_rate_limit_max: 30,
             message_rate_limit_window_secs: 10,
+            observability_enabled: false,
+            observability_rate_limit_max: 120,
+            observability_rate_limit_window_secs: 60,
             admin_email: None,
             admin_username: None,
             admin_password: None,

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -27,9 +27,7 @@ async fn main() {
     let config = config::Config::from_env();
 
     if config.is_production && config.trusted_proxies.is_empty() {
-        tracing::warn!(
-            "TRUSTED_PROXY_CIDRS is empty; forwarded client-IP headers are disabled"
-        );
+        tracing::warn!("TRUSTED_PROXY_CIDRS is empty; forwarded client-IP headers are disabled");
     }
 
     if let Err(msg) = validate_security_config(
@@ -110,6 +108,9 @@ async fn main() {
         trusted_proxies: config.trusted_proxies.clone(),
         message_rate_limit_max: config.message_rate_limit_max,
         message_rate_limit_window_secs: config.message_rate_limit_window_secs,
+        observability_enabled: config.observability_enabled,
+        observability_rate_limit_max: config.observability_rate_limit_max,
+        observability_rate_limit_window_secs: config.observability_rate_limit_window_secs,
         cookie_secure: config.cookie_secure,
         cookie_name: config.cookie_name.clone(),
         cors_origins: config.cors_origins.clone(),

--- a/apps/server/src/routes/system.rs
+++ b/apps/server/src/routes/system.rs
@@ -1,9 +1,23 @@
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use axum::{extract::State, routing::get, Json, Router};
-use serde::Serialize;
+use axum::{
+    extract::{ConnectInfo, State},
+    http::HeaderMap,
+    routing::{get, post},
+    Extension, Json, Router,
+};
+use serde::{Deserialize, Serialize};
 
-use crate::AppState;
+use crate::{
+    services::{
+        client_ip::resolve_client_ip,
+        observability::{
+            log_client_event, rate_limit_fingerprint, ClientObservabilityEvent, ObservabilityClient,
+        },
+        rate_limit::enforce_rate_limit,
+    },
+    AppState,
+};
 
 #[derive(Debug, Serialize)]
 pub struct SystemFeaturesResponse {
@@ -12,10 +26,13 @@ pub struct SystemFeaturesResponse {
     pub email_verification_enabled: bool,
     pub email_verification_required: bool,
     pub password_reset_enabled: bool,
+    pub observability_enabled: bool,
 }
 
 pub fn router(_state: Arc<AppState>) -> Router<Arc<AppState>> {
-    Router::new().route("/features", get(get_features))
+    Router::new()
+        .route("/features", get(get_features))
+        .route("/observability/events", post(record_observability_event))
 }
 
 async fn get_features(State(state): State<Arc<AppState>>) -> Json<SystemFeaturesResponse> {
@@ -25,5 +42,46 @@ async fn get_features(State(state): State<Arc<AppState>>) -> Json<SystemFeatures
         email_verification_enabled: state.email_verification_enabled,
         email_verification_required: state.email_verification_required,
         password_reset_enabled: state.password_reset_enabled,
+        observability_enabled: state.observability_enabled,
     })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ObservabilityEventRequest {
+    event: ClientObservabilityEvent,
+    client: ObservabilityClient,
+}
+
+async fn record_observability_event(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    connect_info: Option<Extension<ConnectInfo<SocketAddr>>>,
+    Json(body): Json<ObservabilityEventRequest>,
+) -> axum::http::StatusCode {
+    if !state.observability_enabled {
+        return axum::http::StatusCode::NO_CONTENT;
+    }
+
+    let peer_ip = connect_info
+        .as_ref()
+        .map(|Extension(ConnectInfo(addr))| addr.ip());
+    let client_ip = resolve_client_ip(&headers, peer_ip, &state.trusted_proxies)
+        .unwrap_or_else(|| "unknown".into());
+    let fingerprint = rate_limit_fingerprint(&state.jwt_secret, &client_ip);
+    let rate_result = enforce_rate_limit(
+        &state.redis,
+        format!("observability:{fingerprint}"),
+        state.observability_rate_limit_max,
+        Duration::from_secs(state.observability_rate_limit_window_secs),
+        "Too many observability events",
+    )
+    .await;
+
+    if rate_result.is_ok() {
+        log_client_event(body.event, body.client);
+    }
+
+    // Observability must never alter product behavior or reveal rate-limit state.
+    axum::http::StatusCode::NO_CONTENT
 }

--- a/apps/server/src/services/mod.rs
+++ b/apps/server/src/services/mod.rs
@@ -1,13 +1,14 @@
 pub mod attachments;
-pub mod avatar_images;
 pub mod audit;
-pub mod automod;
 pub mod auth;
+pub mod automod;
+pub mod avatar_images;
 pub mod client_ip;
 pub mod email;
 pub mod idempotency;
 pub mod jwt_blacklist;
 pub mod moderation;
+pub mod observability;
 pub mod permissions;
 pub mod rate_limit;
 pub mod voice_revoke;

--- a/apps/server/src/services/observability.rs
+++ b/apps/server/src/services/observability.rs
@@ -1,0 +1,135 @@
+use axum::http::StatusCode;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientObservabilityEvent {
+    FrontendSessionStarted,
+    FrontendCrash,
+    DesktopOauthReturnReceived,
+    DesktopOauthReturnSucceeded,
+    DesktopOauthReturnFailed,
+    DesktopOauthSetupFailed,
+    WebsocketReconnectStarted,
+    WebsocketReconnectSucceeded,
+    WebsocketReconnectExhausted,
+    VoiceJoinStarted,
+    VoiceJoinSucceeded,
+    VoiceJoinFailed,
+    LivekitReconnectStarted,
+    LivekitReconnectSucceeded,
+    LivekitDisconnected,
+    MediaMicrophoneStarted,
+    MediaMicrophoneFailed,
+    MediaCameraStarted,
+    MediaCameraFailed,
+    MediaScreenShareStarted,
+    MediaScreenShareFailed,
+}
+
+impl ClientObservabilityEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FrontendSessionStarted => "frontend_session_started",
+            Self::FrontendCrash => "frontend_crash",
+            Self::DesktopOauthReturnReceived => "desktop_oauth_return_received",
+            Self::DesktopOauthReturnSucceeded => "desktop_oauth_return_succeeded",
+            Self::DesktopOauthReturnFailed => "desktop_oauth_return_failed",
+            Self::DesktopOauthSetupFailed => "desktop_oauth_setup_failed",
+            Self::WebsocketReconnectStarted => "websocket_reconnect_started",
+            Self::WebsocketReconnectSucceeded => "websocket_reconnect_succeeded",
+            Self::WebsocketReconnectExhausted => "websocket_reconnect_exhausted",
+            Self::VoiceJoinStarted => "voice_join_started",
+            Self::VoiceJoinSucceeded => "voice_join_succeeded",
+            Self::VoiceJoinFailed => "voice_join_failed",
+            Self::LivekitReconnectStarted => "livekit_reconnect_started",
+            Self::LivekitReconnectSucceeded => "livekit_reconnect_succeeded",
+            Self::LivekitDisconnected => "livekit_disconnected",
+            Self::MediaMicrophoneStarted => "media_microphone_started",
+            Self::MediaMicrophoneFailed => "media_microphone_failed",
+            Self::MediaCameraStarted => "media_camera_started",
+            Self::MediaCameraFailed => "media_camera_failed",
+            Self::MediaScreenShareStarted => "media_screen_share_started",
+            Self::MediaScreenShareFailed => "media_screen_share_failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservabilityClient {
+    Web,
+    Desktop,
+}
+
+impl ObservabilityClient {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Web => "web",
+            Self::Desktop => "desktop",
+        }
+    }
+}
+
+pub fn rate_limit_fingerprint(secret: &str, client_ip: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    hasher.update(b":observability:");
+    hasher.update(client_ip.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+pub fn log_client_event(event: ClientObservabilityEvent, client: ObservabilityClient) {
+    tracing::info!(
+        target: "voxpery_observability",
+        event_code = event.as_str(),
+        client = client.as_str(),
+        "privacy_safe_event"
+    );
+}
+
+pub fn should_observe_backend_response(enabled: bool, status: StatusCode) -> bool {
+    enabled && status.is_server_error()
+}
+
+pub fn log_backend_5xx(status: StatusCode) {
+    tracing::error!(
+        target: "voxpery_observability",
+        event_code = "backend_http_5xx",
+        status = status.as_u16(),
+        "privacy_safe_event"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limit_fingerprint_does_not_expose_the_ip() {
+        let fingerprint = rate_limit_fingerprint("secret", "203.0.113.10");
+        assert_eq!(fingerprint.len(), 64);
+        assert!(!fingerprint.contains("203.0.113.10"));
+        assert_ne!(
+            fingerprint,
+            rate_limit_fingerprint("other-secret", "203.0.113.10")
+        );
+    }
+
+    #[test]
+    fn only_enabled_server_errors_are_observed() {
+        assert!(should_observe_backend_response(
+            true,
+            StatusCode::INTERNAL_SERVER_ERROR
+        ));
+        assert!(!should_observe_backend_response(
+            true,
+            StatusCode::BAD_REQUEST
+        ));
+        assert!(!should_observe_backend_response(
+            false,
+            StatusCode::INTERNAL_SERVER_ERROR
+        ));
+    }
+}

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -65,6 +65,19 @@ async fn setup_app_with_auth_features(
     email_verification_enabled: bool,
     password_reset_enabled: bool,
 ) -> (axum::Router, Arc<AppState>) {
+    setup_app_with_features(
+        email_verification_enabled,
+        password_reset_enabled,
+        false,
+    )
+    .await
+}
+
+async fn setup_app_with_features(
+    email_verification_enabled: bool,
+    password_reset_enabled: bool,
+    observability_enabled: bool,
+) -> (axum::Router, Arc<AppState>) {
     let database_url = test_db_url().expect("DATABASE_URL must be set for integration tests");
     let db = PgPoolOptions::new()
         .max_connections(5)
@@ -108,6 +121,9 @@ async fn setup_app_with_auth_features(
         trusted_proxies: voxpery_server::services::client_ip::TrustedProxySet::default(),
         message_rate_limit_max: 100,
         message_rate_limit_window_secs: 10,
+        observability_enabled,
+        observability_rate_limit_max: 100,
+        observability_rate_limit_window_secs: 60,
         cookie_secure: false,
         cookie_name: "voxpery_token".to_string(),
         cors_origins: vec!["http://localhost:5173".to_string()],
@@ -264,6 +280,52 @@ async fn health_returns_200_when_db_connected() {
 }
 
 #[tokio::test]
+async fn privacy_safe_observability_is_feature_gated_and_accepts_only_the_fixed_schema() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, _) = setup_app_with_features(false, false, true).await;
+
+    let features = Request::builder()
+        .uri("/api/system/features")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, features).await;
+    assert_eq!(status, StatusCode::OK);
+    let features: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(features["observability_enabled"], true);
+
+    let valid = Request::builder()
+        .method("POST")
+        .uri("/api/system/observability/events")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "event": "voice_join_succeeded", "client": "web" }).to_string(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, valid).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(body.is_empty());
+
+    let arbitrary = Request::builder()
+        .method("POST")
+        .uri("/api/system/observability/events")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "event": "voice_join_succeeded",
+                "client": "web",
+                "message": "must not be logged"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let (status, _) = oneshot(&mut app, arbitrary).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
 async fn api_security_headers_cover_normal_error_and_preflight_responses() {
     let Some(_) = test_db_url() else {
         eprintln!("SKIP: DATABASE_URL not set");
@@ -272,7 +334,10 @@ async fn api_security_headers_cover_normal_error_and_preflight_responses() {
     let (app, _) = setup_app().await;
 
     let requests = [
-        Request::builder().uri("/health").body(Body::empty()).unwrap(),
+        Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap(),
         Request::builder()
             .uri("/missing-route")
             .body(Body::empty())
@@ -614,7 +679,10 @@ async fn default_voxpery_server_has_moderator_role_after_register() {
     .await
     .expect("default Voxpery server should have a seeded onboarding guide");
 
-    assert!(guide.0, "default Voxpery onboarding guide should be enabled");
+    assert!(
+        guide.0,
+        "default Voxpery onboarding guide should be enabled"
+    );
     assert_eq!(guide.1, "Welcome to the Voxpery Community");
     assert!(
         guide
@@ -786,8 +854,13 @@ async fn server_onboarding_guide_update_and_member_read_permissions() {
     let owner_uid = Uuid::new_v4();
     let owner_email = format!("onboarding-owner-{owner_uid}@example.com");
     let owner_username = format!("onboarding_owner_{}", owner_uid.as_u128() % 1_000_000);
-    let (owner_token, _) =
-        register_user(&mut app, &owner_email, &owner_username, test_credential("default")).await;
+    let (owner_token, _) = register_user(
+        &mut app,
+        &owner_email,
+        &owner_username,
+        test_credential("default"),
+    )
+    .await;
     let owner_auth = format!("Bearer {owner_token}");
 
     let req = Request::builder()
@@ -848,8 +921,13 @@ async fn server_onboarding_guide_update_and_member_read_permissions() {
     let member_uid = Uuid::new_v4();
     let member_email = format!("onboarding-member-{member_uid}@example.com");
     let member_username = format!("onboarding_member_{}", member_uid.as_u128() % 1_000_000);
-    let (member_token, _) =
-        register_user(&mut app, &member_email, &member_username, test_credential("default")).await;
+    let (member_token, _) = register_user(
+        &mut app,
+        &member_email,
+        &member_username,
+        test_credential("default"),
+    )
+    .await;
     let member_auth = format!("Bearer {member_token}");
 
     let req = Request::builder()
@@ -895,8 +973,13 @@ async fn server_onboarding_guide_update_and_member_read_permissions() {
     let outsider_email = format!("onboarding-outsider-{outsider_uid}@example.com");
     let outsider_username = format!("onboarding_outsider_{}", outsider_uid.as_u128() % 1_000_000);
     let outsider_password = format!("onboarding-credential-{}", Uuid::new_v4().as_simple());
-    let (outsider_token, _) =
-        register_user(&mut app, &outsider_email, &outsider_username, &outsider_password).await;
+    let (outsider_token, _) = register_user(
+        &mut app,
+        &outsider_email,
+        &outsider_username,
+        &outsider_password,
+    )
+    .await;
     let outsider_auth = format!("Bearer {outsider_token}");
     let req = Request::builder()
         .uri(format!("/api/servers/{server_id}/onboarding"))
@@ -918,8 +1001,13 @@ async fn member_timeout_blocks_and_clear_restores_messages() {
     let owner_uid = Uuid::new_v4();
     let owner_email = format!("timeout-owner-{owner_uid}@example.com");
     let owner_username = format!("timeout_owner_{}", owner_uid.as_u128() % 1_000_000);
-    let (owner_token, _) =
-        register_user(&mut app, &owner_email, &owner_username, test_credential("default")).await;
+    let (owner_token, _) = register_user(
+        &mut app,
+        &owner_email,
+        &owner_username,
+        test_credential("default"),
+    )
+    .await;
     let owner_auth = format!("Bearer {owner_token}");
 
     let req = Request::builder()
@@ -945,8 +1033,13 @@ async fn member_timeout_blocks_and_clear_restores_messages() {
     let member_uid = Uuid::new_v4();
     let member_email = format!("timeout-member-{member_uid}@example.com");
     let member_username = format!("timeout_member_{}", member_uid.as_u128() % 1_000_000);
-    let (member_token, member_id) =
-        register_user(&mut app, &member_email, &member_username, test_credential("default")).await;
+    let (member_token, member_id) = register_user(
+        &mut app,
+        &member_email,
+        &member_username,
+        test_credential("default"),
+    )
+    .await;
     let member_auth = format!("Bearer {member_token}");
 
     let req = Request::builder()
@@ -4143,7 +4236,10 @@ async fn concurrent_duplicate_reports_create_one_open_report() {
     .fetch_one(&state.db)
     .await
     .unwrap();
-    assert_eq!(open_report_count, 2, "one user and one message report should remain");
+    assert_eq!(
+        open_report_count, 2,
+        "one user and one message report should remain"
+    );
 
     let duplicate_groups: i64 = sqlx::query_scalar(
         r#"SELECT COUNT(*)
@@ -4197,21 +4293,17 @@ async fn dm_message_search_rate_limit_matches_server_search() {
         .execute(&state.db)
         .await
         .unwrap();
-    sqlx::query(
-        "INSERT INTO dm_channel_members (channel_id, user_id) VALUES ($1, $2), ($1, $3)",
-    )
-    .bind(channel_id)
-    .bind(user_id)
-    .bind(peer_id)
-    .execute(&state.db)
-    .await
-    .unwrap();
+    sqlx::query("INSERT INTO dm_channel_members (channel_id, user_id) VALUES ($1, $2), ($1, $3)")
+        .bind(channel_id)
+        .bind(user_id)
+        .bind(peer_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
 
     let search_request = || {
         Request::builder()
-            .uri(format!(
-                "/api/dm/messages/{channel_id}/search?q=rate-limit"
-            ))
+            .uri(format!("/api/dm/messages/{channel_id}/search?q=rate-limit"))
             .header("Authorization", &auth_header)
             .body(Body::empty())
             .unwrap()
@@ -4488,15 +4580,13 @@ async fn message_and_dm_retries_create_one_persistent_message() {
         .execute(&state.db)
         .await
         .unwrap();
-    sqlx::query(
-        "INSERT INTO dm_channel_members (channel_id, user_id) VALUES ($1, $2), ($1, $3)",
-    )
-    .bind(dm_channel_id)
-    .bind(user_id)
-    .bind(peer_id)
-    .execute(&state.db)
-    .await
-    .unwrap();
+    sqlx::query("INSERT INTO dm_channel_members (channel_id, user_id) VALUES ($1, $2), ($1, $3)")
+        .bind(dm_channel_id)
+        .bind(user_id)
+        .bind(peer_id)
+        .execute(&state.db)
+        .await
+        .unwrap();
     let dm_request_id = format!("dm-{suffix}");
     let dm_request = || {
         Request::builder()
@@ -4674,18 +4764,16 @@ async fn concurrent_friend_requests_create_one_pending_pair() {
     .await;
     let sender_auth = format!("Bearer {sender_token}");
     let target_auth = format!("Bearer {target_token}");
-    let sender_username: String =
-        sqlx::query_scalar("SELECT username FROM users WHERE id = $1")
-            .bind(sender_id)
-            .fetch_one(&state.db)
-            .await
-            .unwrap();
-    let target_username: String =
-        sqlx::query_scalar("SELECT username FROM users WHERE id = $1")
-            .bind(target_id)
-            .fetch_one(&state.db)
-            .await
-            .unwrap();
+    let sender_username: String = sqlx::query_scalar("SELECT username FROM users WHERE id = $1")
+        .bind(sender_id)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+    let target_username: String = sqlx::query_scalar("SELECT username FROM users WHERE id = $1")
+        .bind(target_id)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
     let friend_request = |auth: &str, username: &str| {
         Request::builder()
             .method("POST")

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -322,7 +322,7 @@ async fn privacy_safe_observability_is_feature_gated_and_accepts_only_the_fixed_
         ))
         .unwrap();
     let (status, _) = oneshot(&mut app, arbitrary).await;
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/apps/web/e2e/auth-core-regressions.spec.ts
+++ b/apps/web/e2e/auth-core-regressions.spec.ts
@@ -3,6 +3,7 @@ import { createMockCoreState, installMockCoreApi } from './mock-core-api'
 
 const AUTH_FEATURES = {
   google_oauth_enabled: false,
+  observability_enabled: false,
   email_delivery_enabled: true,
   email_verification_enabled: true,
   email_verification_required: false,

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -68,6 +68,7 @@ export interface MockCoreState {
 
 const DEFAULT_FEATURES: SystemFeatures = {
   google_oauth_enabled: false,
+  observability_enabled: false,
   email_delivery_enabled: false,
   email_verification_enabled: false,
   email_verification_required: false,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { ROUTES } from './routes'
 import { useSocketStore } from './stores/socket'
 import { useFeatureStore } from './stores/features'
 import { createDesktopOAuthDeepLinkHandler, registerDesktopOAuthDeepLinks } from './desktopOAuth'
+import { configureObservability, reportObservabilityEvent } from './observability'
 
 const AppShell = lazy(() => import('./pages/AppShell'))
 const UnifiedLayout = lazy(() => import('./pages/UnifiedLayout'))
@@ -72,6 +73,8 @@ function App() {
   const setUser = useAuthStore((s) => s.setUser)
   const logout = useAuthStore((s) => s.logout)
   const loadFeatures = useFeatureStore((s) => s.loadFeatures)
+  const features = useFeatureStore((s) => s.features)
+  const featureError = useFeatureStore((s) => s.error)
   const [restoring, setRestoring] = useState(true)
   const validatedSessionRef = useRef(false)
   const authFailureHandledRef = useRef(false)
@@ -81,6 +84,11 @@ function App() {
   useEffect(() => {
     void loadFeatures()
   }, [loadFeatures])
+
+  useEffect(() => {
+    if (features) configureObservability(features.observability_enabled)
+    else if (featureError) configureObservability(false)
+  }, [featureError, features])
 
   useEffect(() => {
     if (!isDesktopApp) return
@@ -129,6 +137,7 @@ function App() {
         persistToken: setSecureToken,
         navigate: (path) => navigate(path, { replace: true }),
         onError: (error) => console.error('Desktop OAuth return failed:', error),
+        onObservabilityEvent: reportObservabilityEvent,
       })
 
       const bootstrapDesktopSession = async () => {
@@ -147,14 +156,20 @@ function App() {
             ),
           },
           handleDeepLinkUrl,
-          (error) => console.error('Desktop deep-link setup failed:', error),
+          (error) => {
+            reportObservabilityEvent('desktop_oauth_setup_failed')
+            console.error('Desktop deep-link setup failed:', error)
+          },
         )
         if (disposed) cleanup()
         else disposeDeepLinks = cleanup
       }
 
       void bootstrapDesktopSession()
-        .catch((error) => console.error('Desktop session bootstrap failed:', error))
+        .catch((error) => {
+          reportObservabilityEvent('desktop_oauth_setup_failed')
+          console.error('Desktop session bootstrap failed:', error)
+        })
         .finally(() => {
           if (!disposed) setRestoring(false)
         })

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -86,6 +86,7 @@ export interface SystemFeatures {
     email_verification_enabled: boolean
     email_verification_required: boolean
     password_reset_enabled: boolean
+    observability_enabled: boolean
 }
 
 export interface ServerDetail extends Server {

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { reportFrontendCrash } from '../observability'
 
 interface Props {
   children: ReactNode
@@ -18,6 +19,7 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    reportFrontendCrash()
     console.error('ErrorBoundary caught:', error, errorInfo)
   }
 

--- a/apps/web/src/desktopOAuth.test.ts
+++ b/apps/web/src/desktopOAuth.test.ts
@@ -30,6 +30,7 @@ describe('desktop OAuth deep links', () => {
     const persistToken = vi.fn().mockResolvedValue(undefined)
     const clearCodeVerifier = vi.fn()
     const navigate = vi.fn()
+    const onObservabilityEvent = vi.fn()
     const handler = createDesktopOAuthDeepLinkHandler({
       getCodeVerifier: () => 'pkce-verifier',
       clearCodeVerifier,
@@ -37,6 +38,7 @@ describe('desktop OAuth deep links', () => {
       setAuth,
       persistToken,
       navigate,
+      onObservabilityEvent,
     })
     const url = `voxpery://auth/servers?code=${code}`
 
@@ -49,11 +51,16 @@ describe('desktop OAuth deep links', () => {
     expect(persistToken).toHaveBeenCalledWith('desktop-token')
     expect(clearCodeVerifier).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith('/servers')
+    expect(onObservabilityEvent.mock.calls).toEqual([
+      ['desktop_oauth_return_received'],
+      ['desktop_oauth_return_succeeded'],
+    ])
   })
 
   it('returns to login when the callback cannot be completed', async () => {
     const navigate = vi.fn()
     const onError = vi.fn()
+    const onObservabilityEvent = vi.fn()
     const handler = createDesktopOAuthDeepLinkHandler({
       getCodeVerifier: () => null,
       clearCodeVerifier: vi.fn(),
@@ -62,12 +69,17 @@ describe('desktop OAuth deep links', () => {
       persistToken: vi.fn(),
       navigate,
       onError,
+      onObservabilityEvent,
     })
 
     await handler(`voxpery://auth/servers?code=${code}`)
 
     expect(onError).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith('/login?error=oauth_failed&redirect=%2Fservers')
+    expect(onObservabilityEvent.mock.calls).toEqual([
+      ['desktop_oauth_return_received'],
+      ['desktop_oauth_return_failed'],
+    ])
   })
 
   it('registers runtime listeners and processes the cold-start URL from getCurrent', async () => {

--- a/apps/web/src/desktopOAuth.ts
+++ b/apps/web/src/desktopOAuth.ts
@@ -1,6 +1,7 @@
 import type { UserPublic } from './api'
 import { resolvePostAuthRoute } from './authRedirect'
 import { ROUTES } from './routes'
+import type { ObservabilityEventCode } from './observability'
 
 const DESKTOP_OAUTH_PROTOCOL = 'voxpery:'
 const DESKTOP_OAUTH_HOST = 'auth'
@@ -20,6 +21,7 @@ interface DesktopOAuthHandlerDependencies {
   persistToken: (token: string) => Promise<void>
   navigate: (path: string) => void
   onError?: (error: unknown) => void
+  onObservabilityEvent?: (event: ObservabilityEventCode) => void
 }
 
 export interface DesktopOAuthDeepLinkSources {
@@ -87,15 +89,19 @@ export function createDesktopOAuthDeepLinkHandler(deps: DesktopOAuthHandlerDepen
     if (!deepLink) return false
 
     if (deepLink.error || !deepLink.code) {
+      deps.onObservabilityEvent?.('desktop_oauth_return_received')
+      deps.onObservabilityEvent?.('desktop_oauth_return_failed')
       deps.navigate(oauthFailureRoute(deepLink.redirectTo))
       return true
     }
 
     if (handledCodes.has(deepLink.code)) return true
     handledCodes.add(deepLink.code)
+    deps.onObservabilityEvent?.('desktop_oauth_return_received')
 
     const codeVerifier = deps.getCodeVerifier()
     if (!codeVerifier) {
+      deps.onObservabilityEvent?.('desktop_oauth_return_failed')
       deps.onError?.(new Error('Desktop OAuth code verifier is missing'))
       deps.navigate(oauthFailureRoute(deepLink.redirectTo))
       return true
@@ -106,9 +112,11 @@ export function createDesktopOAuthDeepLinkHandler(deps: DesktopOAuthHandlerDepen
       deps.setAuth(auth.token, auth.user)
       await deps.persistToken(auth.token)
       deps.clearCodeVerifier()
+      deps.onObservabilityEvent?.('desktop_oauth_return_succeeded')
       deps.navigate(deepLink.redirectTo)
     } catch (error) {
       deps.clearCodeVerifier()
+      deps.onObservabilityEvent?.('desktop_oauth_return_failed')
       deps.onError?.(error)
       deps.navigate(oauthFailureRoute(deepLink.redirectTo))
     }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,8 +4,10 @@ import { BrowserRouter } from 'react-router'
 import './index.css'
 import App from './App'
 import { registerPwaServiceWorker } from './pwa'
+import { installGlobalObservabilityHandlers } from './observability'
 
 registerPwaServiceWorker()
+installGlobalObservabilityHandlers()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/web/src/observability.test.ts
+++ b/apps/web/src/observability.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  configureObservability,
+  isObservabilityEventCode,
+  reportFrontendCrash,
+  reportObservabilityEvent,
+  resetObservabilityForTests,
+} from './observability'
+
+describe('privacy-safe observability', () => {
+  beforeEach(() => {
+    resetObservabilityForTests()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('drops queued events when the server feature is disabled', async () => {
+    reportObservabilityEvent('voice_join_failed')
+    configureObservability(false)
+    await Promise.resolve()
+
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('flushes only allowlisted event codes without error details or identifiers', async () => {
+    reportObservabilityEvent('desktop_oauth_return_received')
+    configureObservability(true)
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+
+    const payloads = vi.mocked(fetch).mock.calls.map(([, options]) => JSON.parse(String(options?.body)))
+    expect(payloads).toEqual([
+      { event: 'frontend_session_started', client: 'web' },
+      { event: 'desktop_oauth_return_received', client: 'web' },
+    ])
+    expect(JSON.stringify(payloads)).not.toMatch(/token|email|username|message|stack|url|device/i)
+  })
+
+  it('counts at most one frontend crash per page session', async () => {
+    configureObservability(true)
+    reportFrontendCrash()
+    reportFrontendCrash()
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+
+    const crashCalls = vi.mocked(fetch).mock.calls.filter(([, options]) =>
+      String(options?.body).includes('frontend_crash')
+    )
+    expect(crashCalls).toHaveLength(1)
+  })
+
+  it('rejects arbitrary runtime event names', () => {
+    expect(isObservabilityEventCode('voice_join_succeeded')).toBe(true)
+    expect(isObservabilityEventCode('user_joined_secret-channel')).toBe(false)
+  })
+})

--- a/apps/web/src/observability.ts
+++ b/apps/web/src/observability.ts
@@ -1,0 +1,124 @@
+import { effectiveApiBase, shouldUseTauriHttpPluginForApiBase } from './api/client'
+import { isTauri } from './secureStorage'
+
+export const OBSERVABILITY_EVENT_CODES = [
+  'frontend_session_started',
+  'frontend_crash',
+  'desktop_oauth_return_received',
+  'desktop_oauth_return_succeeded',
+  'desktop_oauth_return_failed',
+  'desktop_oauth_setup_failed',
+  'websocket_reconnect_started',
+  'websocket_reconnect_succeeded',
+  'websocket_reconnect_exhausted',
+  'voice_join_started',
+  'voice_join_succeeded',
+  'voice_join_failed',
+  'livekit_reconnect_started',
+  'livekit_reconnect_succeeded',
+  'livekit_disconnected',
+  'media_microphone_started',
+  'media_microphone_failed',
+  'media_camera_started',
+  'media_camera_failed',
+  'media_screen_share_started',
+  'media_screen_share_failed',
+] as const
+
+export type ObservabilityEventCode = (typeof OBSERVABILITY_EVENT_CODES)[number]
+
+const MAX_PENDING_EVENTS = 24
+const OBSERVABILITY_PATH = '/api/system/observability/events'
+const eventCodeSet = new Set<string>(OBSERVABILITY_EVENT_CODES)
+
+type DeliveryMode = 'pending' | 'enabled' | 'disabled'
+
+let deliveryMode: DeliveryMode = 'pending'
+let pendingEvents: ObservabilityEventCode[] = []
+let sessionStarted = false
+let crashReported = false
+let globalHandlersInstalled = false
+
+export function isObservabilityEventCode(value: unknown): value is ObservabilityEventCode {
+  return typeof value === 'string' && eventCodeSet.has(value)
+}
+
+async function deliverEvent(event: ObservabilityEventCode): Promise<void> {
+  const apiBase = effectiveApiBase()
+  const url = `${apiBase}${OBSERVABILITY_PATH}`
+  const body = JSON.stringify({
+    event,
+    client: isTauri() ? 'desktop' : 'web',
+  })
+
+  if (shouldUseTauriHttpPluginForApiBase(isTauri(), apiBase)) {
+    const mod = await import('@tauri-apps/plugin-http')
+    await mod.fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      credentials: 'omit',
+      timeout: 10,
+    } as RequestInit & { timeout?: number })
+    return
+  }
+
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    credentials: 'omit',
+    keepalive: true,
+  })
+}
+
+function dispatchEvent(event: ObservabilityEventCode): void {
+  void deliverEvent(event).catch(() => {
+    // Observability is best-effort and must never affect product behavior.
+  })
+}
+
+export function reportObservabilityEvent(event: ObservabilityEventCode): void {
+  if (!isObservabilityEventCode(event) || deliveryMode === 'disabled') return
+  if (deliveryMode === 'enabled') {
+    dispatchEvent(event)
+    return
+  }
+  if (pendingEvents.length < MAX_PENDING_EVENTS) pendingEvents.push(event)
+}
+
+export function configureObservability(enabled: boolean): void {
+  deliveryMode = enabled ? 'enabled' : 'disabled'
+  if (!enabled) {
+    pendingEvents = []
+    return
+  }
+
+  if (!sessionStarted) {
+    sessionStarted = true
+    pendingEvents.unshift('frontend_session_started')
+  }
+  const queued = pendingEvents
+  pendingEvents = []
+  queued.forEach(dispatchEvent)
+}
+
+export function reportFrontendCrash(): void {
+  if (crashReported) return
+  crashReported = true
+  reportObservabilityEvent('frontend_crash')
+}
+
+export function installGlobalObservabilityHandlers(): void {
+  if (globalHandlersInstalled || typeof window === 'undefined') return
+  globalHandlersInstalled = true
+  window.addEventListener('error', reportFrontendCrash)
+  window.addEventListener('unhandledrejection', reportFrontendCrash)
+}
+
+export function resetObservabilityForTests(): void {
+  deliveryMode = 'pending'
+  pendingEvents = []
+  sessionStarted = false
+  crashReported = false
+}

--- a/apps/web/src/pages/AuthFeatureGating.test.tsx
+++ b/apps/web/src/pages/AuthFeatureGating.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../openExternalUrl', () => ({
 }))
 const disabledFeatures: SystemFeatures = {
   google_oauth_enabled: false,
+  observability_enabled: false,
   email_delivery_enabled: false,
   email_verification_enabled: false,
   email_verification_required: false,
@@ -24,6 +25,7 @@ const disabledFeatures: SystemFeatures = {
 const enabledGoogleFeatures: SystemFeatures = {
   ...disabledFeatures,
   google_oauth_enabled: true,
+  observability_enabled: false,
 }
 
 function renderWithFeatures(ui: ReactElement, features: SystemFeatures = disabledFeatures) {

--- a/apps/web/src/pages/AuthNotificationPermission.test.tsx
+++ b/apps/web/src/pages/AuthNotificationPermission.test.tsx
@@ -51,6 +51,7 @@ describe('auth notification permission behavior', () => {
     useFeatureStore.setState({
       features: {
         google_oauth_enabled: false,
+        observability_enabled: false,
         email_delivery_enabled: false,
         email_verification_enabled: false,
         email_verification_required: false,

--- a/apps/web/src/stores/socket.test.ts
+++ b/apps/web/src/stores/socket.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useSocketStore, websocketReconnectDelayMs } from './socket'
 import { act } from '@testing-library/react'
 
+const { reportObservabilityEvent } = vi.hoisted(() => ({
+  reportObservabilityEvent: vi.fn(),
+}))
+
+vi.mock('../observability', () => ({ reportObservabilityEvent }))
+
 // WebSocket ready state constants
 const WS_CONNECTING = 0
 const WS_OPEN = 1
@@ -71,6 +77,7 @@ describe('WebSocket Store', () => {
       wasConnectedBefore: false,
     })
     MockWebSocket.instances = []
+    reportObservabilityEvent.mockClear()
     vi.clearAllTimers()
     vi.useFakeTimers()
   })
@@ -223,6 +230,10 @@ describe('WebSocket Store', () => {
     await vi.advanceTimersByTimeAsync(1100)
 
     expect(reconnectListener).toHaveBeenCalled()
+    expect(reportObservabilityEvent.mock.calls).toEqual([
+      ['websocket_reconnect_started'],
+      ['websocket_reconnect_succeeded'],
+    ])
     unsubscribe()
   })
 

--- a/apps/web/src/stores/socket.ts
+++ b/apps/web/src/stores/socket.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { createWebSocket } from '../api'
+import { reportObservabilityEvent } from '../observability'
 
 type WsListener = (data: unknown) => void
 type ReconnectListener = () => void
@@ -71,6 +72,7 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             if (get().connectionId !== connectionId) return
 
             const wasConnected = get().wasConnectedBefore
+            const reconnectAttempt = get().reconnectAttempt
             set({
                 isConnected: true,
                 socket: ws,
@@ -81,6 +83,9 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 
             // Fire reconnect listeners if this was a re-establishment (not first connect)
             if (wasConnected) {
+                if (reconnectAttempt > 0) {
+                    reportObservabilityEvent('websocket_reconnect_succeeded')
+                }
                 get().reconnectListeners.forEach((cb) => {
                     try { cb() } catch (e) { console.error('[WS] reconnect listener error:', e) }
                 })
@@ -109,6 +114,9 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             const { shouldReconnect, reconnectAttempt } = get()
             if (shouldReconnect && reconnectAttempt < RECONNECT_MAX_ATTEMPTS) {
                 const nextAttempt = reconnectAttempt + 1
+                if (nextAttempt === 1) {
+                    reportObservabilityEvent('websocket_reconnect_started')
+                }
                 const delayMs = websocketReconnectDelayMs(nextAttempt)
                 const reconnectTimer = setTimeout(() => {
                     const { token: latestToken, shouldReconnect: latestShouldReconnect, connectionId: latestConnectionId } = get()
@@ -125,6 +133,7 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 
                 set({ reconnectAttempt: nextAttempt, reconnectTimer })
             } else if (shouldReconnect) {
+                reportObservabilityEvent('websocket_reconnect_exhausted')
                 set({ shouldReconnect: false, reconnectAttempt: 0, reconnectTimer: null })
             }
         }

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -4,6 +4,7 @@ import {
     getPreferredMicrophoneStream,
     getStoredVoiceInputDeviceId,
 } from '../../voiceDevices'
+import { reportObservabilityEvent } from '../../observability'
 
 export const SCREEN_SHARE_QUALITY_KEY = 'voxpery-settings-screen-share-quality'
 export const SCREEN_SHARE_CAPTURE_READY_EVENT = 'voxpery-screen-share-capture-ready'
@@ -158,8 +159,10 @@ export function useLocalMedia() {
             const stream = await getPreferredMicrophoneStream()
             cachedMicStreamRef.current = stream
             cachedMicDeviceIdRef.current = getStoredVoiceInputDeviceId()
+            reportObservabilityEvent('media_microphone_started')
             return stream
         } catch (err: unknown) {
+            reportObservabilityEvent('media_microphone_failed')
             const name = (err as { name?: string })?.name ?? ''
             if (name === 'NotAllowedError') throw new Error('Microphone permission denied', { cause: err })
             if (name === 'NotFoundError') throw new Error('No microphone device detected', { cause: err })
@@ -199,6 +202,7 @@ export function useLocalMedia() {
             try {
                 const stream = await navigator.mediaDevices.getUserMedia(constraints)
                 if (stream.getVideoTracks().length > 0) {
+                    reportObservabilityEvent('media_camera_started')
                     return stream
                 }
                 stream.getTracks().forEach((t) => t.stop())
@@ -215,6 +219,7 @@ export function useLocalMedia() {
         const name = (lastErr as { name?: string })?.name ?? ''
         const message = String((lastErr as { message?: unknown })?.message ?? '').toLowerCase()
 
+        reportObservabilityEvent('media_camera_failed')
         if (name === 'NotAllowedError' || name === 'SecurityError') throw new Error('Camera permission denied')
         if (name === 'NotFoundError' || name === 'DevicesNotFoundError') throw new Error('No camera device detected')
         if (name === 'NotReadableError' || message.includes('in use') || message.includes('busy')) {
@@ -235,13 +240,19 @@ export function useLocalMedia() {
             cachedScreenStreamRef.current = null
         }
         const videoConstraints = getScreenShareConstraints()
-        const stream = await navigator.mediaDevices.getDisplayMedia(
-            toScreenShareDisplayMediaOptions(videoConstraints),
-        )
-        await applyScreenShareTrackProfile(stream.getVideoTracks()[0])
-        cachedScreenStreamRef.current = stream
-        window.dispatchEvent(new Event(SCREEN_SHARE_CAPTURE_READY_EVENT))
-        return stream
+        try {
+            const stream = await navigator.mediaDevices.getDisplayMedia(
+                toScreenShareDisplayMediaOptions(videoConstraints),
+            )
+            await applyScreenShareTrackProfile(stream.getVideoTracks()[0])
+            cachedScreenStreamRef.current = stream
+            window.dispatchEvent(new Event(SCREEN_SHARE_CAPTURE_READY_EVENT))
+            reportObservabilityEvent('media_screen_share_started')
+            return stream
+        } catch (error) {
+            reportObservabilityEvent('media_screen_share_failed')
+            throw error
+        }
     }, [applyScreenShareTrackProfile, getScreenShareConstraints])
 
     /** Returns LiveKit-compatible videoEncoding and content hint based on quality mode. */

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -27,6 +27,7 @@ import {
 } from './voiceInputProfile'
 import { updateVoiceDiagnostics } from './voiceDiagnostics'
 import type { RemoteMediaKind } from './remoteMediaControls'
+import { reportObservabilityEvent } from '../observability'
 
 if (import.meta.env.PROD) {
   setLogLevel('silent')
@@ -564,6 +565,7 @@ export function useLiveKitVoice() {
     finalMediaDisconnectReconciledRef.current = false
     isJoiningRef.current = true
     setIsJoining(true)
+    reportObservabilityEvent('voice_join_started')
     let preflightStream: MediaStream | null = options?.preflightStream ?? null
     let micPublished = false
 
@@ -752,10 +754,12 @@ export function useLiveKitVoice() {
           playVoiceCue('join')
         })
         .on(RoomEvent.Reconnecting, () => {
+          reportObservabilityEvent('livekit_reconnect_started')
           console.warn('[useLiveKitVoice] LiveKit Room reconnecting...')
           updateRoomStats()
         })
         .on(RoomEvent.Reconnected, () => {
+          reportObservabilityEvent('livekit_reconnect_succeeded')
           updateRoomStats()
           refreshLocalStreams()
           // Re-subscribe to all existing remote participants' tracks
@@ -766,6 +770,9 @@ export function useLiveKitVoice() {
           }
         })
         .on(RoomEvent.Disconnected, (reason) => {
+          if (roomRef.current === room) {
+            reportObservabilityEvent('livekit_disconnected')
+          }
           if (!import.meta.env.PROD) {
             console.warn('[useLiveKitVoice] LiveKit Room disconnected, reason:', reason)
           }
@@ -838,7 +845,9 @@ export function useLiveKitVoice() {
       useAppStore.getState().setJoinedVoiceChannelId(channelId)
       send('SetVoiceControl', { muted: desiredMicMutedRef.current, deafened: false, screen_sharing: false, camera_on: false })
       playVoiceCue('join')
+      reportObservabilityEvent('voice_join_succeeded')
     } catch (e: unknown) {
+      reportObservabilityEvent('voice_join_failed')
       const msg = (e as Error)?.message ?? 'Failed to join voice'
       setLastError(msg)
       remoteMediaStartCueReadyRef.current = false

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,6 +74,16 @@ Notes:
 - `email/request-verification` can optionally change the current account email and issues a fresh verification token.
 - `email/confirm` accepts the verification token from the email link and can be redeemed without an existing session.
 
+## System Endpoints
+
+- `GET /api/system/features`
+  - Public integration capability flags used by web and desktop clients.
+- `POST /api/system/observability/events`
+  - Public, rate-limited, best-effort operational event endpoint.
+  - Accepts only `{ "event": "<allowlisted_code>", "client": "web|desktop" }` and rejects unknown fields.
+  - Returns an empty `204` when accepted, disabled, or unavailable so event delivery never affects product behavior.
+  - Disabled by default; see [OBSERVABILITY.md](OBSERVABILITY.md) for the event list and privacy contract.
+
 ## Server Endpoints
 
 - `GET /api/servers`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -65,6 +65,11 @@ Attachments note:
 Optional integrations note:
 
 - Google OAuth is disabled unless `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are both set.
+- Privacy-safe operational observability is disabled by default. Set `OBSERVABILITY_ENABLED=true`
+  only when the deployment needs aggregate reliability counters; see
+  [OBSERVABILITY.md](OBSERVABILITY.md) for the fixed event schema and retention policy.
+- `OBSERVABILITY_RATE_LIMIT_MAX` and `OBSERVABILITY_RATE_LIMIT_WINDOW_SECS` control the
+  unauthenticated event endpoint's per-network-fingerprint limit. Defaults are `120` and `60`.
 - Email delivery is disabled unless `SMTP_HOST`, `SMTP_USER`, and `SMTP_PASSWORD` are all set.
 - SMTP delivery uses STARTTLS on submission port 587 and forces an IPv4 outbound connection, matching hosts that do not provide Docker IPv6 routing.
 - Password reset and email verification depend on email delivery.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,77 @@
+# Privacy-Safe Observability
+
+Voxpery can emit aggregate operational counters for critical web, desktop, realtime,
+voice, and media flows. The feature is designed to answer whether a flow started,
+succeeded, failed, or recovered without collecting behavioral analytics.
+
+## Defaults and Configuration
+
+Operational observability is disabled by default for self-hosted deployments.
+
+```env
+OBSERVABILITY_ENABLED=true
+OBSERVABILITY_RATE_LIMIT_MAX=120
+OBSERVABILITY_RATE_LIMIT_WINDOW_SECS=60
+```
+
+The backend publishes the enabled state through `GET /api/system/features`. Clients
+send no events after the feature is reported as disabled. Event delivery is
+best-effort and never changes product behavior when the endpoint or network fails.
+
+## Data Contract
+
+`POST /api/system/observability/events` accepts exactly two fields:
+
+```json
+{
+  "event": "voice_join_succeeded",
+  "client": "web"
+}
+```
+
+`client` is either `web` or `desktop`. Unknown fields and event names are rejected.
+The allowlisted client event codes are:
+
+- `frontend_session_started`, `frontend_crash`
+- `desktop_oauth_return_received`, `desktop_oauth_return_succeeded`, `desktop_oauth_return_failed`, `desktop_oauth_setup_failed`
+- `websocket_reconnect_started`, `websocket_reconnect_succeeded`, `websocket_reconnect_exhausted`
+- `voice_join_started`, `voice_join_succeeded`, `voice_join_failed`
+- `livekit_reconnect_started`, `livekit_reconnect_succeeded`, `livekit_disconnected`
+- `media_microphone_started`, `media_microphone_failed`
+- `media_camera_started`, `media_camera_failed`
+- `media_screen_share_started`, `media_screen_share_failed`
+
+The backend also emits `backend_http_5xx` with only the numeric response status.
+
+Voxpery does not attach message content, attachment names, URLs, route paths, request
+bodies, stack traces, error messages, tokens, email addresses, usernames, user/server/
+channel identifiers, device labels, media details, or raw IP addresses to these events.
+Events are not written to the application database.
+
+## Abuse Protection and Logs
+
+The public event endpoint is rate-limited. The Redis key uses a SHA-256 fingerprint
+derived from the client address and the deployment JWT secret; the raw address is not
+stored in the key or event log. Redis expires the fingerprint after the configured
+rate-limit window plus a 60-second cleanup buffer.
+Rate-limit and Redis failures return an empty `204` response so observability cannot
+become a user-facing dependency.
+
+Structured events use the `voxpery_observability` tracing target and
+`privacy_safe_event` message. Hosted operators should retain these logs for no more
+than 14 days, exclude them from long-lived backups, and publish only aggregate counts.
+Changing that policy requires a matching documentation and privacy review.
+
+## Reliability Metrics
+
+Calculate ratios over the same deployment version and time window:
+
+- Error-free frontend sessions: `1 - frontend_crash / frontend_session_started`
+- Desktop OAuth completion: `desktop_oauth_return_succeeded / desktop_oauth_return_received`
+- Voice join success: `voice_join_succeeded / voice_join_started`
+- WebSocket recovery: `websocket_reconnect_succeeded / websocket_reconnect_started`
+- LiveKit recovery: `livekit_reconnect_succeeded / livekit_reconnect_started`
+- Media start success: `media_*_started / (media_*_started + media_*_failed)`
+
+Treat small samples cautiously. These counters identify a regression area; they do
+not identify a user or explain the content of an individual failure.

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -169,6 +169,18 @@ Focus on:
 - DB/Redis connectivity failures
 - LiveKit token/join errors
 
+When `OBSERVABILITY_ENABLED=true`, review privacy-safe reliability counters separately:
+
+```bash
+docker compose logs --since 24h server | grep 'voxpery_observability'
+```
+
+These lines contain only an allowlisted `event_code` plus `client` or numeric HTTP
+`status`. They must not contain paths, request bodies, account identifiers, message
+content, IP addresses, error text, or stack traces. Keep hosted observability logs for
+at most 14 days, exclude them from long-lived backups, and aggregate counts before
+sharing reports. Self-hosted deployments may leave the feature disabled.
+
 ## 6) Production Triage Commands
 
 Use these commands when the app is unreachable, the backend is restarting, or users report login, voice, or attachment failures.
@@ -240,3 +252,6 @@ Alert when any of these conditions persist for more than one check window:
 - Server logs contain `Failed to run migrations`, `VersionMismatch`, `ParseIntError`, or `must be a number`.
 - Server logs show repeated `WebSocket disconnected` surges or `Broadcast receiver lagged` lines.
 - Attachment logs show repeated read/write, malware scanner, or upload failures.
+- Privacy-safe counters show falling OAuth/voice/reconnect success ratios or a sustained
+  increase in `frontend_crash` or `backend_http_5xx`; metric formulas are documented in
+  [OBSERVABILITY.md](OBSERVABILITY.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This folder is the source of truth for architecture, development, deployment, ro
 - **[VOICE_SYSTEM.md](VOICE_SYSTEM.md)** - LiveKit integration and voice pipeline
 - **[VOICE_SUPPRESSION_SMOKE_TEST.md](VOICE_SUPPRESSION_SMOKE_TEST.md)** - release gate for RNNoise and voice suppression parity
 - **[PERFORMANCE_REVIEW.md](PERFORMANCE_REVIEW.md)** - Realtime workload risks and measurement plan
+- **[OBSERVABILITY.md](OBSERVABILITY.md)** - Privacy-safe operational event contract, metrics, and retention
 - **[DATABASE.md](DATABASE.md)** - Schema, migrations, and key queries
 - **[SECURITY.md](SECURITY.md)** - Security model and hardening checklist
 - **[../SECURITY.md](../SECURITY.md)** - Private vulnerability reporting policy


### PR DESCRIPTION
## Summary

- add opt-in, privacy-safe operational observability
- track aggregate OAuth, WebSocket, voice, LiveKit, media, frontend crash, and backend 5xx events
- enforce a fixed event allowlist with rate limiting
- keep observability disabled by default for self-hosted deployments
- document event contracts, retention policy, reliability metrics, and production operations

## Privacy

Events contain no message content, identifiers, tokens, email addresses, usernames, device labels, URLs, stack traces, error messages, or raw IP addresses. Events are written only to structured logs and are not persisted in the application database.

## Validation

- `cargo test --manifest-path apps/server/Cargo.toml --lib`
- `npm run lint`
- `npm run test:run`
- `npm run build`

The database-backed integration test is included and will run in CI; it was skipped locally because `DATABASE_URL` was unavailable.