### PR TITLE
fix: preserve natural voice in suppression profiles

### DIFF
--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -72,6 +72,7 @@ function getSpeechIsolationTarget(
     lowFloorThr: number,
     openFloorThr: number,
     aggressiveIsolation: boolean,
+    suppressionTuning: VoiceSuppressionTuning,
 ): number {
     const presenceDb = getBandAverageDb(frequencyData, sampleRate, fftSize, 220, 1500)
     const bodyDb = getBandAverageDb(frequencyData, sampleRate, fftSize, 180, 2400)
@@ -86,24 +87,49 @@ function getSpeechIsolationTarget(
     const boomyNoise = lowNoiseDb > bodyDb + 2.5
     const clickyNoise = highNoiseDb > presenceDb + 2.5
 
-    if (aggressiveIsolation && clickyNoise) return quietish ? 0.18 : 0.42
-    if (aggressiveIsolation && boomyNoise && quietish) return 0.24
-
-    if (!speechLike) {
-        if (rms <= lowFloorThr || quietish) return aggressiveIsolation ? 0.035 : 0.16
-        return clickyNoise || boomyNoise
-            ? (aggressiveIsolation ? 0.08 : 0.24)
-            : (aggressiveIsolation ? 0.14 : 0.3)
+    if (aggressiveIsolation && clickyNoise && !speechLike) {
+        return quietish
+            ? pickSuppressionValue(suppressionTuning, { off: 0.86, balanced: 0.5, high: 0.3 })
+            : pickSuppressionValue(suppressionTuning, { off: 0.92, balanced: 0.68, high: 0.42 })
+    }
+    if (aggressiveIsolation && boomyNoise && quietish) {
+        return pickSuppressionValue(suppressionTuning, { off: 0.86, balanced: 0.52, high: 0.34 })
     }
 
-    if (rms <= lowFloorThr) return aggressiveIsolation ? 0.14 : 0.28
+    if (!speechLike) {
+        if (rms <= lowFloorThr || quietish) {
+            return aggressiveIsolation
+                ? pickSuppressionValue(suppressionTuning, { off: 0.16, balanced: 0.16, high: 0.07 })
+                : 0.16
+        }
+        return clickyNoise || boomyNoise
+            ? (aggressiveIsolation
+                ? pickSuppressionValue(suppressionTuning, { off: 0.24, balanced: 0.24, high: 0.12 })
+                : 0.24)
+            : (aggressiveIsolation
+                ? pickSuppressionValue(suppressionTuning, { off: 0.3, balanced: 0.34, high: 0.22 })
+                : 0.3)
+    }
+
+    if (rms <= lowFloorThr) {
+        return aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 0.28, balanced: 0.48, high: 0.3 })
+            : 0.28
+    }
     if (rms < openFloorThr) {
         const ratio = (rms - lowFloorThr) / Math.max(1e-6, openFloorThr - lowFloorThr)
         const eased = ratio * ratio * (3 - 2 * ratio)
-        return aggressiveIsolation ? (0.28 + eased * 0.64) : (0.42 + eased * 0.5)
+        if (!aggressiveIsolation) return 0.42 + eased * 0.5
+        const closedGain = pickSuppressionValue(suppressionTuning, { off: 0.42, balanced: 0.64, high: 0.46 })
+        const openGain = pickSuppressionValue(suppressionTuning, { off: 0.92, balanced: 0.98, high: 0.96 })
+        return closedGain + eased * (openGain - closedGain)
     }
 
-    if (clickyNoise && quietish) return aggressiveIsolation ? 0.68 : 0.86
+    if (clickyNoise && quietish) {
+        return aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 0.86, balanced: 0.88, high: 0.8 })
+            : 0.86
+    }
     return 1
 }
 
@@ -112,6 +138,7 @@ function isLikelySpeechFrame(
     sampleRate: number,
     fftSize: number,
     aggressiveIsolation: boolean,
+    suppressionTuning: VoiceSuppressionTuning,
 ): boolean {
     const presenceDb = getBandAverageDb(frequencyData, sampleRate, fftSize, 220, 1400)
     const speechBodyDb = getBandAverageDb(frequencyData, sampleRate, fftSize, 180, 2200)
@@ -131,9 +158,16 @@ function isLikelySpeechFrame(
         highNoiseDb > presenceDb + 2.2
         && highNoiseDb > speechBodyDb + 2.8
         && upperSpeechDb < highNoiseDb + 1.2
-    return score >= (aggressiveIsolation ? -0.8 : -2.8)
+    const boomy =
+        lowNoiseDb > speechBodyDb + 2.5
+        && lowNoiseDb > upperSpeechDb + 3
+    const scoreThreshold = aggressiveIsolation
+        ? pickSuppressionValue(suppressionTuning, { off: -2.8, balanced: -2, high: -1.8 })
+        : -2.8
+    return score >= scoreThreshold
         && !clicky
-        && (!aggressiveIsolation || !noiseDominant)
+        && !boomy
+        && (!aggressiveIsolation || suppressionTuning !== 'high' || !noiseDominant)
 }
 
 export type VoiceCueKind =
@@ -154,6 +188,17 @@ export interface LiveSuppressionConfig {
     minFloorGain: number
     floorReleaseAlpha: number
     floorReleaseTime: number
+    speechSafeFloorGain: number
+    isolationAttenuationAlpha: number
+    isolationRecoveryAlpha: number
+    isolationAttenuationTime: number
+    isolationRecoveryTime: number
+}
+
+export interface SuppressionFrameEvaluation {
+    targetFloorGain: number
+    targetIsolationGain: number
+    likelySpeech: boolean
 }
 
 interface LiveSuppressionNodes {
@@ -183,31 +228,31 @@ export function buildSuppressionFilterConfig(
 ): LiveSuppressionFilterConfig {
     return {
         highPassHz: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 120, balanced: 135, high: 170 })
+            ? pickSuppressionValue(suppressionTuning, { off: 120, balanced: 110, high: 145 })
             : pickSuppressionValue(suppressionTuning, { off: 120, balanced: 125, high: 145 }),
         lowPassHz: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 7200, balanced: 6800, high: 3500 })
+            ? pickSuppressionValue(suppressionTuning, { off: 7200, balanced: 7600, high: 5600 })
             : pickSuppressionValue(suppressionTuning, { off: 7200, balanced: 6200, high: 4400 }),
         deClickGainDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: -2.4, high: -10 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: -1.2, high: -5 })
             : pickSuppressionValue(suppressionTuning, { off: 0, balanced: -1.8, high: -4.2 }),
         speechPresenceGainDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: 0.9, high: 1.9 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0, balanced: 0.5, high: 1 })
             : pickSuppressionValue(suppressionTuning, { off: 0, balanced: 1.1, high: 1.75 }),
         compressorThresholdDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: -30, balanced: -32, high: -44 })
+            ? pickSuppressionValue(suppressionTuning, { off: -30, balanced: -28, high: -37 })
             : pickSuppressionValue(suppressionTuning, { off: -30, balanced: -31, high: -36 }),
         compressorKneeDb: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 10, balanced: 9, high: 5 })
+            ? pickSuppressionValue(suppressionTuning, { off: 10, balanced: 12, high: 8 })
             : pickSuppressionValue(suppressionTuning, { off: 10, balanced: 10, high: 8 }),
         compressorRatio: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 3.5, balanced: 4, high: 8.2 })
+            ? pickSuppressionValue(suppressionTuning, { off: 3.5, balanced: 2.6, high: 4.8 })
             : pickSuppressionValue(suppressionTuning, { off: 3.5, balanced: 3.8, high: 5.4 }),
         compressorAttackSec: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.003, balanced: 0.0028, high: 0.001 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.003, balanced: 0.004, high: 0.002 })
             : pickSuppressionValue(suppressionTuning, { off: 0.003, balanced: 0.0024, high: 0.0015 }),
         compressorReleaseSec: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.085, balanced: 0.085, high: 0.038 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.085, balanced: 0.12, high: 0.075 })
             : pickSuppressionValue(suppressionTuning, { off: 0.085, balanced: 0.082, high: 0.065 }),
     }
 }
@@ -236,21 +281,77 @@ export function buildSuppressionConfig(
         aggressiveIsolation,
         suppressionTuning,
         lowFloorThr: dbToLinear(aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: -51, balanced: -51, high: -40 })
+            ? pickSuppressionValue(suppressionTuning, { off: -51, balanced: -54, high: -43 })
             : pickSuppressionValue(suppressionTuning, { off: -51, balanced: -50, high: -46 })),
         openFloorThr: dbToLinear(aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: -40, balanced: -39, high: -29 })
+            ? pickSuppressionValue(suppressionTuning, { off: -40, balanced: -42, high: -31 })
             : pickSuppressionValue(suppressionTuning, { off: -40, balanced: -38, high: -34 })),
         minFloorGain: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.12, balanced: 0.12, high: 0.012 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.12, balanced: 0.22, high: 0.035 })
             : pickSuppressionValue(suppressionTuning, { off: 0.12, balanced: 0.1, high: 0.06 }),
         floorReleaseAlpha: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.08, balanced: 0.07, high: 0.12 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.08, balanced: 0.045, high: 0.08 })
             : pickSuppressionValue(suppressionTuning, { off: 0.08, balanced: 0.075, high: 0.09 }),
         floorReleaseTime: aggressiveIsolation
-            ? pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.075, high: 0.046 })
+            ? pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.11, high: 0.07 })
             : pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.066, high: 0.055 }),
+        speechSafeFloorGain: aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 1, balanced: 0.9, high: 0.82 })
+            : pickSuppressionValue(suppressionTuning, { off: 1, balanced: 0.9, high: 0.84 }),
+        isolationAttenuationAlpha: aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 0.14, balanced: 0.1, high: 0.15 })
+            : 0.14,
+        isolationRecoveryAlpha: aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 0.22, balanced: 0.3, high: 0.28 })
+            : 0.22,
+        isolationAttenuationTime: aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 0.06, balanced: 0.09, high: 0.075 })
+            : 0.06,
+        isolationRecoveryTime: aggressiveIsolation
+            ? pickSuppressionValue(suppressionTuning, { off: 0.03, balanced: 0.022, high: 0.025 })
+            : 0.03,
     }
+}
+
+export function evaluateSuppressionFrame(
+    frequencyData: Float32Array,
+    sampleRate: number,
+    fftSize: number,
+    rms: number,
+    config: LiveSuppressionConfig,
+): SuppressionFrameEvaluation {
+    let targetFloorGain = 1
+    if (rms <= config.lowFloorThr) {
+        targetFloorGain = config.minFloorGain
+    } else if (rms < config.openFloorThr) {
+        const ratio = (rms - config.lowFloorThr) / Math.max(1e-6, config.openFloorThr - config.lowFloorThr)
+        const eased = ratio * ratio * (3 - 2 * ratio)
+        targetFloorGain = config.minFloorGain + eased * (1 - config.minFloorGain)
+    }
+
+    const targetIsolationGain = getSpeechIsolationTarget(
+        frequencyData,
+        sampleRate,
+        fftSize,
+        rms,
+        config.lowFloorThr,
+        config.openFloorThr,
+        config.aggressiveIsolation,
+        config.suppressionTuning,
+    )
+    const likelySpeech = isLikelySpeechFrame(
+        frequencyData,
+        sampleRate,
+        fftSize,
+        config.aggressiveIsolation,
+        config.suppressionTuning,
+    )
+
+    if (likelySpeech) {
+        targetFloorGain = Math.max(targetFloorGain, config.speechSafeFloorGain)
+    }
+
+    return { targetFloorGain, targetIsolationGain, likelySpeech }
 }
 
 function applySuppressionConfig(
@@ -576,34 +677,16 @@ export function useAudioEngine() {
                 let likelySpeech = false
 
                 if (refinementEnabled) {
-                    if (rms <= liveSuppressionConfig.lowFloorThr) {
-                        targetGain = liveSuppressionConfig.minFloorGain
-                    } else if (rms < liveSuppressionConfig.openFloorThr) {
-                        const ratio = (rms - liveSuppressionConfig.lowFloorThr) / (liveSuppressionConfig.openFloorThr - liveSuppressionConfig.lowFloorThr)
-                        const eased = ratio * ratio * (3 - 2 * ratio)
-                        targetGain = liveSuppressionConfig.minFloorGain + eased * (1 - liveSuppressionConfig.minFloorGain)
-                    }
-                    targetIsolationGain = getSpeechIsolationTarget(
+                    const evaluation = evaluateSuppressionFrame(
                         frequencyBuffer,
                         ctx.sampleRate,
                         refinementAnalyser.fftSize,
                         rms,
-                        liveSuppressionConfig.lowFloorThr,
-                        liveSuppressionConfig.openFloorThr,
-                        liveSuppressionConfig.aggressiveIsolation,
+                        liveSuppressionConfig,
                     )
-                    likelySpeech = isLikelySpeechFrame(
-                        frequencyBuffer,
-                        ctx.sampleRate,
-                        refinementAnalyser.fftSize,
-                        liveSuppressionConfig.aggressiveIsolation,
-                    )
-                    // When we detect speech, avoid over-attenuating the send floor.
-                    // This keeps syllables intact while retaining strong suppression in non-speech frames.
-                    if (likelySpeech) {
-                        const speechSafeFloor = liveSuppressionConfig.aggressiveIsolation ? 0.72 : 0.8
-                        targetGain = Math.max(targetGain, speechSafeFloor)
-                    }
+                    targetGain = evaluation.targetFloorGain
+                    targetIsolationGain = evaluation.targetIsolationGain
+                    likelySpeech = evaluation.likelySpeech
                 }
 
                 const alpha = targetGain > currentFloorGain ? 0.38 : liveSuppressionConfig.floorReleaseAlpha
@@ -613,14 +696,17 @@ export function useAudioEngine() {
                     ctx.currentTime,
                     targetGain > currentFloorGain ? 0.016 : liveSuppressionConfig.floorReleaseTime,
                 )
-                const isolationAlpha = targetIsolationGain > currentIsolationGain
-                    ? 0.22
-                    : (liveSuppressionConfig.aggressiveIsolation ? 0.2 : 0.14)
+                const recoveringIsolation = targetIsolationGain > currentIsolationGain
+                const isolationAlpha = recoveringIsolation
+                    ? liveSuppressionConfig.isolationRecoveryAlpha
+                    : liveSuppressionConfig.isolationAttenuationAlpha
                 currentIsolationGain = isolationAlpha * targetIsolationGain + (1 - isolationAlpha) * currentIsolationGain
                 speechIsolationGainNode.gain.setTargetAtTime(
                     currentIsolationGain,
                     ctx.currentTime,
-                    targetIsolationGain > currentIsolationGain ? 0.03 : 0.06,
+                    recoveringIsolation
+                        ? liveSuppressionConfig.isolationRecoveryTime
+                        : liveSuppressionConfig.isolationAttenuationTime,
                 )
                 const nowMs = Date.now()
                 if (nowMs - lastProcessingDiagnosticsAt >= 750) {

--- a/apps/web/src/webrtc/voiceQualityBenchmarkConfig.test.ts
+++ b/apps/web/src/webrtc/voiceQualityBenchmarkConfig.test.ts
@@ -13,10 +13,12 @@ import { evaluateVoiceGateFrame } from './voiceGate'
 import {
   buildSuppressionConfig,
   buildSuppressionFilterConfig,
+  evaluateSuppressionFrame,
 } from './hooks/useAudioEngine'
 
 const SAMPLE_RATE = 48_000
 const FFT_SIZE = 256
+const SUPPRESSION_FFT_SIZE = 2048
 
 function dbFromSlider(slider: number): number {
   return Math.round(20 * Math.log10(onThresholdFromSlider(slider)))
@@ -24,6 +26,10 @@ function dbFromSlider(slider: number): number {
 
 function dbFromLinear(value: number): number {
   return Math.round(20 * Math.log10(value))
+}
+
+function linearFromDb(value: number): number {
+  return Math.pow(10, value / 20)
 }
 
 function buildFrequencyFrame({
@@ -47,6 +53,38 @@ function buildFrequencyFrame({
   setBand(2800, 7200, highNoiseDb)
   setBand(0, 140, lowNoiseDb)
   return bins
+}
+
+function buildSuppressionFrame({
+  bodyDb,
+  upperSpeechDb,
+  highNoiseDb,
+  lowNoiseDb,
+}: {
+  bodyDb: number
+  upperSpeechDb: number
+  highNoiseDb: number
+  lowNoiseDb: number
+}): Float32Array {
+  const bins = new Float32Array(SUPPRESSION_FFT_SIZE / 2).fill(-96)
+  const binWidth = SAMPLE_RATE / SUPPRESSION_FFT_SIZE
+  const setBand = (minHz: number, maxHz: number, value: number) => {
+    const start = Math.max(0, Math.floor(minHz / binWidth))
+    const end = Math.min(bins.length - 1, Math.ceil(maxHz / binWidth))
+    for (let i = start; i <= end; i++) bins[i] = value
+  }
+
+  setBand(0, 140, lowNoiseDb)
+  setBand(180, 1599, bodyDb)
+  setBand(1600, 3399, upperSpeechDb)
+  setBand(3400, 7200, highNoiseDb)
+  return bins
+}
+
+function suppressionConfigForPreset(preset: 'normal' | 'noisy') {
+  localStorage.setItem('voxpery-settings-speaking-preset', preset)
+  localStorage.setItem('voxpery-settings-voice-input-profile', 'isolation')
+  return buildSuppressionConfig(true)
 }
 
 describe('voice quality benchmark configuration', () => {
@@ -88,15 +126,26 @@ describe('voice quality benchmark configuration', () => {
     const highFilters = buildSuppressionFilterConfig(true, 'high')
 
     expect(balancedFilters).toMatchObject({
-      highPassHz: 135,
-      lowPassHz: 6800,
-      deClickGainDb: -2.4,
-      speechPresenceGainDb: 0.9,
-      compressorThresholdDb: -32,
-      compressorKneeDb: 9,
-      compressorRatio: 4,
-      compressorAttackSec: 0.0028,
-      compressorReleaseSec: 0.085,
+      highPassHz: 110,
+      lowPassHz: 7600,
+      deClickGainDb: -1.2,
+      speechPresenceGainDb: 0.5,
+      compressorThresholdDb: -28,
+      compressorKneeDb: 12,
+      compressorRatio: 2.6,
+      compressorAttackSec: 0.004,
+      compressorReleaseSec: 0.12,
+    })
+    expect(highFilters).toMatchObject({
+      highPassHz: 145,
+      lowPassHz: 5600,
+      deClickGainDb: -5,
+      speechPresenceGainDb: 1,
+      compressorThresholdDb: -37,
+      compressorKneeDb: 8,
+      compressorRatio: 4.8,
+      compressorAttackSec: 0.002,
+      compressorReleaseSec: 0.075,
     })
     expect(balancedFilters.highPassHz).toBeLessThan(highFilters.highPassHz)
     expect(balancedFilters.lowPassHz).toBeGreaterThan(highFilters.lowPassHz)
@@ -112,13 +161,158 @@ describe('voice quality benchmark configuration', () => {
     localStorage.setItem('voxpery-settings-speaking-preset', 'noisy')
     const highConfig = buildSuppressionConfig(true)
 
-    expect(dbFromLinear(balancedConfig.lowFloorThr)).toBe(-51)
-    expect(dbFromLinear(balancedConfig.openFloorThr)).toBe(-39)
-    expect(balancedConfig.minFloorGain).toBe(0.12)
-    expect(balancedConfig.floorReleaseAlpha).toBe(0.07)
-    expect(balancedConfig.floorReleaseTime).toBe(0.075)
+    expect(dbFromLinear(balancedConfig.lowFloorThr)).toBe(-54)
+    expect(dbFromLinear(balancedConfig.openFloorThr)).toBe(-42)
+    expect(balancedConfig.minFloorGain).toBe(0.22)
+    expect(balancedConfig.floorReleaseAlpha).toBe(0.045)
+    expect(balancedConfig.floorReleaseTime).toBe(0.11)
+    expect(balancedConfig.speechSafeFloorGain).toBe(0.9)
+    expect(balancedConfig.isolationAttenuationAlpha).toBe(0.1)
+    expect(dbFromLinear(highConfig.lowFloorThr)).toBe(-43)
+    expect(dbFromLinear(highConfig.openFloorThr)).toBe(-31)
+    expect(highConfig.minFloorGain).toBe(0.035)
+    expect(highConfig.speechSafeFloorGain).toBe(0.82)
     expect(balancedConfig.minFloorGain).toBeGreaterThan(highConfig.minFloorGain)
     expect(balancedConfig.floorReleaseTime).toBeGreaterThan(highConfig.floorReleaseTime)
+  })
+
+  it('preserves clean speech without post-RNNoise attenuation in both presets', () => {
+    const frame = buildSuppressionFrame({
+      bodyDb: -24,
+      upperSpeechDb: -28,
+      highNoiseDb: -72,
+      lowNoiseDb: -70,
+    })
+
+    for (const preset of ['normal', 'noisy'] as const) {
+      const evaluation = evaluateSuppressionFrame(
+        frame,
+        SAMPLE_RATE,
+        SUPPRESSION_FFT_SIZE,
+        linearFromDb(-27),
+        suppressionConfigForPreset(preset),
+      )
+      expect(evaluation).toEqual({
+        targetFloorGain: 1,
+        targetIsolationGain: 1,
+        likelySpeech: true,
+      })
+    }
+  })
+
+  it('keeps quiet speech more open in Balanced while Noisy room retains bounded cleanup', () => {
+    const frame = buildSuppressionFrame({
+      bodyDb: -35,
+      upperSpeechDb: -37,
+      highNoiseDb: -41,
+      lowNoiseDb: -50,
+    })
+    const rms = linearFromDb(-38)
+    const balanced = evaluateSuppressionFrame(
+      frame,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      rms,
+      suppressionConfigForPreset('normal'),
+    )
+    const noisy = evaluateSuppressionFrame(
+      frame,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      rms,
+      suppressionConfigForPreset('noisy'),
+    )
+
+    expect(balanced.likelySpeech).toBe(true)
+    expect(noisy.likelySpeech).toBe(true)
+    expect(balanced.targetFloorGain).toBe(1)
+    expect(balanced.targetIsolationGain).toBe(1)
+    expect(noisy.targetFloorGain).toBeGreaterThanOrEqual(0.82)
+    expect(noisy.targetIsolationGain).toBeGreaterThanOrEqual(0.46)
+    expect(noisy.targetIsolationGain).toBeLessThan(1)
+  })
+
+  it('does not mistake speech mixed with keyboard transients for keyboard-only noise', () => {
+    const speechWhileTyping = buildSuppressionFrame({
+      bodyDb: -32,
+      upperSpeechDb: -34,
+      highNoiseDb: -29.4,
+      lowNoiseDb: -68,
+    })
+    const rms = linearFromDb(-30)
+    const balanced = evaluateSuppressionFrame(
+      speechWhileTyping,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      rms,
+      suppressionConfigForPreset('normal'),
+    )
+    const noisy = evaluateSuppressionFrame(
+      speechWhileTyping,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      rms,
+      suppressionConfigForPreset('noisy'),
+    )
+
+    expect(balanced.likelySpeech).toBe(true)
+    expect(noisy.likelySpeech).toBe(true)
+    expect(balanced.targetIsolationGain).toBe(1)
+    expect(noisy.targetIsolationGain).toBeGreaterThanOrEqual(0.8)
+  })
+
+  it('keeps keyboard and fan attenuation stronger in Noisy room without muting them to zero', () => {
+    const keyboardFrame = buildSuppressionFrame({
+      bodyDb: -56,
+      upperSpeechDb: -48,
+      highNoiseDb: -27,
+      lowNoiseDb: -78,
+    })
+    const fanFrame = buildSuppressionFrame({
+      bodyDb: -54,
+      upperSpeechDb: -58,
+      highNoiseDb: -64,
+      lowNoiseDb: -28,
+    })
+    const balancedConfig = suppressionConfigForPreset('normal')
+    const noisyConfig = suppressionConfigForPreset('noisy')
+    const balancedKeyboard = evaluateSuppressionFrame(
+      keyboardFrame,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      linearFromDb(-31),
+      balancedConfig,
+    )
+    const noisyKeyboard = evaluateSuppressionFrame(
+      keyboardFrame,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      linearFromDb(-31),
+      noisyConfig,
+    )
+    const balancedFan = evaluateSuppressionFrame(
+      fanFrame,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      linearFromDb(-42),
+      balancedConfig,
+    )
+    const noisyFan = evaluateSuppressionFrame(
+      fanFrame,
+      SAMPLE_RATE,
+      SUPPRESSION_FFT_SIZE,
+      linearFromDb(-42),
+      noisyConfig,
+    )
+
+    expect(balancedKeyboard.likelySpeech).toBe(false)
+    expect(noisyKeyboard.likelySpeech).toBe(false)
+    expect(balancedFan.likelySpeech).toBe(false)
+    expect(noisyFan.likelySpeech).toBe(false)
+    expect(noisyKeyboard.targetIsolationGain).toBeGreaterThan(0)
+    expect(noisyKeyboard.targetIsolationGain).toBeLessThan(balancedKeyboard.targetIsolationGain)
+    expect(noisyFan.targetIsolationGain).toBeGreaterThan(0)
+    expect(noisyFan.targetIsolationGain).toBeLessThan(balancedFan.targetIsolationGain)
   })
 
   it('keeps Studio out of the benchmark isolation path', () => {

--- a/docs/VOICE_QUALITY_BENCHMARK.md
+++ b/docs/VOICE_QUALITY_BENCHMARK.md
@@ -68,6 +68,19 @@ Record separate scores for:
 
 `Balanced` is the natural-voice baseline. It should keep more body and upper detail than `Noisy room`, with gentler de-clicking, compression, and floor attenuation. `Noisy room` remains the stronger cleanup mode for keyboard, fan, and room-noise rejection.
 
+## Automated Suppression Guardrails
+
+`apps/web/src/webrtc/voiceQualityBenchmarkConfig.test.ts` runs deterministic spectral fixtures before subjective call testing. These fixtures compare the raw frame with the gain targets produced by both suppression profiles:
+
+- Clean speech must remain at `1.0` floor gain and `1.0` isolation gain in both profiles.
+- Quiet speech mixed with dense background noise must remain fully open in `Balanced`.
+- The same quiet speech in `Noisy room` must keep at least `0.82` floor gain and `0.46` isolation gain; cleanup may be audible, but it cannot collapse to silence.
+- Speech mixed with keyboard transients must remain classified as speech; `Noisy room` must retain at least `0.80` isolation gain instead of treating the whole frame as keyboard-only noise.
+- Keyboard and fan fixtures must receive stronger isolation in `Noisy room` than in `Balanced`, while both targets remain above zero.
+- `Balanced` must retain the wider speech band and gentler compressor; `Noisy room` may be stronger but cannot return to the previous narrow-band, high-ratio configuration.
+
+These model-level fixtures prevent destructive parameter regressions and run in CI. They do not replace the reference call because synthetic spectra cannot measure perceived timbre, codec artifacts, microphone-specific behavior, or end-to-end WebRTC output.
+
 ## Runtime Diagnostics
 
 Before the Voxpery run, enable diagnostics on the sender:
@@ -120,6 +133,7 @@ A voice-quality change is acceptable only when:
 - Voxpery normal speech clarity is at least `4/5`.
 - Voxpery naturalness is at least `4/5`.
 - Voxpery has no repeated clipped syllables during normal speech.
+- Neither preset makes a familiar speaker sound distinctly thinner, metallic, robotic, or telephone-like.
 - Voxpery does not consistently open voice activity for fan, mouse, keyboard, clap, or breath while silent.
 - Voxpery is not more than one point worse than the reference app in clarity or naturalness.
 - `Noisy room` improves noise rejection without making normal speech hard to understand.
@@ -144,9 +158,10 @@ Use small PRs for each tuning change.
    - input gain/compression
    - LiveKit publish options
 3. Run unit tests for changed voice helpers.
-4. Run `docs/VOICE_SUPPRESSION_SMOKE_TEST.md`.
-5. Run this benchmark against the same reference call.
-6. Put before/after scores and diagnostic fields in the PR description.
+4. Confirm the automated suppression guardrails pass for clean speech, quiet speech in noise, keyboard, and fan fixtures.
+5. Run `docs/VOICE_SUPPRESSION_SMOKE_TEST.md`.
+6. Run this benchmark against the same reference call.
+7. Put before/after scores and diagnostic fields in the PR description.
 
 ## PR Result Template
 

--- a/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
+++ b/docs/VOICE_SUPPRESSION_SMOKE_TEST.md
@@ -65,14 +65,15 @@ Run each sound while the receiver listens:
 
 | Input | Expected result |
 | --- | --- |
-| Normal speech | Clear and intelligible, without chopped syllables. |
+| Normal speech | Clear, natural, and intelligible, without chopped syllables or metallic/telephone-like coloration. |
+| Quiet speech | Remains understandable and does not disappear between syllables. |
 | Single clap near the mic | Not transmitted, or only a heavily attenuated transient. |
 | Keyboard typing | Not transmitted as continuous speech. |
 | Mouse clicks | Not transmitted as continuous speech. |
 | Fan or steady room noise | Does not open the voice activity gate by itself. |
 | Short breath near mic | Does not keep the gate open after the breath ends. |
 
-Fail the release candidate if normal speech is hard to understand, or if clap/keyboard/fan noise consistently reaches the receiver like normal voice.
+Fail the release candidate if normal or quiet speech is hard to understand, if a familiar speaker sounds distinctly thinner or synthetic than the reference call, or if clap/keyboard/fan noise consistently reaches the receiver like normal voice.
 
 ## Local vs Production Parity
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -120,8 +120,10 @@ Room.localParticipant.publishTrack
     - speech-presence shaping
     - compressor strength
     - residual noise floor attenuation
-  - `Balanced` is the recommended default and keeps a wider speech band with gentler compression/floor attenuation so everyday voices sound more natural
-  - `Noisy room` and stricter custom thresholds trend more aggressive for keyboard and room noise
+  - `Balanced` is the recommended default. It keeps a `110 Hz .. 7.6 kHz` post-denoise band, uses gentle `2.6:1` compression, and keeps detected speech above a `0.90` residual-floor gain so everyday voices retain body and upper detail.
+  - `Noisy room` remains stronger without collapsing into a telephone-like voice band. It keeps a `145 Hz .. 5.6 kHz` band, uses bounded `4.8:1` compression, and keeps detected speech above a `0.82` residual-floor gain.
+  - Spectral isolation and attack/recovery smoothing are profile-aware: `Balanced` recovers speech faster and attenuates it less, while `Noisy room` applies stronger isolation only to noise-dominant frames such as keyboard and fan fixtures.
+  - Clean speech bypasses post-RNNoise floor and spectral attenuation in both presets. Quiet speech remains fully open in `Balanced`; `Noisy room` may apply bounded cleanup but must not mute or hard-gate it.
 - **Microphone publish quality**
   - The processed microphone track is published with LiveKit's high-quality mono Opus preset.
   - DTX remains enabled to avoid sending unnecessary silence, and RED remains enabled for packet-loss resilience.


### PR DESCRIPTION
## Summary

- retune Balanced suppression for wider, more natural speech reproduction
- reduce destructive filtering, compression, and floor attenuation in Noisy room
- make speech isolation and recovery behavior profile-aware
- preserve quiet speech and speech mixed with keyboard transients
- prevent keyboard and fan noise from being classified as speech
- add deterministic regression fixtures for clean speech, noisy speech, keyboard, and fan scenarios
- document measurable suppression guardrails and updated voice-quality checks

## Validation

- `npm run lint`
- `npm run test:run` — 202 tests passed
- `npm run build`

No environment or deployment configuration changes are required.