### PR TITLE
feat: simplify appearance and add feedback dock

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Voxpery is strongest when you want a smaller, inspectable, self-hostable communi
 - **Friends & social** - Add friends, see status, mutual presence
 - **Fast navigation** - Quick switcher for server, channel, and DM jumps
 - **Reactions & attachments** - Emoji reactions, uploads, signed attachment access
+- **Personal appearance** - Ready-made themes plus a simple custom color that generates a contrast-safe palette
+- **Direct feedback** - Bug reports and feature requests open the repository's matching GitHub issue template from web or desktop
 
 ### Security & Privacy
 - **Secure auth defaults** - JWT + Argon2id, httpOnly cookies, Google OAuth support

--- a/apps/web/e2e/core-ui-smoke.spec.ts
+++ b/apps/web/e2e/core-ui-smoke.spec.ts
@@ -113,6 +113,7 @@ test.describe('mocked core UI smoke', () => {
     await expect(page.locator('.channel-header-title')).toHaveText('Core Guild')
     await expect(page.locator('.chat-header .channel-title')).toHaveText('general')
     await expect(page.getByText('Pinned release note')).toBeVisible()
+    await expect(page.locator('.feedback-dock .feedback-card').getByRole('heading', { name: 'Share feedback' })).toBeVisible()
 
     const content = `Server smoke message ${Date.now()}`
     const messageInput = page.getByPlaceholder('Message #general')

--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -26,8 +26,21 @@ test.describe('mocked mobile web smoke', () => {
     const modal = page.locator('.user-settings-modal')
     await expect(modal.getByRole('heading', { name: 'Appearance' })).toBeVisible()
     await expectNoHorizontalOverflow(modal)
-    await modal.getByRole('button', { name: /Rose/ }).click()
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'rose')
+    await modal.locator('.theme-option', { hasText: 'Dark' }).click()
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+
+    await modal.getByRole('button', { name: /Custom/ }).click()
+    const customThemeInput = modal.getByRole('textbox', { name: 'Custom theme hex color' })
+    await customThemeInput.fill('#c9578f')
+    await customThemeInput.press('Enter')
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme', 'true')
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme-mode', 'dark')
+    await expect(modal.getByText('Background style', { exact: true })).toHaveCount(0)
+    await expectNoHorizontalOverflow(modal)
+
+    await page.reload()
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme', 'true')
+    await expect(page.locator('.feedback-dock')).not.toBeVisible()
   })
 
   test('keeps Social friends, requests, and DM entry usable on a phone viewport', async ({ page }) => {

--- a/apps/web/e2e/release-settings-core-regressions.spec.ts
+++ b/apps/web/e2e/release-settings-core-regressions.spec.ts
@@ -42,7 +42,7 @@ test.describe('mocked release and settings regressions', () => {
     await expect(modal.getByText('Benchmark diagnostics', { exact: true })).toHaveCount(0)
   })
 
-  test('persists theme and accent preferences without layout overflow', async ({ page }) => {
+  test('switches built-in themes and resets appearance defaults without layout overflow', async ({ page }) => {
     const state = createMockCoreState({ friends: buildFriends(2) })
     await installMockCoreApi(page, state)
     await page.setViewportSize({ width: 1366, height: 768 })
@@ -53,38 +53,98 @@ test.describe('mocked release and settings regressions', () => {
 
     const modal = page.locator('.user-settings-modal')
     await expect(modal.getByRole('heading', { name: 'Appearance' })).toBeVisible()
-    await modal.getByRole('button', { name: /Rose/ }).click()
+    await modal.locator('.theme-option', { hasText: 'Dark' }).click()
     await page.evaluate(() => {
       const probe = document.createElement('button')
       probe.className = 'chat-jump-to-latest theme-contract-probe'
       probe.textContent = 'Newest'
       document.body.appendChild(probe)
     })
-    const roseTheme = await readAppearanceThemeSnapshot(page)
+    const darkTheme = await readAppearanceThemeSnapshot(page)
 
-    await modal.getByRole('button', { name: /Light/ }).click()
+    await modal.locator('.theme-option', { hasText: 'Light' }).click()
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
     const lightTheme = await readAppearanceThemeSnapshot(page)
 
-    expect(roseTheme.modalSurface).not.toBe(lightTheme.modalSurface)
-    expect(roseTheme.activeSettingsNavigation).not.toBe(lightTheme.activeSettingsNavigation)
-    expect(roseTheme.serverActions).not.toBe(lightTheme.serverActions)
-    expect(roseTheme.releaseBadge).not.toBe(lightTheme.releaseBadge)
-    expect(roseTheme.jumpToLatest).not.toBe(lightTheme.jumpToLatest)
+    expect(darkTheme.modalSurface).not.toBe(lightTheme.modalSurface)
+    expect(darkTheme.activeSettingsNavigation).not.toBe(lightTheme.activeSettingsNavigation)
+    expect(darkTheme.serverActions).not.toBe(lightTheme.serverActions)
+    expect(darkTheme.releaseBadge).not.toBe(lightTheme.releaseBadge)
+    expect(darkTheme.jumpToLatest).not.toBe(lightTheme.jumpToLatest)
     await expect.poll(async () => {
       return page.locator('.server-sidebar-actions').evaluate((element) => getComputedStyle(element).backgroundImage)
     }).toContain('rgb(232, 235, 240)')
 
-    const accentInput = modal.getByRole('textbox', { name: 'Custom accent hex color' })
-    await accentInput.fill('#2d8f70')
-    await accentInput.press('Enter')
-    await expect(page.locator('html')).toHaveAttribute('data-custom-accent', 'true')
     await expectNoHorizontalOverflow(modal)
 
+    await modal.getByRole('button', { name: 'Reset defaults' }).click()
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'voxpery')
+    await expect(modal.getByRole('button', { name: 'Reset defaults' })).toBeDisabled()
+
     await page.reload()
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
-    await expect(page.locator('html')).toHaveCSS('--user-accent', '#2d8f70')
-    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(244, 246, 248)')
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'voxpery')
+    await expect(page.locator('html')).not.toHaveAttribute('data-custom-accent', 'true')
+  })
+
+  test('persists a generated full theme from one custom color', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(2) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('button', { name: 'Appearance' }).click()
+
+    const modal = page.locator('.user-settings-modal')
+    const themeGroup = modal.getByRole('group', { name: 'Theme' })
+    await expect(themeGroup.locator('.theme-option')).toHaveCount(4)
+    await expect(themeGroup.getByRole('button', { name: /Default/ })).toBeVisible()
+    await expect(themeGroup.getByRole('button', { name: /Dark/ })).toBeVisible()
+    await expect(themeGroup.getByRole('button', { name: /Light/ })).toBeVisible()
+    await expect(themeGroup.getByRole('button', { name: /Custom/ })).toBeVisible()
+    await expect(modal.locator('.theme-custom-panel')).toHaveCount(0)
+    await modal.getByRole('button', { name: /Custom/ }).click()
+    await expect(modal.locator('.theme-custom-panel')).toBeVisible()
+    const customThemeInput = modal.getByRole('textbox', { name: 'Custom theme hex color' })
+    await customThemeInput.fill('#7b3fc6')
+    await customThemeInput.press('Enter')
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme', 'true')
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme-mode', 'dark')
+    await expect(modal.getByText('Choose your color', { exact: true })).toBeVisible()
+    await expect(modal.getByText('Background style', { exact: true })).toHaveCount(0)
+    await expect(modal.getByRole('textbox', { name: 'Custom accent hex color' })).toHaveCount(0)
+    await expectNoHorizontalOverflow(modal)
+
+    const generatedBackground = await page.locator('html').evaluate((element) => (
+      getComputedStyle(element).getPropertyValue('--user-theme-bg-primary').trim()
+    ))
+    expect(generatedBackground).toMatch(/^#[0-9a-f]{6}$/)
+
+    await page.reload()
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme', 'true')
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme-mode', 'dark')
+    await expect(page.locator('html')).toHaveCSS('--user-theme-bg-primary', generatedBackground)
+  })
+
+  test('shows feedback entry points on Social without replacing conversation content', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(2) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+
+    const feedbackCard = page.locator('.feedback-dock .feedback-card')
+    await expect(feedbackCard.getByRole('heading', { name: 'Share feedback' })).toBeVisible()
+    await expect(feedbackCard.getByRole('button', { name: 'Report a bug' })).toBeVisible()
+    await expect(feedbackCard.getByRole('button', { name: 'Request a feature' })).toBeVisible()
+    await expect(page.locator('.home-side .feedback-card')).toHaveCount(0)
+
+    const dockBox = await page.locator('.feedback-dock').boundingBox()
+    expect(dockBox).not.toBeNull()
+    expect(dockBox?.width).toBe(240)
+    expect(dockBox?.height).toBe(80)
+    expect(dockBox?.x).toBe(1126)
+    expect(dockBox?.y).toBe(688)
   })
 
   test('keeps profile password modal validation and submission wired', async ({ page }) => {

--- a/apps/web/e2e/server-settings-core-regressions.spec.ts
+++ b/apps/web/e2e/server-settings-core-regressions.spec.ts
@@ -44,41 +44,41 @@ test.describe('mocked server settings UI regressions', () => {
   test('keeps member profile popout aligned with the active theme', async ({ page }) => {
     const state = createServerSettingsState()
     await installMockCoreApi(page, state)
-    await page.addInitScript(() => localStorage.setItem('voxpery-settings-theme', 'rose'))
+    await page.addInitScript(() => localStorage.setItem('voxpery-settings-theme', 'dark'))
 
     await page.goto('/servers')
     await page.locator('.member-item', { hasText: 'Friend 01' }).click()
     const popout = page.locator('.member-profile-popout')
     await expect(popout).toBeVisible()
 
-    const rose = await readMemberProfileThemeSnapshot(popout)
+    const dark = await readMemberProfileThemeSnapshot(popout)
     await page.evaluate(() => { document.documentElement.dataset.theme = 'light' })
     const light = await readMemberProfileThemeSnapshot(popout)
 
-    expect(rose.popoutBackground).not.toBe(light.popoutBackground)
-    expect(rose.sectionBackground).not.toBe(light.sectionBackground)
-    expect(rose.badgeBackground).not.toBe(light.badgeBackground)
-    expect(rose.popoutBorder).not.toBe(light.popoutBorder)
+    expect(dark.popoutBackground).not.toBe(light.popoutBackground)
+    expect(dark.sectionBackground).not.toBe(light.sectionBackground)
+    expect(dark.badgeBackground).not.toBe(light.badgeBackground)
+    expect(dark.popoutBorder).not.toBe(light.popoutBorder)
   })
 
   test('keeps server settings surfaces aligned with the active theme', async ({ page }) => {
     const state = createServerSettingsState()
     await installMockCoreApi(page, state)
-    await page.addInitScript(() => localStorage.setItem('voxpery-settings-theme', 'rose'))
+    await page.addInitScript(() => localStorage.setItem('voxpery-settings-theme', 'dark'))
 
     await openServerSettings(page)
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'rose')
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
 
     const modal = page.locator('.modal-server-settings')
-    const rose = await readSettingsThemeSnapshot(modal)
+    const dark = await readSettingsThemeSnapshot(modal)
     await page.evaluate(() => { document.documentElement.dataset.theme = 'light' })
     const light = await readSettingsThemeSnapshot(modal)
 
-    expect(rose.overlayBackground).not.toBe(light.overlayBackground)
-    expect(rose.modalBackground).not.toBe(light.modalBackground)
-    expect(rose.navigationBackground).not.toBe(light.navigationBackground)
-    expect(rose.activeNavigationBackground).not.toBe(light.activeNavigationBackground)
-    expect(rose.inputBackground).not.toBe(light.inputBackground)
+    expect(dark.overlayBackground).not.toBe(light.overlayBackground)
+    expect(dark.modalBackground).not.toBe(light.modalBackground)
+    expect(dark.navigationBackground).not.toBe(light.navigationBackground)
+    expect(dark.activeNavigationBackground).not.toBe(light.activeNavigationBackground)
+    expect(dark.inputBackground).not.toBe(light.inputBackground)
   })
 
   test('opens server settings and saves overview profile changes', async ({ page }) => {

--- a/apps/web/src/components/FeedbackCard.test.tsx
+++ b/apps/web/src/components/FeedbackCard.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { openExternalUrl } from '../openExternalUrl'
+import FeedbackCard, { BUG_REPORT_URL, FEATURE_REQUEST_URL } from './FeedbackCard'
+
+vi.mock('../openExternalUrl', () => ({
+  openExternalUrl: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('FeedbackCard', () => {
+  beforeEach(() => {
+    vi.mocked(openExternalUrl).mockClear()
+  })
+
+  it('opens the repository bug report template', () => {
+    render(<FeedbackCard />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Report a bug' }))
+
+    expect(openExternalUrl).toHaveBeenCalledWith(BUG_REPORT_URL)
+  })
+
+  it('opens the repository feature request template', () => {
+    render(<FeedbackCard />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Request a feature' }))
+
+    expect(openExternalUrl).toHaveBeenCalledWith(FEATURE_REQUEST_URL)
+  })
+})

--- a/apps/web/src/components/FeedbackCard.tsx
+++ b/apps/web/src/components/FeedbackCard.tsx
@@ -1,0 +1,26 @@
+import { Bug, Lightbulb, MessageSquarePlus } from 'lucide-react'
+import { openExternalUrl } from '../openExternalUrl'
+
+export const BUG_REPORT_URL = 'https://github.com/emircanagac/voxpery/issues/new?template=bug.md'
+export const FEATURE_REQUEST_URL = 'https://github.com/emircanagac/voxpery/issues/new?template=feature.md'
+
+export default function FeedbackCard() {
+  return (
+    <section className="feedback-card" aria-labelledby="app-feedback-title">
+      <div className="feedback-card-heading">
+        <MessageSquarePlus size={15} aria-hidden="true" />
+        <h2 id="app-feedback-title">Share feedback</h2>
+      </div>
+      <div className="feedback-card-actions">
+        <button type="button" onClick={() => void openExternalUrl(BUG_REPORT_URL)}>
+          <Bug size={14} aria-hidden="true" />
+          Report a bug
+        </button>
+        <button type="button" onClick={() => void openExternalUrl(FEATURE_REQUEST_URL)}>
+          <Lightbulb size={14} aria-hidden="true" />
+          Request a feature
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/ThemeSettings.test.tsx
+++ b/apps/web/src/components/ThemeSettings.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   THEME_ACCENT_STORAGE_KEY,
+  THEME_CUSTOM_COLOR_STORAGE_KEY,
   THEME_STORAGE_KEY,
 } from '../theme'
 import ThemeSettings from './ThemeSettings'
@@ -11,6 +12,8 @@ describe('ThemeSettings', () => {
     localStorage.clear()
     document.documentElement.removeAttribute('data-theme')
     document.documentElement.removeAttribute('data-custom-accent')
+    document.documentElement.removeAttribute('data-custom-theme')
+    document.documentElement.removeAttribute('data-custom-theme-mode')
     document.documentElement.removeAttribute('style')
     document.head.innerHTML = '<meta name="theme-color" content="#16213e">'
   })
@@ -18,29 +21,49 @@ describe('ThemeSettings', () => {
   it('changes and persists the active theme', () => {
     render(<ThemeSettings />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Rose/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Dark/ }))
 
-    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('rose')
-    expect(document.documentElement.dataset.theme).toBe('rose')
-    expect(screen.getByRole('button', { name: /Rose/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(screen.getByRole('button', { name: /Dark/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /Default/ })).toBeVisible()
+    expect(screen.getByRole('button', { name: /Custom/ })).toBeVisible()
   })
 
-  it('validates, applies, and resets a custom accent', () => {
+  it('resets every appearance preference to the Voxpery default', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    localStorage.setItem(THEME_ACCENT_STORAGE_KEY, '#2d8f70')
+    localStorage.setItem(THEME_CUSTOM_COLOR_STORAGE_KEY, '#7b3fc6')
     render(<ThemeSettings />)
-    const input = screen.getByRole('textbox', { name: 'Custom accent hex color' })
 
-    fireEvent.change(input, { target: { value: '#12' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Reset defaults' }))
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('voxpery')
+    expect(localStorage.getItem(THEME_ACCENT_STORAGE_KEY)).toBeNull()
+    expect(localStorage.getItem(THEME_CUSTOM_COLOR_STORAGE_KEY)).toBeNull()
+    expect(document.documentElement.dataset.theme).toBe('voxpery')
+    expect(document.documentElement.dataset.customAccent).toBeUndefined()
+    expect(document.documentElement.dataset.customTheme).toBeUndefined()
+    expect(screen.getByRole('button', { name: 'Reset defaults' })).toBeDisabled()
+  })
+
+  it('builds and persists a readable custom theme from one color', () => {
+    render(<ThemeSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /Custom/ }))
+    const input = screen.getByRole('textbox', { name: 'Custom theme hex color' })
+    const initialCustomColor = localStorage.getItem(THEME_CUSTOM_COLOR_STORAGE_KEY)
+
+    fireEvent.change(input, { target: { value: '#zzzzzz' } })
     fireEvent.blur(input)
     expect(screen.getByRole('alert')).toHaveTextContent('six-digit hex color')
-    expect(localStorage.getItem(THEME_ACCENT_STORAGE_KEY)).toBeNull()
+    expect(localStorage.getItem(THEME_CUSTOM_COLOR_STORAGE_KEY)).toBe(initialCustomColor)
 
-    fireEvent.change(input, { target: { value: '#2d8f70' } })
+    fireEvent.change(input, { target: { value: '#7b3fc6' } })
     fireEvent.keyDown(input, { key: 'Enter' })
-    expect(localStorage.getItem(THEME_ACCENT_STORAGE_KEY)).toBe('#2d8f70')
-    expect(document.documentElement.dataset.customAccent).toBe('true')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Use theme accent' }))
-    expect(localStorage.getItem(THEME_ACCENT_STORAGE_KEY)).toBeNull()
-    expect(document.documentElement.dataset.customAccent).toBeUndefined()
+    expect(localStorage.getItem(THEME_CUSTOM_COLOR_STORAGE_KEY)).toBe('#7b3fc6')
+    expect(document.documentElement.dataset.customTheme).toBe('true')
+    expect(document.documentElement.dataset.customThemeMode).toBe('dark')
+    expect(screen.queryByText('Background style')).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: 'Custom accent hex color' })).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/ThemeSettings.tsx
+++ b/apps/web/src/components/ThemeSettings.tsx
@@ -1,6 +1,8 @@
 import { Check, RotateCcw } from 'lucide-react'
 import { useState, type CSSProperties } from 'react'
 import {
+  createCustomThemePalette,
+  DEFAULT_THEME,
   getStoredThemePreference,
   getThemeOption,
   normalizeHexColor,
@@ -10,13 +12,20 @@ import {
   type ThemePreference,
 } from '../theme'
 
-const ACCENT_SWATCHES = ['#4f7fd8', '#6078d4', '#c9578f', '#2d8f70', '#c56b22', '#7657cf'] as const
+const VISIBLE_THEME_OPTIONS = THEME_OPTIONS.filter((option) => option.id !== 'rose')
 
 export default function ThemeSettings() {
   const [preference, setPreference] = useState<ThemePreference>(() => getStoredThemePreference())
   const activeTheme = getThemeOption(preference.theme)
-  const [accentDraft, setAccentDraft] = useState(preference.customAccent ?? activeTheme.defaultAccent)
-  const [accentError, setAccentError] = useState<string | null>(null)
+  const [themeColorDraft, setThemeColorDraft] = useState(preference.customThemeColor ?? activeTheme.defaultAccent)
+  const [themeColorError, setThemeColorError] = useState<string | null>(null)
+  const customThemePalette = createCustomThemePalette(
+    normalizeHexColor(themeColorDraft) ?? activeTheme.defaultAccent,
+    'dark',
+  )
+  const isDefaultPreference = preference.theme === DEFAULT_THEME
+    && !preference.customThemeColor
+    && !preference.customAccent
 
   const savePreference = (next: ThemePreference) => {
     const saved = setThemePreference(next)
@@ -25,37 +34,68 @@ export default function ThemeSettings() {
   }
 
   const selectTheme = (theme: ThemeId) => {
-    const saved = savePreference({ ...preference, theme })
-    if (!saved.customAccent) setAccentDraft(getThemeOption(theme).defaultAccent)
+    const nextTheme = getThemeOption(theme)
+    const saved = savePreference({
+      ...preference,
+      theme,
+      customAccent: null,
+      customThemeColor: null,
+      customThemeMode: nextTheme.colorScheme,
+    })
+    setThemeColorError(null)
+    setThemeColorDraft(nextTheme.defaultAccent)
+    return saved
   }
 
-  const selectAccent = (accent: string) => {
-    const normalized = normalizeHexColor(accent)
+  const selectCustomThemeColor = (color: string) => {
+    const normalized = normalizeHexColor(color)
     if (!normalized) {
-      setAccentError('Enter a six-digit hex color such as #4f7fd8.')
+      setThemeColorError('Enter a six-digit hex color such as #4f7fd8.')
       return
     }
-    setAccentError(null)
-    setAccentDraft(normalized)
-    savePreference({ ...preference, customAccent: normalized })
+    setThemeColorError(null)
+    setThemeColorDraft(normalized)
+    savePreference({
+      ...preference,
+      customAccent: null,
+      customThemeColor: normalized,
+      customThemeMode: 'dark',
+    })
   }
 
-  const resetAccent = () => {
-    setAccentError(null)
-    setAccentDraft(activeTheme.defaultAccent)
-    savePreference({ ...preference, customAccent: null })
+  const resetDefaults = () => {
+    const defaultTheme = getThemeOption(DEFAULT_THEME)
+    setThemeColorError(null)
+    setThemeColorDraft(defaultTheme.defaultAccent)
+    savePreference({
+      theme: DEFAULT_THEME,
+      customAccent: null,
+      customThemeColor: null,
+      customThemeMode: defaultTheme.colorScheme,
+    })
   }
 
   return (
     <section className="user-settings-section theme-settings" aria-labelledby="appearance-settings-title">
       <h3 className="user-settings-section-title" id="appearance-settings-title">Appearance</h3>
-      <div className="theme-settings-copy">
-        <strong>Theme</strong>
-        <span>Choose a palette for Voxpery on this device.</span>
+      <div className="theme-settings-heading">
+        <div className="theme-settings-copy">
+          <strong>Theme</strong>
+          <span>Choose a ready-made look or create one from a color.</span>
+        </div>
+        <button
+          type="button"
+          className="theme-reset-defaults"
+          onClick={resetDefaults}
+          disabled={isDefaultPreference}
+        >
+          <RotateCcw size={14} aria-hidden />
+          Reset defaults
+        </button>
       </div>
       <div className="theme-option-grid" role="group" aria-label="Theme">
-        {THEME_OPTIONS.map((option) => {
-          const selected = preference.theme === option.id
+        {VISIBLE_THEME_OPTIONS.map((option) => {
+          const selected = !preference.customThemeColor && preference.theme === option.id
           return (
             <button
               key={option.id}
@@ -69,7 +109,7 @@ export default function ThemeSettings() {
                 style={{
                   '--theme-preview-bg': option.backgroundColor,
                   '--theme-preview-surface': option.surfaceColor,
-                  '--theme-preview-accent': preference.customAccent ?? option.defaultAccent,
+                  '--theme-preview-accent': option.defaultAccent,
                   '--theme-preview-text': option.textColor,
                 } as CSSProperties}
                 aria-hidden
@@ -82,7 +122,7 @@ export default function ThemeSettings() {
               </span>
               <span className="theme-option-meta">
                 <span className="theme-option-label">
-                  {option.label}
+                  {option.id === 'voxpery' ? 'Default' : option.label}
                   {selected && <Check size={14} aria-hidden />}
                 </span>
                 <span className="theme-option-description">{option.description}</span>
@@ -90,71 +130,71 @@ export default function ThemeSettings() {
             </button>
           )
         })}
+        <button
+          type="button"
+          className={`theme-option ${preference.customThemeColor ? 'is-selected' : ''}`}
+          onClick={() => selectCustomThemeColor(themeColorDraft)}
+          aria-pressed={Boolean(preference.customThemeColor)}
+        >
+          <span
+            className="theme-option-preview"
+            style={{
+              '--theme-preview-bg': customThemePalette.backgroundColor,
+              '--theme-preview-surface': customThemePalette.surfaceColor,
+              '--theme-preview-accent': customThemePalette.accentColor,
+              '--theme-preview-text': customThemePalette.textColor,
+            } as CSSProperties}
+            aria-hidden
+          >
+            <span className="theme-option-preview-sidebar" />
+            <span className="theme-option-preview-content">
+              <span />
+              <span />
+            </span>
+          </span>
+          <span className="theme-option-meta">
+            <span className="theme-option-label">
+              Custom
+              {preference.customThemeColor && <Check size={14} aria-hidden />}
+            </span>
+            <span className="theme-option-description">Pick one color and Voxpery handles the rest.</span>
+          </span>
+        </button>
       </div>
 
-      <div className="theme-settings-divider" />
-
-      <div className="theme-settings-copy">
-        <strong>Accent color</strong>
-        <span>Use a preset or enter any hex color. Button text adjusts for contrast automatically.</span>
-      </div>
-      <div className="theme-accent-controls">
-        <div className="theme-accent-swatches" role="group" aria-label="Accent presets">
-          {ACCENT_SWATCHES.map((accent) => {
-            const selected = preference.customAccent === accent
-            return (
-              <button
-                key={accent}
-                type="button"
-                className={`theme-accent-swatch ${selected ? 'is-selected' : ''}`}
-                style={{ '--theme-swatch': accent } as CSSProperties}
-                onClick={() => selectAccent(accent)}
-                aria-label={`Use ${accent} accent`}
-                aria-pressed={selected}
-              >
-                {selected && <Check size={13} aria-hidden />}
-              </button>
-            )
-          })}
+      {preference.customThemeColor && <div className="theme-custom-panel is-active" aria-label="Custom theme controls">
+        <div className="theme-custom-panel-copy">
+          <strong>Choose your color</strong>
+          <span>Voxpery automatically creates a readable theme from it.</span>
         </div>
-        <div className="theme-accent-custom">
-          <label className="theme-color-picker" title="Choose accent color">
+        <div className="theme-accent-custom theme-custom-color-controls">
+          <label className="theme-color-picker" title="Choose custom theme color">
             <input
               type="color"
-              value={normalizeHexColor(accentDraft) ?? activeTheme.defaultAccent}
-              onChange={(event) => selectAccent(event.target.value)}
-              aria-label="Choose custom accent color"
+              value={normalizeHexColor(themeColorDraft) ?? activeTheme.defaultAccent}
+              onChange={(event) => selectCustomThemeColor(event.target.value)}
+              aria-label="Choose custom theme color"
             />
           </label>
           <input
-            className={`theme-accent-input ${accentError ? 'is-invalid' : ''}`}
-            value={accentDraft}
-            onChange={(event) => setAccentDraft(event.target.value)}
-            onBlur={() => selectAccent(accentDraft)}
+            className={`theme-accent-input ${themeColorError ? 'is-invalid' : ''}`}
+            value={themeColorDraft}
+            onChange={(event) => setThemeColorDraft(event.target.value)}
+            onBlur={() => selectCustomThemeColor(themeColorDraft)}
             onKeyDown={(event) => {
               if (event.key === 'Enter') {
                 event.preventDefault()
-                selectAccent(accentDraft)
+                selectCustomThemeColor(themeColorDraft)
               }
             }}
-            aria-label="Custom accent hex color"
-            aria-invalid={Boolean(accentError)}
+            aria-label="Custom theme hex color"
+            aria-invalid={Boolean(themeColorError)}
             spellCheck={false}
             maxLength={7}
           />
-          <button
-            type="button"
-            className="theme-accent-reset"
-            onClick={resetAccent}
-            disabled={!preference.customAccent}
-            title="Use theme accent"
-            aria-label="Use theme accent"
-          >
-            <RotateCcw size={15} aria-hidden />
-          </button>
         </div>
-      </div>
-      {accentError && <div className="theme-accent-error" role="alert">{accentError}</div>}
+      </div>}
+      {themeColorError && <div className="theme-accent-error" role="alert">{themeColorError}</div>}
     </section>
   )
 }

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -1,4 +1,4 @@
-import { Settings, Eye, EyeOff, Lock, Download, Trash2, MessageSquare, Mic, Monitor, Shield, User, ChevronsUpDown, Keyboard, LogOut, Palette } from 'lucide-react'
+import { Settings, Eye, EyeOff, Lock, Download, Trash2, MessageSquare, Mic, Monitor, Shield, User, ChevronsUpDown, LogOut, Palette } from 'lucide-react'
 import type { StatusValue } from './StatusIcon'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal, flushSync } from 'react-dom'
@@ -1851,7 +1851,6 @@ export default function UserBar() {
                           }}
                           disabled={globalMuteShortcutSaving}
                         >
-                          <Keyboard size={14} />
                           {capturingGlobalMuteShortcut ? 'Press keys…' : globalMuteShortcut ? 'Rebind' : 'Set shortcut'}
                         </button>
                         {globalMuteShortcut && (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -235,6 +235,89 @@
   --scrollbar-thumb-hover: rgba(49, 95, 189, 0.46);
 }
 
+:root[data-custom-theme='true'] {
+  --bg-primary: var(--user-theme-bg-primary);
+  --bg-secondary: var(--user-theme-bg-secondary);
+  --bg-tertiary: var(--user-theme-bg-tertiary);
+  --bg-surface: var(--user-theme-bg-surface);
+  --bg-surface-hover: var(--user-theme-bg-surface-hover);
+  --bg-chat: var(--user-theme-bg-chat);
+  --bg-input: var(--user-theme-bg-input);
+  --bg-header: var(--user-theme-bg-header);
+  --bg-popover: var(--user-theme-bg-popover);
+  --bg-elevated: var(--user-theme-bg-elevated);
+  --topbar-start: var(--user-theme-topbar-start);
+  --topbar-end: var(--user-theme-topbar-end);
+  --accent-primary: var(--user-theme-accent);
+  --accent-primary-hover: var(--user-theme-accent-hover);
+  --accent-secondary: color-mix(in srgb, var(--user-theme-accent) 55%, var(--user-theme-bg-surface));
+  --accent-gradient: var(--user-theme-accent);
+  --accent-glow: 0 0 0 3px color-mix(in srgb, var(--user-theme-accent) 22%, transparent);
+  --btn-primary-bg: var(--user-theme-accent);
+  --btn-primary-bg-hover: var(--user-theme-accent-hover);
+  --btn-primary-border: color-mix(in srgb, var(--user-theme-accent) 72%, var(--user-theme-text-primary));
+  --btn-primary-border-hover: color-mix(in srgb, var(--user-theme-accent) 60%, var(--user-theme-text-primary));
+  --btn-primary-text: var(--user-theme-accent-contrast);
+  --text-primary: var(--user-theme-text-primary);
+  --text-secondary: var(--user-theme-text-secondary);
+  --text-muted: var(--user-theme-text-muted);
+  --text-link: var(--user-theme-accent);
+  --scrollbar-thumb: var(--user-theme-scrollbar);
+  --scrollbar-thumb-hover: var(--user-theme-scrollbar-hover);
+}
+
+:root[data-custom-theme='true'][data-custom-theme-mode='dark'] {
+  --ui-contrast-rgb: 255, 255, 255;
+  --overlay-backdrop: color-mix(in srgb, var(--user-theme-bg-primary) 72%, transparent);
+  --btn-secondary-bg: rgba(255, 255, 255, 0.04);
+  --btn-secondary-bg-hover: rgba(255, 255, 255, 0.09);
+  --btn-secondary-border: rgba(255, 255, 255, 0.18);
+  --btn-secondary-border-hover: rgba(255, 255, 255, 0.28);
+  --btn-danger-bg: #b64758;
+  --btn-danger-bg-hover: #c55667;
+  --btn-danger-border: #cb6876;
+  --btn-danger-border-hover: #d97b88;
+  --btn-danger-soft-bg: rgba(240, 71, 71, 0.08);
+  --btn-danger-soft-bg-hover: rgba(240, 71, 71, 0.14);
+  --btn-danger-soft-border: rgba(240, 71, 71, 0.38);
+  --btn-danger-soft-border-hover: rgba(240, 71, 71, 0.5);
+  --btn-danger-soft-text: #ff9ca7;
+  --text-positive: #43b581;
+  --text-warning: #faa61a;
+  --text-danger: #f04747;
+  --status-offline: #64748b;
+  --border-subtle: 1px solid rgba(255, 255, 255, 0.08);
+  --shadow-low: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-medium: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-high: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-custom-theme='true'][data-custom-theme-mode='light'] {
+  --ui-contrast-rgb: 31, 35, 43;
+  --overlay-backdrop: rgba(31, 35, 43, 0.42);
+  --btn-secondary-bg: rgba(31, 35, 43, 0.04);
+  --btn-secondary-bg-hover: rgba(31, 35, 43, 0.08);
+  --btn-secondary-border: rgba(31, 35, 43, 0.18);
+  --btn-secondary-border-hover: rgba(31, 35, 43, 0.3);
+  --btn-danger-bg: #b4233a;
+  --btn-danger-bg-hover: #971b30;
+  --btn-danger-border: #971b30;
+  --btn-danger-border-hover: #7f1729;
+  --btn-danger-soft-bg: rgba(180, 35, 58, 0.08);
+  --btn-danger-soft-bg-hover: rgba(180, 35, 58, 0.14);
+  --btn-danger-soft-border: rgba(180, 35, 58, 0.34);
+  --btn-danger-soft-border-hover: rgba(180, 35, 58, 0.48);
+  --btn-danger-soft-text: #9f1f34;
+  --text-positive: #177245;
+  --text-warning: #8a5300;
+  --text-danger: #b4233a;
+  --status-offline: #77808f;
+  --border-subtle: 1px solid rgba(31, 35, 43, 0.12);
+  --shadow-low: 0 1px 3px rgba(25, 32, 45, 0.12);
+  --shadow-medium: 0 5px 16px rgba(25, 32, 45, 0.14);
+  --shadow-high: 0 14px 40px rgba(25, 32, 45, 0.18);
+}
+
 :root[data-custom-accent='true'] {
   --accent-primary: var(--user-accent);
   --accent-primary-hover: color-mix(in srgb, var(--user-accent) 84%, var(--text-primary));
@@ -2331,6 +2414,47 @@ body {
   line-height: 1.4;
 }
 
+.theme-settings-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.theme-settings-heading .theme-settings-copy {
+  margin-bottom: 0;
+}
+
+.theme-reset-defaults {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 0 10px;
+  border: 1px solid rgba(var(--ui-contrast-rgb), 0.14);
+  border-radius: 7px;
+  background: rgba(var(--ui-contrast-rgb), 0.04);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.theme-reset-defaults:hover:not(:disabled) {
+  border-color: rgba(var(--ui-contrast-rgb), 0.24);
+  background: rgba(var(--ui-contrast-rgb), 0.08);
+  color: var(--text-primary);
+}
+
+.theme-reset-defaults:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .theme-option-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2366,8 +2490,7 @@ body {
 }
 
 .theme-option:focus-visible,
-.theme-accent-swatch:focus-visible,
-.theme-accent-reset:focus-visible,
+.theme-reset-defaults:focus-visible,
 .theme-color-picker:focus-within,
 .theme-accent-input:focus-visible {
   outline: 2px solid var(--accent-primary);
@@ -2448,46 +2571,43 @@ body {
   line-height: 1.35;
 }
 
-.theme-settings-divider {
-  height: 1px;
-  margin: 16px 0;
-  background: rgba(var(--ui-contrast-rgb), 0.1);
-}
-
-.theme-accent-controls {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+.theme-custom-panel {
   min-width: 0;
+  margin-top: 10px;
+  display: block;
+  padding: 10px;
+  border: 1px solid rgba(var(--ui-contrast-rgb), 0.12);
+  border-radius: 8px;
+  background: rgba(var(--ui-contrast-rgb), 0.035);
 }
 
-.theme-accent-swatches {
+.theme-custom-panel.is-active {
+  border-color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 9%, var(--bg-surface));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 20%, transparent);
+}
+
+.theme-custom-panel-copy {
   display: flex;
-  align-items: center;
-  gap: 7px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 10px;
 }
 
-.theme-accent-swatch {
-  width: 30px;
-  height: 30px;
-  min-width: 30px;
-  padding: 0;
-  border: 2px solid transparent;
-  border-radius: 50%;
-  background: var(--theme-swatch);
-  color: var(--user-accent-contrast, #ffffff);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: 0 0 0 1px rgba(var(--ui-contrast-rgb), 0.18);
+.theme-custom-panel-copy strong {
+  color: var(--text-primary);
+  font-size: 12px;
 }
 
-.theme-accent-swatch.is-selected {
-  border-color: var(--text-primary);
-  box-shadow: 0 0 0 2px var(--bg-surface), 0 0 0 4px var(--accent-primary);
+.theme-custom-panel-copy span {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.theme-custom-color-controls {
+  width: min(100%, 220px);
+  grid-template-columns: 34px minmax(0, 1fr);
 }
 
 .theme-accent-custom {
@@ -2537,30 +2657,6 @@ body {
   border-color: var(--text-danger);
 }
 
-.theme-accent-reset {
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  border: 1px solid rgba(var(--ui-contrast-rgb), 0.14);
-  border-radius: 7px;
-  background: rgba(var(--ui-contrast-rgb), 0.04);
-  color: var(--text-secondary);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-
-.theme-accent-reset:hover:not(:disabled) {
-  background: rgba(var(--ui-contrast-rgb), 0.08);
-  color: var(--text-primary);
-}
-
-.theme-accent-reset:disabled {
-  opacity: 0.42;
-  cursor: not-allowed;
-}
-
 .theme-accent-error {
   margin-top: 8px;
   color: var(--text-danger);
@@ -2576,9 +2672,25 @@ body {
     min-height: 96px;
   }
 
-  .theme-accent-controls {
-    align-items: flex-start;
+  .theme-settings-heading {
+    align-items: stretch;
     flex-direction: column;
+  }
+
+  .theme-custom-panel {
+    padding: 9px;
+  }
+
+  .theme-custom-color-controls {
+    width: 100%;
+  }
+
+  .theme-custom-color-controls {
+    grid-template-columns: 34px minmax(0, 1fr);
+  }
+
+  .theme-custom-color-controls .theme-accent-input {
+    width: 100%;
   }
 }
 
@@ -6459,6 +6571,72 @@ body {
   transition: border-color var(--transition-fast);
 }
 
+.feedback-card {
+  width: 100%;
+  border: 1px solid rgba(var(--ui-contrast-rgb), 0.1);
+  border-radius: var(--border-radius-md);
+  background: color-mix(in srgb, var(--bg-surface) 92%, var(--accent-primary) 8%);
+  padding: 7px 8px;
+  color: var(--text-primary);
+  box-shadow: inset 0 1px rgba(var(--ui-contrast-rgb), 0.035);
+}
+
+.feedback-card-heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-primary);
+}
+
+.feedback-card-heading svg {
+  color: var(--accent-primary);
+  flex: 0 0 auto;
+}
+
+.feedback-card h2 {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.3;
+  font-weight: 700;
+}
+
+.feedback-card-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px;
+  margin-top: 5px;
+}
+
+.feedback-card-actions button {
+  width: 100%;
+  min-height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 4px 6px;
+  border: 1px solid rgba(var(--ui-contrast-rgb), 0.11);
+  border-radius: var(--border-radius-sm);
+  background: rgba(var(--ui-contrast-rgb), 0.04);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.feedback-card-actions button:hover {
+  background: rgba(var(--ui-contrast-rgb), 0.075);
+  border-color: rgba(var(--ui-contrast-rgb), 0.18);
+  color: var(--text-primary);
+}
+
+.feedback-card-actions button:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 .form-group select {
   min-height: 40px;
   appearance: none;
@@ -8976,18 +9154,20 @@ a.community-open-btn:hover {
   background: var(--bg-surface);
 }
 
-/* Bottom right empty corner block overlay */
-.callbar-overlay::after {
-  content: '';
-  position: absolute;
-  top: -1px; /* Pull up to perfectly cover the 1px border-top */
-  right: calc(-1 * var(--member-sidebar-width));
+.feedback-dock {
+  position: fixed;
+  right: 0;
+  bottom: 0;
   width: var(--member-sidebar-width);
   height: 80px;
+  z-index: 131;
+  display: flex;
+  align-items: center;
+  padding: 7px 8px;
+  box-sizing: border-box;
   background: var(--bg-surface);
   border-top: var(--border-subtle);
   border-left: var(--border-subtle);
-  pointer-events: none;
 }
 
 
@@ -14333,7 +14513,7 @@ textarea {
     max-width: none;
   }
 
-  .callbar-overlay::after {
+  .feedback-dock {
     display: none;
   }
 

--- a/apps/web/src/openExternalUrl.test.ts
+++ b/apps/web/src/openExternalUrl.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { isTauri } from './secureStorage'
+import { openExternalUrl } from './openExternalUrl'
+
+vi.mock('./secureStorage', () => ({
+  isTauri: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('openExternalUrl', () => {
+  beforeEach(() => {
+    vi.mocked(isTauri).mockReset()
+    vi.mocked(openUrl).mockClear()
+    vi.restoreAllMocks()
+  })
+
+  it('opens HTTPS links in a protected web tab', async () => {
+    vi.mocked(isTauri).mockReturnValue(false)
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    await openExternalUrl('https://github.com/emircanagac/voxpery/issues/new')
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://github.com/emircanagac/voxpery/issues/new',
+      '_blank',
+      'noopener,noreferrer',
+    )
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('uses the system browser from the Tauri desktop shell', async () => {
+    vi.mocked(isTauri).mockReturnValue(true)
+
+    await openExternalUrl('https://github.com/emircanagac/voxpery/issues/new?template=bug.md')
+
+    expect(openUrl).toHaveBeenCalledWith(
+      'https://github.com/emircanagac/voxpery/issues/new?template=bug.md',
+    )
+  })
+
+  it('rejects non-HTTP protocols', async () => {
+    vi.mocked(isTauri).mockReturnValue(false)
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    await openExternalUrl('javascript:alert(1)')
+
+    expect(openSpy).not.toHaveBeenCalled()
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -10,6 +10,7 @@ import ActiveCallBar from '../components/ActiveCallBar'
 import QuickSwitcher, { type QuickSwitcherItem } from '../components/QuickSwitcher'
 import UserBar from '../components/UserBar'
 import NotificationPermissionPrompt from '../components/NotificationPermissionPrompt'
+import FeedbackCard from '../components/FeedbackCard'
 import { useToastStore } from '../stores/toast'
 import { dmApi, friendApi, type DmChannel, type Friend, type User } from '../api'
 import { touchDmChannelActivity, upsertDmChannel } from '../friendsList'
@@ -675,6 +676,9 @@ export default function AppShell() {
           selectedVoiceChannelId={selectedVoiceChannelId}
           activeChannelId={showVoiceStage ? activeChannelId : null}
         />
+      </div>
+      <div className="feedback-dock">
+        <FeedbackCard />
       </div>
       {/* User profile bar — stays in left sidebar */}
       <div className="left-bottom-panel">

--- a/apps/web/src/theme.test.ts
+++ b/apps/web/src/theme.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   DEFAULT_THEME,
+  createCustomThemePalette,
   getAccessibleAccentText,
   getContrastRatio,
   getStoredThemePreference,
@@ -8,6 +9,8 @@ import {
   normalizeHexColor,
   setThemePreference,
   THEME_ACCENT_STORAGE_KEY,
+  THEME_CUSTOM_COLOR_STORAGE_KEY,
+  THEME_CUSTOM_MODE_STORAGE_KEY,
   THEME_OPTIONS,
   THEME_STORAGE_KEY,
 } from './theme'
@@ -17,6 +20,8 @@ describe('theme preferences', () => {
     localStorage.clear()
     document.documentElement.removeAttribute('data-theme')
     document.documentElement.removeAttribute('data-custom-accent')
+    document.documentElement.removeAttribute('data-custom-theme')
+    document.documentElement.removeAttribute('data-custom-theme-mode')
     document.documentElement.removeAttribute('style')
     document.head.innerHTML = '<meta name="theme-color" content="#16213e">'
   })
@@ -28,6 +33,8 @@ describe('theme preferences', () => {
     expect(getStoredThemePreference()).toEqual({
       theme: DEFAULT_THEME,
       customAccent: null,
+      customThemeColor: null,
+      customThemeMode: 'dark',
     })
   })
 
@@ -37,22 +44,36 @@ describe('theme preferences', () => {
     expect(normalizeHexColor('12af90')).toBeNull()
   })
 
-  it('persists and applies the selected theme and custom accent', () => {
-    const saved = setThemePreference({ theme: 'rose', customAccent: '#2d8f70' })
+  it('removes obsolete custom accent preferences when saving appearance', () => {
+    localStorage.setItem(THEME_ACCENT_STORAGE_KEY, '#2d8f70')
+    const saved = setThemePreference({
+      theme: 'dark',
+      customAccent: '#2d8f70',
+      customThemeColor: null,
+      customThemeMode: 'dark',
+    })
 
-    expect(saved).toEqual({ theme: 'rose', customAccent: '#2d8f70' })
-    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('rose')
-    expect(localStorage.getItem(THEME_ACCENT_STORAGE_KEY)).toBe('#2d8f70')
-    expect(document.documentElement.dataset.theme).toBe('rose')
-    expect(document.documentElement.dataset.customAccent).toBe('true')
-    expect(document.documentElement.style.getPropertyValue('--user-accent')).toBe('#2d8f70')
-    expect(document.querySelector('meta[name="theme-color"]')).toHaveAttribute('content', '#2a1a29')
+    expect(saved).toEqual({
+      theme: 'dark',
+      customAccent: null,
+      customThemeColor: null,
+      customThemeMode: 'dark',
+    })
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+    expect(localStorage.getItem(THEME_ACCENT_STORAGE_KEY)).toBeNull()
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(document.documentElement.dataset.customAccent).toBeUndefined()
   })
 
   it('restores the stored preference during startup without user interaction', () => {
     localStorage.setItem(THEME_STORAGE_KEY, 'light')
 
-    expect(initializeTheme()).toEqual({ theme: 'light', customAccent: null })
+    expect(initializeTheme()).toEqual({
+      theme: 'light',
+      customAccent: null,
+      customThemeColor: null,
+      customThemeMode: 'light',
+    })
     expect(document.documentElement.dataset.theme).toBe('light')
     expect(document.documentElement.style.colorScheme).toBe('light')
   })
@@ -65,6 +86,67 @@ describe('theme preferences', () => {
         getContrastRatio(getAccessibleAccentText(option.defaultAccent), option.defaultAccent),
         `${option.label} accent`,
       ).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('persists and restores a generated full theme palette', () => {
+    const saved = setThemePreference({
+      theme: 'voxpery',
+      customAccent: null,
+      customThemeColor: '#7b3fc6',
+      customThemeMode: 'light',
+    })
+
+    expect(saved.customThemeColor).toBe('#7b3fc6')
+    expect(localStorage.getItem(THEME_CUSTOM_COLOR_STORAGE_KEY)).toBe('#7b3fc6')
+    expect(localStorage.getItem(THEME_CUSTOM_MODE_STORAGE_KEY)).toBe('dark')
+    expect(document.documentElement.dataset.customTheme).toBe('true')
+    expect(document.documentElement.dataset.customThemeMode).toBe('dark')
+    expect(document.documentElement.style.getPropertyValue('--user-theme-bg-primary')).toMatch(/^#[0-9a-f]{6}$/)
+    expect(document.documentElement.style.getPropertyValue('--user-theme-accent')).toMatch(/^#[0-9a-f]{6}$/)
+    expect(document.documentElement.style.colorScheme).toBe('dark')
+  })
+
+  it('maps the legacy rose preference into the visible custom theme flow', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'rose')
+
+    expect(getStoredThemePreference()).toEqual({
+      theme: DEFAULT_THEME,
+      customAccent: null,
+      customThemeColor: '#c9578f',
+      customThemeMode: 'dark',
+    })
+  })
+
+  it('generates readable dark and light palettes for extreme user colors', () => {
+    for (const baseColor of ['#000000', '#ffffff', '#ff00aa', '#1463ff']) {
+      for (const mode of ['dark', 'light'] as const) {
+        const palette = createCustomThemePalette(baseColor, mode)
+        const surfaces = [
+          palette.backgroundColor,
+          palette.secondaryBackgroundColor,
+          palette.tertiaryBackgroundColor,
+          palette.surfaceColor,
+          palette.surfaceHoverColor,
+          palette.chatColor,
+          palette.inputColor,
+          palette.headerColor,
+          palette.popoverColor,
+          palette.elevatedColor,
+          palette.topbarStartColor,
+          palette.topbarEndColor,
+        ]
+        for (const surface of surfaces) {
+          expect(getContrastRatio(palette.textColor, surface), `${baseColor} ${mode} text on ${surface}`).toBeGreaterThanOrEqual(4.5)
+          expect(getContrastRatio(palette.secondaryTextColor, surface), `${baseColor} ${mode} secondary on ${surface}`).toBeGreaterThanOrEqual(4.5)
+          expect(getContrastRatio(palette.mutedTextColor, surface), `${baseColor} ${mode} muted on ${surface}`).toBeGreaterThanOrEqual(4.5)
+          expect(getContrastRatio(palette.accentColor, surface), `${baseColor} ${mode} accent on ${surface}`).toBeGreaterThanOrEqual(4.5)
+        }
+        expect(
+          getContrastRatio(getAccessibleAccentText(palette.accentColor), palette.accentColor),
+          `${baseColor} ${mode} accent`,
+        ).toBeGreaterThanOrEqual(4.5)
+      }
     }
   })
 })

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -1,14 +1,17 @@
 export const THEME_STORAGE_KEY = 'voxpery-settings-theme'
 export const THEME_ACCENT_STORAGE_KEY = 'voxpery-settings-theme-accent'
+export const THEME_CUSTOM_COLOR_STORAGE_KEY = 'voxpery-settings-theme-custom-color'
+export const THEME_CUSTOM_MODE_STORAGE_KEY = 'voxpery-settings-theme-custom-mode'
 export const THEME_CHANGED_EVENT = 'voxpery-theme-changed'
 
 export type ThemeId = 'voxpery' | 'dark' | 'rose' | 'light'
+export type ThemeColorScheme = 'dark' | 'light'
 
 export interface ThemeOption {
   id: ThemeId
   label: string
   description: string
-  colorScheme: 'dark' | 'light'
+  colorScheme: ThemeColorScheme
   chromeColor: string
   backgroundColor: string
   surfaceColor: string
@@ -20,6 +23,33 @@ export interface ThemeOption {
 export interface ThemePreference {
   theme: ThemeId
   customAccent: string | null
+  customThemeColor: string | null
+  customThemeMode: ThemeColorScheme
+}
+
+export interface CustomThemePalette {
+  colorScheme: ThemeColorScheme
+  baseColor: string
+  chromeColor: string
+  backgroundColor: string
+  secondaryBackgroundColor: string
+  tertiaryBackgroundColor: string
+  surfaceColor: string
+  surfaceHoverColor: string
+  chatColor: string
+  inputColor: string
+  headerColor: string
+  popoverColor: string
+  elevatedColor: string
+  topbarStartColor: string
+  topbarEndColor: string
+  textColor: string
+  secondaryTextColor: string
+  mutedTextColor: string
+  accentColor: string
+  accentHoverColor: string
+  scrollbarColor: string
+  scrollbarHoverColor: string
 }
 
 export const DEFAULT_THEME: ThemeId = 'voxpery'
@@ -77,6 +107,28 @@ export const THEME_OPTIONS: readonly ThemeOption[] = [
 
 const THEME_IDS = new Set<ThemeId>(THEME_OPTIONS.map((option) => option.id))
 const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i
+const CUSTOM_THEME_STYLE_PROPERTIES = [
+  '--user-theme-bg-primary',
+  '--user-theme-bg-secondary',
+  '--user-theme-bg-tertiary',
+  '--user-theme-bg-surface',
+  '--user-theme-bg-surface-hover',
+  '--user-theme-bg-chat',
+  '--user-theme-bg-input',
+  '--user-theme-bg-header',
+  '--user-theme-bg-popover',
+  '--user-theme-bg-elevated',
+  '--user-theme-topbar-start',
+  '--user-theme-topbar-end',
+  '--user-theme-text-primary',
+  '--user-theme-text-secondary',
+  '--user-theme-text-muted',
+  '--user-theme-accent',
+  '--user-theme-accent-hover',
+  '--user-theme-accent-contrast',
+  '--user-theme-scrollbar',
+  '--user-theme-scrollbar-hover',
+] as const
 
 export function isThemeId(value: unknown): value is ThemeId {
   return typeof value === 'string' && THEME_IDS.has(value as ThemeId)
@@ -100,6 +152,38 @@ function hexToRgb(hex: string): [number, number, number] {
     Number.parseInt(normalized.slice(3, 5), 16),
     Number.parseInt(normalized.slice(5, 7), 16),
   ]
+}
+
+function rgbToHex([red, green, blue]: [number, number, number]): string {
+  const toHex = (value: number) => Math.round(Math.min(255, Math.max(0, value))).toString(16).padStart(2, '0')
+  return `#${toHex(red)}${toHex(green)}${toHex(blue)}`
+}
+
+function mixHexColors(first: string, second: string, firstWeight: number): string {
+  const firstRgb = hexToRgb(first)
+  const secondRgb = hexToRgb(second)
+  const weight = Math.min(1, Math.max(0, firstWeight))
+  return rgbToHex([
+    firstRgb[0] * weight + secondRgb[0] * (1 - weight),
+    firstRgb[1] * weight + secondRgb[1] * (1 - weight),
+    firstRgb[2] * weight + secondRgb[2] * (1 - weight),
+  ])
+}
+
+function ensureContrastColor(
+  color: string,
+  surfaces: readonly string[],
+  contrastTarget: string,
+  minimumRatio = 4.5,
+): string {
+  for (let step = 0; step <= 20; step += 1) {
+    const colorWeight = 1 - step / 20
+    const candidate = mixHexColors(color, contrastTarget, colorWeight)
+    if (surfaces.every((surface) => getContrastRatio(candidate, surface) >= minimumRatio)) {
+      return candidate
+    }
+  }
+  return contrastTarget
 }
 
 function relativeLuminance(hex: string): number {
@@ -128,16 +212,136 @@ export function getThemeOption(theme: ThemeId): ThemeOption {
   return THEME_OPTIONS.find((option) => option.id === theme) ?? THEME_OPTIONS[0]
 }
 
+export function createCustomThemePalette(baseColor: string, colorScheme: ThemeColorScheme): CustomThemePalette {
+  const normalized = normalizeHexColor(baseColor) ?? getThemeOption(DEFAULT_THEME).defaultAccent
+  if (colorScheme === 'light') {
+    const backgroundColor = mixHexColors(normalized, '#f5f7fa', 0.045)
+    const secondaryBackgroundColor = mixHexColors(normalized, '#e8ebf0', 0.075)
+    const tertiaryBackgroundColor = mixHexColors(normalized, '#dce2eb', 0.12)
+    const surfaceColor = mixHexColors(normalized, '#ffffff', 0.025)
+    const surfaceHoverColor = mixHexColors(normalized, '#edf0f4', 0.095)
+    const chatColor = mixHexColors(normalized, '#f8f9fb', 0.035)
+    const inputColor = mixHexColors(normalized, '#ffffff', 0.02)
+    const headerColor = mixHexColors(normalized, '#ffffff', 0.03)
+    const popoverColor = mixHexColors(normalized, '#ffffff', 0.045)
+    const elevatedColor = mixHexColors(normalized, '#f1f3f6', 0.08)
+    const topbarStartColor = mixHexColors(normalized, '#ffffff', 0.05)
+    const topbarEndColor = mixHexColors(normalized, '#f4f6f8', 0.055)
+    const accent = ensureContrastColor(normalized, [
+      backgroundColor,
+      secondaryBackgroundColor,
+      tertiaryBackgroundColor,
+      surfaceColor,
+      surfaceHoverColor,
+      chatColor,
+      inputColor,
+      headerColor,
+      popoverColor,
+      elevatedColor,
+      topbarStartColor,
+      topbarEndColor,
+    ], '#111827')
+    return {
+      colorScheme,
+      baseColor: normalized,
+      chromeColor: mixHexColors(normalized, '#ffffff', 0.035),
+      backgroundColor,
+      secondaryBackgroundColor,
+      tertiaryBackgroundColor,
+      surfaceColor,
+      surfaceHoverColor,
+      chatColor,
+      inputColor,
+      headerColor,
+      popoverColor,
+      elevatedColor,
+      topbarStartColor,
+      topbarEndColor,
+      textColor: '#20242c',
+      secondaryTextColor: '#3f4855',
+      mutedTextColor: '#46505f',
+      accentColor: accent,
+      accentHoverColor: mixHexColors(accent, '#000000', 0.82),
+      scrollbarColor: mixHexColors(accent, '#ffffff', 0.42),
+      scrollbarHoverColor: mixHexColors(accent, '#ffffff', 0.64),
+    }
+  }
+
+  const backgroundColor = mixHexColors(normalized, '#15171d', 0.08)
+  const secondaryBackgroundColor = mixHexColors(normalized, '#151820', 0.12)
+  const tertiaryBackgroundColor = mixHexColors(normalized, '#252b36', 0.18)
+  const surfaceColor = mixHexColors(normalized, '#20232b', 0.13)
+  const surfaceHoverColor = mixHexColors(normalized, '#292d36', 0.17)
+  const chatColor = mixHexColors(normalized, '#17191f', 0.08)
+  const inputColor = mixHexColors(normalized, '#0f1116', 0.05)
+  const headerColor = mixHexColors(normalized, '#1b1e25', 0.12)
+  const popoverColor = mixHexColors(normalized, '#1d2028', 0.15)
+  const elevatedColor = mixHexColors(normalized, '#242832', 0.18)
+  const topbarStartColor = mixHexColors(normalized, '#20232b', 0.14)
+  const topbarEndColor = mixHexColors(normalized, '#171a20', 0.11)
+  const accent = ensureContrastColor(normalized, [
+    backgroundColor,
+    secondaryBackgroundColor,
+    tertiaryBackgroundColor,
+    surfaceColor,
+    surfaceHoverColor,
+    chatColor,
+    inputColor,
+    headerColor,
+    popoverColor,
+    elevatedColor,
+    topbarStartColor,
+    topbarEndColor,
+  ], '#ffffff')
+  return {
+    colorScheme,
+    baseColor: normalized,
+    chromeColor: mixHexColors(normalized, '#12141a', 0.13),
+    backgroundColor,
+    secondaryBackgroundColor,
+    tertiaryBackgroundColor,
+    surfaceColor,
+    surfaceHoverColor,
+    chatColor,
+    inputColor,
+    headerColor,
+    popoverColor,
+    elevatedColor,
+    topbarStartColor,
+    topbarEndColor,
+    textColor: '#f3f4f6',
+    secondaryTextColor: '#dde0e5',
+    mutedTextColor: '#c3c8cf',
+    accentColor: accent,
+    accentHoverColor: mixHexColors(accent, '#ffffff', 0.82),
+    scrollbarColor: mixHexColors(accent, '#15171d', 0.44),
+    scrollbarHoverColor: mixHexColors(accent, '#ffffff', 0.62),
+  }
+}
+
 export function getStoredThemePreference(storage: Pick<Storage, 'getItem'> = localStorage): ThemePreference {
   try {
     const storedTheme = storage.getItem(THEME_STORAGE_KEY)
-    const storedAccent = normalizeHexColor(storage.getItem(THEME_ACCENT_STORAGE_KEY))
+    const storedCustomThemeColor = normalizeHexColor(storage.getItem(THEME_CUSTOM_COLOR_STORAGE_KEY))
+    const isLegacyRoseTheme = storedTheme === 'rose'
+    const theme = isLegacyRoseTheme
+      ? DEFAULT_THEME
+      : isThemeId(storedTheme) ? storedTheme : DEFAULT_THEME
+    const customThemeColor = storedCustomThemeColor
+      ?? (isLegacyRoseTheme ? getThemeOption('rose').defaultAccent : null)
     return {
-      theme: isThemeId(storedTheme) ? storedTheme : DEFAULT_THEME,
-      customAccent: storedAccent,
+      theme,
+      customAccent: null,
+      customThemeColor,
+      customThemeMode: customThemeColor ? 'dark' : getThemeOption(theme).colorScheme,
     }
   } catch {
-    return { theme: DEFAULT_THEME, customAccent: null }
+    return {
+      theme: DEFAULT_THEME,
+      customAccent: null,
+      customThemeColor: null,
+      customThemeMode: getThemeOption(DEFAULT_THEME).colorScheme,
+    }
   }
 }
 
@@ -146,12 +350,47 @@ export function applyThemePreference(
   documentTarget: Document = document,
 ): ThemePreference {
   const theme = isThemeId(preference.theme) ? preference.theme : DEFAULT_THEME
-  const customAccent = normalizeHexColor(preference.customAccent)
+  const customAccent = null
+  const customThemeColor = normalizeHexColor(preference.customThemeColor)
   const option = getThemeOption(theme)
+  const customThemeMode = customThemeColor ? 'dark' : option.colorScheme
+  const customThemePalette = customThemeColor
+    ? createCustomThemePalette(customThemeColor, customThemeMode)
+    : null
   const root = documentTarget.documentElement
 
   root.dataset.theme = theme
-  root.style.colorScheme = option.colorScheme
+  root.style.colorScheme = customThemeColor ? customThemeMode : option.colorScheme
+
+  if (customThemePalette) {
+    const palette = customThemePalette
+    root.dataset.customTheme = 'true'
+    root.dataset.customThemeMode = customThemeMode
+    root.style.setProperty('--user-theme-bg-primary', palette.backgroundColor)
+    root.style.setProperty('--user-theme-bg-secondary', palette.secondaryBackgroundColor)
+    root.style.setProperty('--user-theme-bg-tertiary', palette.tertiaryBackgroundColor)
+    root.style.setProperty('--user-theme-bg-surface', palette.surfaceColor)
+    root.style.setProperty('--user-theme-bg-surface-hover', palette.surfaceHoverColor)
+    root.style.setProperty('--user-theme-bg-chat', palette.chatColor)
+    root.style.setProperty('--user-theme-bg-input', palette.inputColor)
+    root.style.setProperty('--user-theme-bg-header', palette.headerColor)
+    root.style.setProperty('--user-theme-bg-popover', palette.popoverColor)
+    root.style.setProperty('--user-theme-bg-elevated', palette.elevatedColor)
+    root.style.setProperty('--user-theme-topbar-start', palette.topbarStartColor)
+    root.style.setProperty('--user-theme-topbar-end', palette.topbarEndColor)
+    root.style.setProperty('--user-theme-text-primary', palette.textColor)
+    root.style.setProperty('--user-theme-text-secondary', palette.secondaryTextColor)
+    root.style.setProperty('--user-theme-text-muted', palette.mutedTextColor)
+    root.style.setProperty('--user-theme-accent', palette.accentColor)
+    root.style.setProperty('--user-theme-accent-hover', palette.accentHoverColor)
+    root.style.setProperty('--user-theme-accent-contrast', getAccessibleAccentText(palette.accentColor))
+    root.style.setProperty('--user-theme-scrollbar', palette.scrollbarColor)
+    root.style.setProperty('--user-theme-scrollbar-hover', palette.scrollbarHoverColor)
+  } else {
+    delete root.dataset.customTheme
+    delete root.dataset.customThemeMode
+    for (const property of CUSTOM_THEME_STYLE_PROPERTIES) root.style.removeProperty(property)
+  }
 
   if (customAccent) {
     root.dataset.customAccent = 'true'
@@ -164,9 +403,10 @@ export function applyThemePreference(
   }
 
   const themeColor = documentTarget.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
-  themeColor?.setAttribute('content', option.chromeColor)
+  const activeChromeColor = customThemePalette?.chromeColor ?? option.chromeColor
+  themeColor?.setAttribute('content', activeChromeColor)
 
-  return { theme, customAccent }
+  return { theme, customAccent, customThemeColor, customThemeMode }
 }
 
 export function setThemePreference(preference: ThemePreference): ThemePreference {
@@ -178,6 +418,12 @@ export function setThemePreference(preference: ThemePreference): ThemePreference
     } else {
       localStorage.removeItem(THEME_ACCENT_STORAGE_KEY)
     }
+    if (normalized.customThemeColor) {
+      localStorage.setItem(THEME_CUSTOM_COLOR_STORAGE_KEY, normalized.customThemeColor)
+    } else {
+      localStorage.removeItem(THEME_CUSTOM_COLOR_STORAGE_KEY)
+    }
+    localStorage.setItem(THEME_CUSTOM_MODE_STORAGE_KEY, normalized.customThemeMode)
   } catch {
     // Applying the in-memory preference still keeps the current session usable.
   }

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -73,6 +73,8 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
 - [ ] DM pins persist across refresh/login, pinned conversations stay above activity-sorted unpinned DMs, and a hidden DM returns only after explicit reopen or new message activity.
 - [ ] Channel managers can create channels from the compact header menu, a category `+`, and the category context menu; non-managers see none of these controls.
+- [ ] Appearance offers Default, Dark, Light, and Custom choices; Custom generates a readable palette from one valid hex color, persists after reload, and `Reset defaults` restores the original Voxpery palette without horizontal overflow on desktop or mobile.
+- [ ] The fixed bottom-right feedback dock shows theme-aligned `Report a bug` and `Request a feature` actions that open the matching GitHub issue templates on web and desktop; it stays outside information sidebars and is hidden on mobile so chat/composer width is unchanged.
 - [ ] Login and registration do not open a native notification permission prompt; the delayed in-app prompt requests permission only after the user selects `Enable`, and `Not now` suppresses it during the snooze window.
 - [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.


### PR DESCRIPTION
## Summary
- simplify Appearance into Default, Dark, Light, and one-color Custom themes
- add Reset defaults and safely migrate legacy theme preferences
- add a theme-aware feedback dock for bug reports and feature requests
- remove the visual artifact from the microphone shortcut button
- add regression coverage for theme persistence, reset, contrast, feedback links, and responsive layouts

## Validation
- `npm run lint`
- `npm run test:run` (223 tests)
- `npm run build`
- `npm run test:e2e:ui-smoke` (37 tests)
- `npm run test:e2e:mobile-smoke` (3 tests)