### PR TITLE
feat: improve DM organization and channel sidebar workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Voxpery is strongest when you want a smaller, inspectable, self-hostable communi
 
 ### Communication
 - **Crystal-clear voice** - LiveKit SFU, auto quality adaptation, screen sharing
-- **Text & DMs** - Servers, channels, direct messages with real-time typing
+- **Text & DMs** - Servers, compact channel management, activity-sorted direct messages, and pinned conversations
 - **Friends & social** - Add friends, see status, mutual presence
 - **Fast navigation** - Quick switcher for server, channel, and DM jumps
 - **Reactions & attachments** - Emoji reactions, uploads, signed attachment access
@@ -204,12 +204,6 @@ docker compose up -d --build  # Full stack
 - **[Join Voxpery Discussions](https://github.com/emircanagac/voxpery/discussions)** - Ask questions, get help, discuss features
 - **[Report bugs / suggest features](https://github.com/emircanagac/voxpery/issues)**
 - **[Read docs](docs/)**
-
----
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=emircanagac/voxpery&type=Date)](https://star-history.com/#emircanagac/voxpery&Date)
 
 ---
 

--- a/apps/server/migrations/043_dm_channel_pinned_state.sql
+++ b/apps/server/migrations/043_dm_channel_pinned_state.sql
@@ -1,0 +1,6 @@
+ALTER TABLE dm_channel_members
+    ADD COLUMN IF NOT EXISTS pinned_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dm_channel_members_user_pinned_at
+    ON dm_channel_members(user_id, pinned_at DESC)
+    WHERE pinned_at IS NOT NULL;

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -40,6 +40,8 @@ pub struct DmChannelInfo {
     pub peer_status: String,
     pub last_message_at: Option<chrono::DateTime<chrono::Utc>>,
     pub unread_count: i64,
+    pub pinned_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub is_pinned: bool,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -80,6 +82,11 @@ pub struct RemoveDmReactionQuery {
 #[derive(Debug, serde::Deserialize)]
 pub struct PinDmMessageRequest {
     pub message_id: Uuid,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct UpdateDmChannelPreferencesRequest {
+    pub pinned: bool,
 }
 
 #[derive(sqlx::FromRow)]
@@ -221,6 +228,10 @@ pub fn router(state: Arc<AppState>) -> Router<Arc<AppState>> {
         .route("/channels", get(list_dm_channels))
         .route("/channels/{peer_id}", post(get_or_create_dm_channel))
         .route("/channels/{channel_id}/hide", post(hide_dm_channel))
+        .route(
+            "/channels/{channel_id}/preferences",
+            patch(update_dm_channel_preferences),
+        )
         .route("/channels/{channel_id}/read-state", get(get_dm_read_state))
         .route("/channels/{channel_id}/read", post(mark_dm_channel_read))
         .route(
@@ -270,6 +281,7 @@ async fn list_dm_channels(
                     u.avatar_url as peer_avatar_url,
                     u.status as peer_status,
                     self_m.hidden_at,
+                    self_m.pinned_at,
                     c.created_at,
                     (
                       SELECT m.created_at
@@ -300,10 +312,17 @@ async fn list_dm_channels(
                   peer_avatar_url,
                   peer_status,
                   last_message_at,
-                  unread_count
+                  unread_count,
+                  pinned_at,
+                  pinned_at IS NOT NULL AS is_pinned
            FROM channel_rows
-           WHERE hidden_at IS NULL OR unread_count > 0
-           ORDER BY COALESCE(last_message_at, created_at) DESC"#,
+           WHERE hidden_at IS NULL
+              OR pinned_at IS NOT NULL
+              OR last_message_at > hidden_at
+           ORDER BY pinned_at IS NULL ASC,
+                    pinned_at DESC NULLS LAST,
+                    COALESCE(last_message_at, created_at) DESC,
+                    id ASC"#,
     )
     .bind(claims.sub)
     .fetch_all(&state.db)
@@ -484,8 +503,12 @@ async fn get_or_create_dm_channel(
                     WHERE m.channel_id = c.id
                       AND m.user_id <> $1
                       AND (r.read_at IS NULL OR m.created_at > r.read_at)
-                  ) as unread_count
+                  ) as unread_count,
+                  self_m.pinned_at,
+                  self_m.pinned_at IS NOT NULL AS is_pinned
            FROM dm_channels c
+           INNER JOIN dm_channel_members self_m
+             ON self_m.channel_id = c.id AND self_m.user_id = $1
            INNER JOIN dm_channel_members peer_m
              ON peer_m.channel_id = c.id AND peer_m.user_id <> $1
            INNER JOIN users u ON u.id = peer_m.user_id
@@ -519,7 +542,7 @@ async fn hide_dm_channel(
     check_dm_access(&state, channel_id, claims.sub).await?;
 
     sqlx::query(
-        "UPDATE dm_channel_members SET hidden_at = NOW() WHERE channel_id = $1 AND user_id = $2",
+        "UPDATE dm_channel_members SET hidden_at = NOW(), pinned_at = NULL WHERE channel_id = $1 AND user_id = $2",
     )
     .bind(channel_id)
     .bind(claims.sub)
@@ -527,6 +550,29 @@ async fn hide_dm_channel(
     .await?;
 
     Ok(Json(()))
+}
+
+async fn update_dm_channel_preferences(
+    State(state): State<Arc<AppState>>,
+    Extension(claims): Extension<Claims>,
+    Path(channel_id): Path<Uuid>,
+    Json(payload): Json<UpdateDmChannelPreferencesRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    check_dm_access(&state, channel_id, claims.sub).await?;
+
+    sqlx::query(
+        r#"UPDATE dm_channel_members
+           SET pinned_at = CASE WHEN $3 THEN NOW() ELSE NULL END,
+               hidden_at = CASE WHEN $3 THEN NULL ELSE hidden_at END
+           WHERE channel_id = $1 AND user_id = $2"#,
+    )
+    .bind(channel_id)
+    .bind(claims.sub)
+    .bind(payload.pinned)
+    .execute(&state.db)
+    .await?;
+
+    Ok(Json(serde_json::json!({ "pinned": payload.pinned })))
 }
 
 async fn get_dm_messages(

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -1691,7 +1691,7 @@ async fn friend_dm_channel_open_returns_channel_info() {
 }
 
 #[tokio::test]
-async fn hidden_dm_channel_stays_out_of_channel_list_until_reopened() {
+async fn dm_channel_visibility_and_pinning_persist_for_each_user() {
     let Some(_) = test_db_url() else {
         eprintln!("SKIP: DATABASE_URL not set");
         return;
@@ -1819,6 +1819,48 @@ async fn hidden_dm_channel_stays_out_of_channel_list_until_reopened() {
 
     let req = Request::builder()
         .method("POST")
+        .uri(format!("/api/dm/messages/{channel_id}"))
+        .header("Authorization", &bob_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "content": "new activity reopens the DM" })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "send DM activity failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels.as_array().unwrap().len(), 1);
+    assert_eq!(channels[0]["id"].as_str().unwrap(), channel_id);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/dm/channels/{channel_id}/hide"))
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "hide reopened friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .method("POST")
         .uri(format!("/api/dm/channels/{bob_id}"))
         .header("Authorization", &alice_auth)
         .body(Body::empty())
@@ -1840,6 +1882,73 @@ async fn hidden_dm_channel_stays_out_of_channel_list_until_reopened() {
     assert_eq!(status, StatusCode::OK);
     let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(channels.as_array().unwrap().len(), 1);
+
+    let req = Request::builder()
+        .method("PATCH")
+        .uri(format!("/api/dm/channels/{channel_id}/preferences"))
+        .header("Authorization", &alice_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "pinned": true })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "pin friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels[0]["is_pinned"].as_bool(), Some(true));
+    assert!(channels[0]["pinned_at"].as_str().is_some());
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &bob_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels[0]["is_pinned"].as_bool(), Some(false));
+    assert!(channels[0]["pinned_at"].is_null());
+
+    let req = Request::builder()
+        .method("PATCH")
+        .uri(format!("/api/dm/channels/{channel_id}/preferences"))
+        .header("Authorization", &alice_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "pinned": false })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "unpin friend DM failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let req = Request::builder()
+        .uri("/api/dm/channels")
+        .header("Authorization", &alice_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let channels: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(channels[0]["is_pinned"].as_bool(), Some(false));
+    assert!(channels[0]["pinned_at"].is_null());
 }
 
 #[tokio::test]

--- a/apps/web/e2e/channel-permission-core-regressions.spec.ts
+++ b/apps/web/e2e/channel-permission-core-regressions.spec.ts
@@ -160,7 +160,9 @@ test.describe('mocked channel permission regressions', () => {
 
     await page.goto('/servers')
 
-    await expect(page.getByTitle('Create Channel')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Create channel in GENERAL' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Create channel in VOICE' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Create channels and categories' })).toHaveCount(0)
 
     const row = page.locator('[data-message-id="moderated-message"]')
     await row.hover()

--- a/apps/web/e2e/core-ui-smoke.spec.ts
+++ b/apps/web/e2e/core-ui-smoke.spec.ts
@@ -155,12 +155,12 @@ test.describe('mocked core UI smoke', () => {
     await page.setViewportSize({ width: 1366, height: 768 })
 
     await page.goto('/servers')
-    await page.locator('.channel-create-btn[title="Create Channel"]').click()
+    await page.getByRole('button', { name: 'Create channel in GENERAL' }).click()
 
     const modal = page.locator('.modal-create-channel')
     await expect(modal.getByRole('heading', { name: 'Create Channel' })).toBeVisible()
     await modal.getByPlaceholder('e.g. general').fill('raid-notes')
-    await modal.locator('input[list="channel-category-suggestions"]').fill('PLANNING')
+    await expect(modal.locator('input[list="channel-category-suggestions"]')).toHaveValue('GENERAL')
     await modal.getByPlaceholder('What is this channel for?').fill('Planning notes used by the smoke test.')
     await modal.getByRole('button', { name: 'Create Channel' }).click()
 
@@ -190,6 +190,8 @@ test.describe('mocked core UI smoke', () => {
         peer_status: 'online',
         last_message_at: null,
         unread_count: 0,
+        pinned_at: null,
+        is_pinned: false,
       }],
       dmMessagesByChannelId: { 'dm-friend-01': [] },
     })

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -1025,6 +1025,8 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
       peer_status: friend?.status ?? 'offline',
       last_message_at: null,
       unread_count: 0,
+      pinned_at: null,
+      is_pinned: false,
     })
     await json(route, channel)
     return
@@ -1033,6 +1035,18 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
   const dmReadStateMatch = pathname.match(/^\/api\/dm\/channels\/([^/]+)\/read-state$/)
   if (dmReadStateMatch && method === 'GET') {
     await json(route, { peer_last_read_message_id: null })
+    return
+  }
+
+  const dmPreferencesMatch = pathname.match(/^\/api\/dm\/channels\/([^/]+)\/preferences$/)
+  if (dmPreferencesMatch && method === 'PATCH') {
+    const body = parseJsonBody<{ pinned?: boolean }>(request)
+    const channel = state.dmChannels.find((item) => item.id === dmPreferencesMatch[1])
+    if (channel) {
+      channel.is_pinned = !!body.pinned
+      channel.pinned_at = body.pinned ? new Date().toISOString() : null
+    }
+    await json(route, { pinned: !!body.pinned })
     return
   }
 

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -134,6 +134,8 @@ export interface DmChannel {
     peer_status: string
     last_message_at: string | null
     unread_count: number
+    pinned_at: string | null
+    is_pinned: boolean
 }
 
 export interface DmReadState {

--- a/apps/web/src/api/dm.ts
+++ b/apps/web/src/api/dm.ts
@@ -18,6 +18,13 @@ export const dmApi = {
             token,
         }),
 
+    updateChannelPreferences: (channelId: string, pinned: boolean, token: AuthToken) =>
+        apiFetch<{ pinned: boolean }>(`/api/dm/channels/${channelId}/preferences`, {
+            method: 'PATCH',
+            body: { pinned },
+            token,
+        }),
+
     listMessages: (channelId: string, token: AuthToken, before?: string) =>
         apiFetch<MessageWithAuthor[]>(
             `/api/dm/messages/${channelId}${before ? `?before=${before}` : ''}`,

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Channel, MemberInfo, Server } from '../api'
 import { useAppStore } from '../stores/app'
@@ -85,5 +85,61 @@ describe('ChannelSidebar voice media presence', () => {
         expect(screen.getByLabelText(`${remoteMember.username} camera on`)).toBeVisible()
         expect(screen.getByLabelText(`${remoteMember.username} screen sharing`)).toHaveTextContent('LIVE')
         expect(useAppStore.getState().joinedVoiceChannelId).toBeNull()
+    })
+
+    it('offers compact, permission-aware channel creation controls', () => {
+        const onOpenCreateChannel = vi.fn()
+        const onOpenCreateCategory = vi.fn()
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            activeChannelId: null,
+        })
+
+        const { container } = render(
+            <ChannelSidebar
+                channelCategories={['Voice']}
+                canManageChannels
+                onOpenCreateChannel={onOpenCreateChannel}
+                onOpenCreateCategory={onOpenCreateCategory}
+            />,
+        )
+
+        expect(container.querySelector('.channel-create-actions')).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Create channels and categories' })).toBeNull()
+        const channelList = container.querySelector('.channel-list')
+        expect(channelList).not.toBeNull()
+        fireEvent.contextMenu(channelList!)
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Create Category' }))
+        expect(onOpenCreateCategory).toHaveBeenCalledTimes(1)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create channel in Voice' }))
+        expect(onOpenCreateChannel).toHaveBeenCalledWith('Voice')
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: 'Voice' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Create Channel' }))
+        expect(onOpenCreateChannel).toHaveBeenLastCalledWith('Voice')
+    })
+
+    it('does not expose channel creation controls without manage permission', () => {
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            activeChannelId: null,
+        })
+
+        render(
+            <ChannelSidebar
+                channelCategories={['Voice']}
+                canManageChannels={false}
+                onOpenCreateChannel={vi.fn()}
+                onOpenCreateCategory={vi.fn()}
+            />,
+        )
+
+        expect(screen.queryByRole('button', { name: 'Create channels and categories' })).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Create channel in Voice' })).toBeNull()
     })
 })

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -15,7 +15,7 @@ type ManualJoinWindow = Window & { __voxperyManualJoinActive?: boolean }
 
 interface ChannelSidebarProps {
     onOpenServerSettings?: () => void
-    onOpenCreateChannel?: () => void
+    onOpenCreateChannel?: (category?: string) => void
     onOpenCreateCategory?: () => void
     onOpenCategoryPermissions?: (category: string) => void
     onRenameCategory?: (category: string) => void
@@ -85,6 +85,7 @@ export default function ChannelSidebar({
     const [draggedCategory, setDraggedCategory] = useState<string | null>(null)
     const [contextMenu, setContextMenu] = useState<{ channelId: string; x: number; y: number } | null>(null)
     const [categoryMenu, setCategoryMenu] = useState<{ category: string; x: number; y: number } | null>(null)
+    const [createMenu, setCreateMenu] = useState<{ x: number; y: number } | null>(null)
     const [participantMenu, setParticipantMenu] = useState<{ userId: string; username: string; channelId: string; x: number; y: number } | null>(null)
     const [collapsedCategories, setCollapsedCategories] = useState<Record<string, boolean>>({})
     const [dragOverCategory, setDragOverCategory] = useState<{ name: string; position: 'before' | 'after' } | null>(null)
@@ -190,15 +191,17 @@ export default function ChannelSidebar({
     const closeAllContextMenus = () => {
         setContextMenu(null)
         setCategoryMenu(null)
+        setCreateMenu(null)
         setParticipantMenu(null)
     }
 
     useEffect(() => {
-        if (!contextMenu && !participantMenu && !categoryMenu) return
+        if (!contextMenu && !participantMenu && !categoryMenu && !createMenu) return
         const close = () => {
             setContextMenu(null)
             setParticipantMenu(null)
             setCategoryMenu(null)
+            setCreateMenu(null)
         }
         window.addEventListener('click', close)
         window.addEventListener('scroll', close, true)
@@ -206,7 +209,7 @@ export default function ChannelSidebar({
             window.removeEventListener('click', close)
             window.removeEventListener('scroll', close, true)
         }
-    }, [contextMenu, participantMenu, categoryMenu])
+    }, [contextMenu, participantMenu, categoryMenu, createMenu])
 
     useEffect(() => {
         if (Object.keys(voiceChannelActiveSince).length === 0) return
@@ -245,60 +248,41 @@ export default function ChannelSidebar({
 
     return (
         <div className="channel-sidebar" ref={sidebarRef}>
-            <div
-                className={`channel-header ${activeServer && onOpenServerSettings ? 'channel-header--clickable' : ''}`}
-                onClick={activeServer && onOpenServerSettings ? onOpenServerSettings : undefined}
-                role={activeServer && onOpenServerSettings ? 'button' : undefined}
-                tabIndex={activeServer && onOpenServerSettings ? 0 : undefined}
-                onKeyDown={
-                    activeServer && onOpenServerSettings
-                        ? (e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault()
-                                onOpenServerSettings()
-                            }
-                        }
-                        : undefined
-                }
-                title={activeServer && onOpenServerSettings ? 'Open server settings' : undefined}
-            >
+            <div className="channel-header">
                 {activeServer ? (
                     <>
-                        <span className="channel-header-title">{activeServer.name}</span>
-                        <span className="channel-header-action" aria-hidden="true">
-                            <Settings2 size={14} />
-                        </span>
+                        <button
+                            type="button"
+                            className="channel-header-server"
+                            onClick={onOpenServerSettings}
+                            title={onOpenServerSettings ? 'Open server settings' : undefined}
+                            disabled={!onOpenServerSettings}
+                        >
+                            <span className="channel-header-title">{activeServer.name}</span>
+                            {onOpenServerSettings && (
+                                <span className="channel-header-action" aria-hidden="true">
+                                    <Settings2 size={14} />
+                                </span>
+                            )}
+                        </button>
                     </>
                 ) : (
                     <span style={{ color: 'var(--text-muted)' }}>{loading ? 'Loading server…' : 'Select a Server'}</span>
                 )}
             </div>
 
-            <div className="channel-list">
-                {canManageChannels && onOpenCreateChannel && (
-                    <div className="channel-create-actions">
-                        <button
-                            type="button"
-                            className="channel-create-btn"
-                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onOpenCreateChannel(); }}
-                            title="Create Channel"
-                        >
-                            <Plus size={16} />
-                            Channel
-                        </button>
-                        {onOpenCreateCategory && (
-                            <button
-                                type="button"
-                                className="channel-create-btn"
-                                onClick={(e) => { e.preventDefault(); e.stopPropagation(); onOpenCreateCategory(); }}
-                                title="Create Category"
-                            >
-                                <Plus size={16} />
-                                Category
-                            </button>
-                        )}
-                    </div>
-                )}
+            <div
+                className="channel-list"
+                onContextMenu={(e) => {
+                    if (!canManageChannels || !onOpenCreateChannel) return
+                    const target = e.target as HTMLElement
+                    if (target.closest('.channel-category-group, .channel-item')) return
+                    e.preventDefault()
+                    const pos = clampMenuPosition(e.clientX, e.clientY, 190, 92)
+                    closeAllContextMenus()
+                    setCreateMenu(pos)
+                }}
+            >
                 {loading ? (
                     <div className="channel-sidebar-skeleton" aria-hidden="true">
                         <div className="channel-sidebar-skeleton-row" />
@@ -371,9 +355,10 @@ export default function ChannelSidebar({
                             }
                         }}
                     >
-                        <button
+                        <div className="channel-category">
+                          <button
                             type="button"
-                            className={`channel-category channel-category-btn ${dragOverCategoryForChannel === category ? 'is-channel-drop-target' : ''}`}
+                            className={`channel-category-btn ${dragOverCategoryForChannel === category ? 'is-channel-drop-target' : ''}`}
                             onClick={() =>
                                 setCollapsedCategories((prev) => ({
                                     ...prev,
@@ -422,10 +407,22 @@ export default function ChannelSidebar({
                                 setDragOverCategory(null)
                                 setDragOverCategoryForChannel(null)
                             }}
-                        >
-                            <ChevronDown size={10} className={collapsedCategories[category] ? 'is-collapsed' : ''} />
-                            {category}
-                        </button>
+                          >
+                              <ChevronDown size={10} className={collapsedCategories[category] ? 'is-collapsed' : ''} />
+                              <span>{category}</span>
+                          </button>
+                          {canManageChannels && onOpenCreateChannel && (
+                              <button
+                                  type="button"
+                                  className="channel-category-add"
+                                  aria-label={`Create channel in ${category}`}
+                                  title={`Create channel in ${category}`}
+                                  onClick={() => onOpenCreateChannel(category)}
+                              >
+                                  <Plus size={14} />
+                              </button>
+                          )}
+                        </div>
                         {!collapsedCategories[category] && chs.map((ch) => {
                             const isActive = activeChannelId === ch.id
                             const channelPerms = typeof ch.my_permissions === 'number' ? ch.my_permissions : 0
@@ -650,6 +647,41 @@ export default function ChannelSidebar({
                 ))}
             </div>
 
+            {createMenu && canManageChannels && onOpenCreateChannel && (
+                <div
+                    ref={menuRef}
+                    className="server-context-menu channel-context-menu"
+                    role="menu"
+                    style={{ left: createMenu.x, top: createMenu.y }}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <button
+                        type="button"
+                        className="server-context-menu-item"
+                        role="menuitem"
+                        onClick={() => {
+                            setCreateMenu(null)
+                            onOpenCreateChannel()
+                        }}
+                    >
+                        Create Channel
+                    </button>
+                    {onOpenCreateCategory && (
+                        <button
+                            type="button"
+                            className="server-context-menu-item"
+                            role="menuitem"
+                            onClick={() => {
+                                setCreateMenu(null)
+                                onOpenCreateCategory()
+                            }}
+                        >
+                            Create Category
+                        </button>
+                    )}
+                </div>
+            )}
+
             {contextMenu && (() => {
                 const channel = channels.find((c) => c.id === contextMenu.channelId)
                 if (!channel) return null
@@ -710,6 +742,18 @@ export default function ChannelSidebar({
                     style={{ left: categoryMenu.x, top: categoryMenu.y }}
                     onClick={(e) => e.stopPropagation()}
                 >
+                    {onOpenCreateChannel && (
+                        <button
+                            type="button"
+                            className="server-context-menu-item"
+                            onClick={() => {
+                                onOpenCreateChannel(categoryMenu.category)
+                                setCategoryMenu(null)
+                            }}
+                        >
+                            Create Channel
+                        </button>
+                    )}
                     <button
                         type="button"
                         className="server-context-menu-item"

--- a/apps/web/src/friendsList.test.ts
+++ b/apps/web/src/friendsList.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { DmChannel, Friend } from './api'
-import { getVisibleFriendsForFilter, upsertDmChannel } from './friendsList'
+import {
+  getVisibleFriendsForFilter,
+  sortDmChannels,
+  touchDmChannelActivity,
+  upsertDmChannel,
+} from './friendsList'
 
 function friend(id: string, username: string, status: string): Friend {
   return {
@@ -20,6 +25,8 @@ function dmChannel(id: string, peerUsername: string): DmChannel {
     peer_status: 'online',
     last_message_at: null,
     unread_count: 0,
+    pinned_at: null,
+    is_pinned: false,
   }
 }
 
@@ -54,7 +61,11 @@ describe('friends list helpers', () => {
 
   it('upserts opened DM channels without leaving stale duplicates', () => {
     const current = [dmChannel('old-a', 'alpha'), dmChannel('old-b', 'bravo')]
-    const updated = { ...dmChannel('old-b', 'bravo'), unread_count: 2 }
+    const updated = {
+      ...dmChannel('old-b', 'bravo'),
+      unread_count: 2,
+      last_message_at: '2026-03-01T00:00:00.000Z',
+    }
 
     expect(upsertDmChannel(current, updated)).toEqual([updated, current[0]])
     expect(upsertDmChannel(current, dmChannel('new-c', 'charlie')).map((channel) => channel.id)).toEqual([
@@ -62,5 +73,27 @@ describe('friends list helpers', () => {
       'old-a',
       'old-b',
     ])
+  })
+
+  it('keeps pinned DMs above recent activity and orders each group by latest message', () => {
+    const oldPinned = { ...dmChannel('pinned-old', 'old pin'), is_pinned: true, pinned_at: '2026-02-01T00:00:00.000Z', last_message_at: '2026-01-01T00:00:00.000Z' }
+    const recent = { ...dmChannel('recent', 'recent'), last_message_at: '2026-03-01T00:00:00.000Z' }
+    const newestPinned = { ...dmChannel('pinned-new', 'new pin'), is_pinned: true, pinned_at: '2026-03-01T00:00:00.000Z', last_message_at: '2025-12-01T00:00:00.000Z' }
+
+    expect(sortDmChannels([recent, oldPinned, newestPinned]).map((channel) => channel.id)).toEqual([
+      'pinned-new',
+      'pinned-old',
+      'recent',
+    ])
+  })
+
+  it('moves an active unpinned DM without displacing pinned conversations', () => {
+    const pinned = { ...dmChannel('pinned', 'pinned'), is_pinned: true, pinned_at: '2026-03-01T00:00:00.000Z' }
+    const older = { ...dmChannel('older', 'older'), last_message_at: '2026-01-01T00:00:00.000Z' }
+    const active = { ...dmChannel('active', 'active'), last_message_at: '2026-01-02T00:00:00.000Z' }
+
+    const touched = touchDmChannelActivity([pinned, active, older], older.id, '2026-04-01T00:00:00.000Z')
+
+    expect(touched.map((channel) => channel.id)).toEqual(['pinned', 'older', 'active'])
   })
 })

--- a/apps/web/src/friendsList.ts
+++ b/apps/web/src/friendsList.ts
@@ -35,6 +35,37 @@ export function getVisibleFriendsForFilter(friends: Friend[], filter: Exclude<Fr
   return [...source].sort(compareFriendsForList)
 }
 
+function dmActivityTimestamp(channel: DmChannel): number {
+  const timestamp = channel.last_message_at ? Date.parse(channel.last_message_at) : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+export function compareDmChannelsForList(a: DmChannel, b: DmChannel): number {
+  if (a.is_pinned !== b.is_pinned) return a.is_pinned ? -1 : 1
+  if (a.is_pinned && b.is_pinned) {
+    const aPinnedAt = a.pinned_at ? Date.parse(a.pinned_at) : 0
+    const bPinnedAt = b.pinned_at ? Date.parse(b.pinned_at) : 0
+    const pinnedDiff = bPinnedAt - aPinnedAt
+    if (Number.isFinite(pinnedDiff) && pinnedDiff !== 0) return pinnedDiff
+    return a.id.localeCompare(b.id)
+  }
+  const activityDiff = dmActivityTimestamp(b) - dmActivityTimestamp(a)
+  if (activityDiff !== 0) return activityDiff
+  return a.id.localeCompare(b.id)
+}
+
+export function sortDmChannels(channels: DmChannel[]): DmChannel[] {
+  return [...channels].sort(compareDmChannelsForList)
+}
+
 export function upsertDmChannel(channels: DmChannel[], channel: DmChannel): DmChannel[] {
-  return [channel, ...channels.filter((existing) => existing.id !== channel.id)]
+  return sortDmChannels([channel, ...channels.filter((existing) => existing.id !== channel.id)])
+}
+
+export function touchDmChannelActivity(channels: DmChannel[], channelId: string, timestamp: string): DmChannel[] {
+  return sortDmChannels(
+    channels.map((channel) =>
+      channel.id === channelId ? { ...channel, last_message_at: timestamp } : channel,
+    ),
+  )
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1285,12 +1285,24 @@ body {
   transition: background var(--transition-fast);
 }
 
-.channel-header--clickable {
+.channel-header-server {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
 }
 
-.channel-header--clickable:hover {
-  background: rgba(255, 255, 255, 0.03);
+.channel-header-server:disabled {
+  cursor: default;
 }
 
 .channel-header-title {
@@ -1315,13 +1327,13 @@ body {
   transition: border-color var(--transition-fast), color var(--transition-fast), background var(--transition-fast);
 }
 
-.channel-header--clickable:hover .channel-header-action {
+.channel-header-server:hover .channel-header-action {
   border-color: rgba(126, 166, 242, 0.45);
   color: rgba(224, 238, 255, 0.94);
   background: rgba(61, 105, 194, 0.14);
 }
 
-.channel-header--clickable:focus-visible {
+.channel-header-server:focus-visible {
   outline: none;
   box-shadow: inset 0 0 0 1px rgba(126, 166, 242, 0.55);
 }
@@ -1331,56 +1343,6 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
   padding: 8px 0;
-}
-
-.channel-create-actions {
-  display: flex;
-  gap: 6px;
-  margin: 6px 8px 8px;
-}
-
-.channel-create-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  flex: 1;
-  min-width: 0;
-  min-height: 28px;
-  padding: 4px 8px;
-  border: 1px solid rgba(143, 171, 222, 0.12);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.02);
-  color: rgba(222, 233, 255, 0.92);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  cursor: pointer;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
-  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.channel-create-btn svg {
-  flex-shrink: 0;
-  width: 10px;
-  height: 10px;
-  stroke-width: 2;
-  opacity: 0.72;
-}
-
-.channel-create-btn:hover {
-  color: #eef3ff;
-  background: rgba(94, 137, 210, 0.09);
-  border-color: rgba(124, 167, 236, 0.24);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
-  transform: translateY(-1px);
-}
-
-.channel-create-actions .channel-create-btn:only-child {
-  flex: 1 1 100%;
 }
 
 .channel-empty-state {
@@ -1459,10 +1421,54 @@ body {
 }
 
 .channel-category-btn {
-  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
   border: none;
+  color: inherit;
+  font: inherit;
   background: transparent;
   text-align: left;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+}
+
+.channel-category-btn>span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.channel-category-add {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.channel-category-add:hover,
+.channel-category-add:focus-visible {
+  color: var(--text-primary);
+  background: rgba(var(--ui-contrast-rgb), 0.07);
+}
+
+.channel-category-add:focus-visible,
+.channel-category-btn:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-primary) 55%, transparent);
+  outline-offset: 1px;
 }
 
 .channel-category-btn.is-channel-drop-target {
@@ -7439,11 +7445,43 @@ body {
   padding: 6px 8px;
   border-radius: var(--border-radius-sm);
   text-align: left;
+  cursor: default;
+}
+
+.social-dm-open {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
   cursor: pointer;
+}
+
+.social-dm-open:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-primary) 65%, transparent);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-sm);
 }
 
 .social-dm-item+.social-dm-item {
   margin-top: 4px;
+}
+
+.social-dm-group-label {
+  margin: 8px 4px 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.social-sidebar-title+.social-dm-group-label {
+  margin-top: 6px;
 }
 
 .social-dm-item:hover {
@@ -7967,17 +8005,31 @@ body {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
+  flex: 0 0 auto;
 }
 
 .social-dm-actions .home-member-action {
-  background: rgba(255, 255, 255, 0.045);
-  opacity: 0.78;
+  width: 24px;
+  height: 24px;
+  border-color: transparent;
+  background: transparent;
+  opacity: 0;
 }
 
 .social-dm-item:hover .home-member-action,
 .social-dm-item:focus-within .home-member-action {
   opacity: 1;
+}
+
+.social-dm-open .home-member-meta>div {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.social-dm-context-menu {
+  width: 196px;
 }
 
 .social-dm-unread {
@@ -13336,20 +13388,18 @@ a.community-open-btn:hover {
   box-shadow: 0 0 10px var(--accent-soft-strong);
 }
 
-.channel-header-action,
-.channel-create-btn {
+.channel-header-action {
   border-color: rgba(var(--ui-contrast-rgb), 0.12);
   color: var(--text-secondary);
 }
 
-.channel-header--clickable:hover .channel-header-action,
-.channel-create-btn:hover {
+.channel-header-server:hover .channel-header-action {
   border-color: var(--accent-border);
   background: var(--accent-soft);
   color: var(--text-primary);
 }
 
-.channel-header--clickable:focus-visible {
+.channel-header-server:focus-visible {
   box-shadow: inset 0 0 0 1px var(--accent-border-strong);
 }
 
@@ -14042,11 +14092,6 @@ textarea {
 
   .home-search {
     min-height: 40px;
-  }
-
-  .channel-create-btn {
-    min-height: 34px;
-    padding: 0 12px;
   }
 
   .chat-header-pinned-wrap {

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -2595,11 +2595,11 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         }
     }
 
-    const openCreateChannelModal = () => {
+    const openCreateChannelModal = (category?: string) => {
         setCreateChannelError(null)
         setCreateChannelName('')
         setCreateChannelType('text')
-        setCreateChannelCategory('')
+        setCreateChannelCategory(category ?? '')
         setCreateChannelDescription('')
         setShowCreateChannel(true)
     }

--- a/apps/web/src/pages/AppShell.test.tsx
+++ b/apps/web/src/pages/AppShell.test.tsx
@@ -78,6 +78,8 @@ function dmChannel(id: string, peerId = 'friend-1', peerUsername = 'friend'): Dm
     peer_status: 'online',
     last_message_at: null,
     unread_count: 0,
+    pinned_at: null,
+    is_pinned: false,
   }
 }
 

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -12,6 +12,7 @@ import UserBar from '../components/UserBar'
 import NotificationPermissionPrompt from '../components/NotificationPermissionPrompt'
 import { useToastStore } from '../stores/toast'
 import { dmApi, friendApi, type DmChannel, type Friend, type User } from '../api'
+import { touchDmChannelActivity, upsertDmChannel } from '../friendsList'
 import { playMessageNotificationSound, shouldPlayNotificationSound } from '../notificationSound'
 import {
   shouldShowPushNotification,
@@ -414,7 +415,7 @@ export default function AppShell() {
           }
         }
         if (e?.type === 'NewMessage') {
-          const payload = e?.data as { channel_id?: string; channel_type?: string; message?: { author?: { user_id?: string; username?: string } } }
+          const payload = e?.data as { channel_id?: string; channel_type?: string; message?: { created_at?: string; author?: { user_id?: string; username?: string } } }
           const channelId = payload?.channel_id
           const channelType = payload?.channel_type
           const incomingMessage = payload?.message
@@ -424,11 +425,13 @@ export default function AppShell() {
           if (authorId && authorId === userId) return
 
           void (async () => {
-            let channel = dmChannels.find((c) => c.id === channelId)
+            let currentChannels = useAppStore.getState().dmChannels
+            let channel = currentChannels.find((c) => c.id === channelId)
             let dmIds = dmChannelIds
             if (!channel) {
               try {
                 const latest = await dmApi.listChannels(token)
+                currentChannels = latest
                 dmIds = latest.map((c) => c.id)
                 setDmChannels(latest)
                 setDmChannelIds(dmIds)
@@ -443,7 +446,8 @@ export default function AppShell() {
               try {
                 const created = await dmApi.getOrCreateChannel(authorId, token)
                 channel = created
-                const next = [created, ...dmChannels.filter((c) => c.id !== created.id)]
+                const next = upsertDmChannel(currentChannels, created)
+                currentChannels = next
                 dmIds = next.map((c) => c.id)
                 setDmChannels(next)
                 setDmChannelIds(dmIds)
@@ -462,7 +466,11 @@ export default function AppShell() {
               unreadHandled = true
             }
 
-            const nextChannels = [channel, ...dmChannels.filter((c) => c.id !== channel.id)]
+            const nextChannels = touchDmChannelActivity(
+              currentChannels,
+              channel.id,
+              incomingMessage?.created_at ?? new Date().toISOString(),
+            )
             setDmChannels(nextChannels)
             setDmChannelIds(nextChannels.map((c) => c.id))
 

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -22,6 +22,7 @@ const apiMocks = vi.hoisted(() => ({
   listDmChannels: vi.fn(),
   getOrCreateDmChannel: vi.fn(),
   hideDmChannel: vi.fn(),
+  updateDmChannelPreferences: vi.fn(),
   listDmMessages: vi.fn(),
   markDmRead: vi.fn(),
   listDmPins: vi.fn(),
@@ -39,6 +40,7 @@ vi.mock('../api', () => ({
     listChannels: apiMocks.listDmChannels,
     getOrCreateChannel: apiMocks.getOrCreateDmChannel,
     hideChannel: apiMocks.hideDmChannel,
+    updateChannelPreferences: apiMocks.updateDmChannelPreferences,
     listMessages: apiMocks.listDmMessages,
     markRead: apiMocks.markDmRead,
     listPins: apiMocks.listDmPins,
@@ -97,6 +99,8 @@ function dmChannel(id: string, peerId = 'friend-cilo', peerUsername = 'cilo'): D
     peer_status: 'online',
     last_message_at: null,
     unread_count: 0,
+    pinned_at: null,
+    is_pinned: false,
   }
 }
 
@@ -161,6 +165,7 @@ describe('HomePage friends list', () => {
     apiMocks.markDmRead.mockResolvedValue(undefined)
     apiMocks.listDmPins.mockResolvedValue([])
     apiMocks.hideDmChannel.mockResolvedValue(undefined)
+    apiMocks.updateDmChannelPreferences.mockResolvedValue({ pinned: true })
   })
 
   it('opens a DM when a friend row is selected', async () => {
@@ -222,6 +227,35 @@ describe('HomePage friends list', () => {
       expect(useAppStore.getState().dmChannelIds).toEqual([])
     })
     expect(screen.queryByRole('button', { name: 'Hide DM with cilo' })).toBeNull()
+  })
+
+  it('pins and unpins a DM using the persisted channel preference endpoint', async () => {
+    const older = { ...dmChannel('dm-older', 'friend-older', 'older'), last_message_at: '2026-01-01T00:00:00.000Z' }
+    const recent = { ...dmChannel('dm-recent', 'friend-recent', 'recent'), last_message_at: '2026-02-01T00:00:00.000Z' }
+    apiMocks.listDmChannels.mockResolvedValue([recent, older])
+
+    renderHomePage()
+
+    const olderDmRow = (await screen.findByRole('button', { name: 'Open DM with older' })).closest('.social-dm-item')
+    expect(olderDmRow).not.toBeNull()
+    fireEvent.contextMenu(olderDmRow!)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Pin Conversation' }))
+
+    await waitFor(() => {
+      expect(apiMocks.updateDmChannelPreferences).toHaveBeenCalledWith(older.id, true, null)
+      expect(useAppStore.getState().dmChannels[0]).toMatchObject({ id: older.id, is_pinned: true })
+    })
+
+    apiMocks.updateDmChannelPreferences.mockResolvedValue({ pinned: false })
+    const pinnedDmRow = screen.getByRole('button', { name: 'Open DM with older' }).closest('.social-dm-item')
+    expect(pinnedDmRow).not.toBeNull()
+    fireEvent.contextMenu(pinnedDmRow!)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Unpin Conversation' }))
+
+    await waitFor(() => {
+      expect(apiMocks.updateDmChannelPreferences).toHaveBeenLastCalledWith(older.id, false, null)
+      expect(useAppStore.getState().dmChannels.map((channel) => channel.id)).toEqual([recent.id, older.id])
+    })
   })
 
   it('shows cached social data without waiting for the server list refresh', async () => {

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate } from 'react-router'
-import { Activity, ArrowRight, Check, Coffee, Compass, Github, Inbox, MessageCircle, MessageSquarePlus, Send, UserMinus, Users, X } from 'lucide-react'
+import { Activity, ArrowRight, Check, Coffee, Compass, Github, Inbox, MessageCircle, MessageSquarePlus, Pin, Send, UserMinus, Users, X } from 'lucide-react'
 import {
   attachmentApi,
   dmApi,
@@ -38,6 +38,8 @@ import {
   type FriendsFilter,
   getVisibleFriendsForFilter,
   normalizePresence,
+  sortDmChannels,
+  touchDmChannelActivity,
   upsertDmChannel,
 } from '../friendsList'
 import {
@@ -157,6 +159,8 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [removeFriendTarget, setRemoveFriendTarget] = useState<Friend | null>(null)
   const [removingFriend, setRemovingFriend] = useState(false)
   const [openingDmPeerId, setOpeningDmPeerId] = useState<string | null>(null)
+  const [updatingDmPreferenceId, setUpdatingDmPreferenceId] = useState<string | null>(null)
+  const [dmContextMenu, setDmContextMenu] = useState<{ channelId: string; x: number; y: number } | null>(null)
   const isMobileSocialSidebarOpen = mobileSidebarPanel === 'social'
   const friends = storeFriends
   const dmChannels = storeDmChannels
@@ -218,6 +222,24 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const pushToast = useToastStore((s) => s.pushToast)
   useEffect(() => { activeDmChannelIdRef.current = activeDmChannelId }, [activeDmChannelId])
   useEffect(() => { isDmConversationVisibleRef.current = isDmConversationVisible }, [isDmConversationVisible])
+
+  useEffect(() => {
+    if (!dmContextMenu) return
+    const closeMenu = () => setDmContextMenu(null)
+    const closeMenuOnKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenu()
+    }
+    window.addEventListener('click', closeMenu)
+    window.addEventListener('scroll', closeMenu, true)
+    window.addEventListener('resize', closeMenu)
+    window.addEventListener('keydown', closeMenuOnKey)
+    return () => {
+      window.removeEventListener('click', closeMenu)
+      window.removeEventListener('scroll', closeMenu, true)
+      window.removeEventListener('resize', closeMenu)
+      window.removeEventListener('keydown', closeMenuOnKey)
+    }
+  }, [dmContextMenu])
 
   const rememberDmMessages = useCallback((channelId: string, messages: UiDmMessage[]) => {
     dmMessagesByChannelRef.current[channelId] = messages
@@ -658,6 +680,57 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     }
   }
 
+  const handleToggleDmPinned = useCallback(async (channelId: string, pinned: boolean) => {
+    if (!user || updatingDmPreferenceId) return
+    const previousChannels = useAppStore.getState().dmChannels
+    const nextChannels = sortDmChannels(
+      previousChannels.map((channel) =>
+        channel.id === channelId
+          ? { ...channel, is_pinned: pinned, pinned_at: pinned ? new Date().toISOString() : null }
+          : channel,
+      ),
+    )
+    setUpdatingDmPreferenceId(channelId)
+    setStoreDmChannels(nextChannels)
+    try {
+      await dmApi.updateChannelPreferences(channelId, pinned, token)
+    } catch (err) {
+      setStoreDmChannels(previousChannels)
+      pushToast({
+        level: 'error',
+        title: pinned ? 'Pin failed' : 'Unpin failed',
+        message: err instanceof Error ? err.message : 'Could not update this conversation.',
+      })
+    } finally {
+      setUpdatingDmPreferenceId(null)
+    }
+  }, [pushToast, setStoreDmChannels, token, updatingDmPreferenceId, user])
+
+  const handleHideDmChannel = useCallback(async (channelId: string) => {
+    const previousChannels = useAppStore.getState().dmChannels
+    const nextChannels = previousChannels.filter((channel) => channel.id !== channelId)
+    setDmContextMenu(null)
+    setStoreDmChannels(nextChannels)
+    setDmChannelIds(nextChannels.map((channel) => channel.id))
+    if (activeDmChannelId === channelId) {
+      setView('friends')
+      setActiveDmChannelId(null)
+      setPersistedSocialView('friends')
+      navigate(ROUTES.home)
+    }
+    try {
+      await dmApi.hideChannel(channelId, token)
+    } catch (err) {
+      setStoreDmChannels(previousChannels)
+      setDmChannelIds(previousChannels.map((channel) => channel.id))
+      pushToast({
+        level: 'error',
+        title: 'DM hide failed',
+        message: err instanceof Error ? err.message : 'Could not hide this conversation.',
+      })
+    }
+  }, [activeDmChannelId, navigate, pushToast, setActiveDmChannelId, setDmChannelIds, setStoreDmChannels, token])
+
   const handleDmAttachmentPick = async (files: FileList | null) => {
     if (!files) return
     const incoming = Array.from(files)
@@ -781,6 +854,9 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     try {
       const msg = await dmApi.sendMessage(channelId, content, attachmentsToSend, token, clientId)
       clearDmUnread(channelId)
+      setStoreDmChannels(
+        touchDmChannelActivity(useAppStore.getState().dmChannels, channelId, msg.created_at),
+      )
       const applySentDm = (current: UiDmMessage[]) => {
         return reconcileConfirmedMessage(current, clientId, msg)
       }
@@ -962,80 +1038,74 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
             </span>
           </div>
         ) : (
-          dmChannels.map((channel) => (
-            <button
-              key={channel.id}
-              type="button"
+          dmChannels.map((channel, index) => (
+            <Fragment key={channel.id}>
+              {channel.is_pinned && (index === 0 || !dmChannels[index - 1]?.is_pinned) && (
+                <div className="social-dm-group-label">Pinned</div>
+              )}
+              {!channel.is_pinned && index > 0 && dmChannels[index - 1]?.is_pinned && (
+                <div className="social-dm-group-label">Recent</div>
+              )}
+            <div
               className={`social-dm-item ${view === 'dm' && activeDmChannelId === channel.id ? 'active' : ''}`}
               onPointerEnter={() => prefetchDmConversation(channel.id)}
-              onFocus={() => prefetchDmConversation(channel.id)}
-              onClick={(e) => {
-                ; (e.currentTarget as HTMLButtonElement).blur()
-                const cached = cachedDmMessages(channel.id)
-                setDmMessages(cached ?? [])
-                setDmConversationReady(!!cached)
-                setView('dm')
-                setActiveDmChannelId(channel.id)
-                setPersistedSocialView('dm')
-                clearDmUnread(channel.id)
-                if (location.pathname !== ROUTES.dm) navigate(ROUTES.dm)
-                setMobileSidebarPanel('none')
+              onContextMenu={(event) => {
+                event.preventDefault()
+                const rect = event.currentTarget.getBoundingClientRect()
+                const menuWidth = 196
+                const menuHeight = 82
+                const requestedX = event.clientX || rect.right
+                const requestedY = event.clientY || rect.bottom
+                setDmContextMenu({
+                  channelId: channel.id,
+                  x: Math.min(Math.max(8, requestedX), Math.max(8, window.innerWidth - menuWidth - 8)),
+                  y: Math.min(Math.max(8, requestedY), Math.max(8, window.innerHeight - menuHeight - 8)),
+                })
               }}
             >
-              <div className={`home-member-avatar avatar-status-${(channel.peer_status ?? 'offline') as StatusValue}`}>
-                {channel.peer_avatar_url ? (
-                  <img src={resolveAvatarUrl(channel.peer_avatar_url) ?? ''} alt="" />
-                ) : (
-                  channel.peer_username.charAt(0).toUpperCase()
-                )}
-              </div>
-              <div className="home-member-meta">
-                <div>{channel.peer_username}</div>
-              </div>
+              <button
+                type="button"
+                className="social-dm-open"
+                onFocus={() => prefetchDmConversation(channel.id)}
+                onClick={(e) => {
+                  e.currentTarget.blur()
+                  const cached = cachedDmMessages(channel.id)
+                  setDmMessages(cached ?? [])
+                  setDmConversationReady(!!cached)
+                  setView('dm')
+                  setActiveDmChannelId(channel.id)
+                  setPersistedSocialView('dm')
+                  clearDmUnread(channel.id)
+                  if (location.pathname !== ROUTES.dm) navigate(ROUTES.dm)
+                  setMobileSidebarPanel('none')
+                }}
+                aria-label={`Open DM with ${channel.peer_username}`}
+              >
+                <div className={`home-member-avatar avatar-status-${(channel.peer_status ?? 'offline') as StatusValue}`}>
+                  {channel.peer_avatar_url ? (
+                    <img src={resolveAvatarUrl(channel.peer_avatar_url) ?? ''} alt="" />
+                  ) : (
+                    channel.peer_username.charAt(0).toUpperCase()
+                  )}
+                </div>
+                <div className="home-member-meta">
+                  <div>{channel.peer_username}</div>
+                </div>
+              </button>
               <div className="social-dm-actions">
                 {(dmUnread[channel.id] ?? 0) > 0 && <span className="social-dm-unread">{formatBadgeCount(dmUnread[channel.id] ?? 0)}</span>}
-                <div
-                  role="button"
-                  tabIndex={0}
-                  className="home-member-action"
+                <button
+                  type="button"
+                  className="home-member-action social-dm-close"
                   title="Hide conversation"
                   aria-label={`Hide DM with ${channel.peer_username}`}
-                  onClick={async (e) => {
-                    e.stopPropagation()
-                    const previousChannels = useAppStore.getState().dmChannels
-                    const nextChannels = previousChannels.filter((dmChannel) => dmChannel.id !== channel.id)
-                    setStoreDmChannels(nextChannels)
-                    setDmChannelIds(nextChannels.map((dmChannel) => dmChannel.id))
-                    if (activeDmChannelId === channel.id) {
-                      setView('friends')
-                      setActiveDmChannelId(null)
-                      setPersistedSocialView('friends')
-                      navigate(ROUTES.home)
-                    }
-                    try {
-                      await dmApi.hideChannel(channel.id, token)
-                    } catch (err) {
-                      setStoreDmChannels(previousChannels)
-                      setDmChannelIds(previousChannels.map((dmChannel) => dmChannel.id))
-                      pushToast({
-                        level: 'error',
-                        title: 'DM hide failed',
-                        message: err instanceof Error ? err.message : 'Could not hide this conversation.',
-                      })
-                    }
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      e.currentTarget.click()
-                    }
-                  }}
+                  onClick={() => void handleHideDmChannel(channel.id)}
                 >
-                  <X size={14} />
-                </div>
+                  <X size={12} />
+                </button>
               </div>
-            </button>
+            </div>
+            </Fragment>
           ))
         )}
 
@@ -1377,6 +1447,44 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
           })()}
         </div>
       </section>
+
+      {dmContextMenu && (() => {
+        const channel = dmChannels.find((candidate) => candidate.id === dmContextMenu.channelId)
+        if (!channel) return null
+        return createPortal(
+          <div
+            className="server-context-menu social-dm-context-menu"
+            role="menu"
+            aria-label={`Conversation actions for ${channel.peer_username}`}
+            style={{ left: dmContextMenu.x, top: dmContextMenu.y }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="server-context-menu-item"
+              role="menuitem"
+              disabled={updatingDmPreferenceId === channel.id}
+              onClick={() => {
+                setDmContextMenu(null)
+                void handleToggleDmPinned(channel.id, !channel.is_pinned)
+              }}
+            >
+              <Pin size={14} />
+              {channel.is_pinned ? 'Unpin Conversation' : 'Pin Conversation'}
+            </button>
+            <button
+              type="button"
+              className="server-context-menu-item danger"
+              role="menuitem"
+              onClick={() => void handleHideDmChannel(channel.id)}
+            >
+              <X size={14} />
+              Close DM
+            </button>
+          </div>,
+          document.body,
+        )
+      })()}
 
       {removeFriendTarget && createPortal(
         <div className="modal-overlay" onClick={() => !removingFriend && setRemoveFriendTarget(null)}>

--- a/apps/web/src/stores/app.test.ts
+++ b/apps/web/src/stores/app.test.ts
@@ -11,6 +11,8 @@ function dmChannel(id: string, unread_count: number): DmChannel {
         peer_status: 'online',
         last_message_at: null,
         unread_count,
+        pinned_at: null,
+        is_pinned: false,
     }
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -239,12 +239,15 @@ Notes:
 ## Direct Message Endpoints
 
 - `GET /api/dm/channels`
-  - Returns visible DM channel metadata including `unread_count`, the server-derived unread count for the current user.
-  - Channels hidden by the current user are excluded unless they have unread messages.
+  - Returns visible DM channel metadata including `unread_count`, `last_message_at`, and the per-user `is_pinned` / `pinned_at` preference.
+  - Pinned conversations are returned first; pinned and unpinned groups are each ordered by latest message activity.
+  - Channels hidden by the current user are excluded until explicitly reopened or a message newer than the hide action arrives.
 - `POST /api/dm/channels/:peer_id`
   - Opens or creates a DM channel with the peer and restores it if the current user had hidden it.
 - `POST /api/dm/channels/:channel_id/hide`
-  - Hides the channel from the current user's DM list without deleting messages or hiding it for the peer.
+  - Hides and unpins the channel for the current user without deleting messages or hiding it for the peer.
+- `PATCH /api/dm/channels/:channel_id/preferences`
+  - Accepts `{ "pinned": true|false }`, persists the preference for the current user, and restores a hidden DM when pinning it.
 - `GET /api/dm/messages/:channel_id?before=<uuid>&limit=<n>`
 - `GET /api/dm/messages/:channel_id/search?q=<term>&from=<username>&has_attachment=<bool>&limit=<n>`
   - `from` filters by message author username.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -129,9 +129,11 @@ Uniqueness (case-insensitive):
 
 ### `dm_channel_members`
 
-- `channel_id`, `user_id`, `joined_at`, `hidden_at`
+- `channel_id`, `user_id`, `joined_at`, `hidden_at`, `pinned_at`
 - `hidden_at` stores whether that specific user has hidden the DM from their sidebar.
-- Hidden DMs remain intact and are shown again when reopened or when unread messages need attention.
+- `pinned_at` stores that user's pinned-conversation preference; it is not shared with the peer.
+- Hidden DMs remain intact and return only when explicitly reopened or when a message newer than `hidden_at` arrives. Hiding a DM also clears its pin.
+- DM lists put pinned conversations first, then order each group by latest message activity.
 
 ### `dm_messages`
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -71,6 +71,8 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Raid protection records message bursts, invite spikes, and join burst signals in audit/moderation activity without exposing private secrets.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
 - [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
+- [ ] DM pins persist across refresh/login, pinned conversations stay above activity-sorted unpinned DMs, and a hidden DM returns only after explicit reopen or new message activity.
+- [ ] Channel managers can create channels from the compact header menu, a category `+`, and the category context menu; non-managers see none of these controls.
 - [ ] Login and registration do not open a native notification permission prompt; the delayed in-app prompt requests permission only after the user selects `Enable`, and `Not now` suppresses it during the snooze window.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.


### PR DESCRIPTION
## Summary

- persist per-user DM pin preferences across sessions and clients
- order unpinned conversations by latest message activity
- keep pinned conversations stable above recent DMs
- reopen hidden DMs only after explicit access or new activity
- move DM pin/unpin actions into a compact context menu
- reduce DM row action clutter and preserve username space
- replace persistent channel creation buttons with category-level and context-menu actions
- keep only the server settings control in the sidebar header
- enforce channel management permissions across creation controls
- update API, database, README, and release smoke documentation
- remove the Star History section from README

## Validation

- `cargo check --locked`
- `cargo test --locked`
- `npm run lint`
- `npm run test:run` — 214 tests passed
- `npm run build`
- `git diff --check`