### PR TITLE
fix: complete theme contrast coverage

### DIFF
--- a/apps/web/e2e/release-settings-core-regressions.spec.ts
+++ b/apps/web/e2e/release-settings-core-regressions.spec.ts
@@ -98,6 +98,7 @@ test.describe('mocked release and settings regressions', () => {
     const modal = page.locator('.user-settings-modal')
     const themeGroup = modal.getByRole('group', { name: 'Theme' })
     await expect(themeGroup.locator('.theme-option')).toHaveCount(4)
+    await expect(themeGroup.locator('.theme-option-label')).toHaveText(['Default', 'Custom', 'Dark', 'Light'])
     await expect(themeGroup.getByRole('button', { name: /Default/ })).toBeVisible()
     await expect(themeGroup.getByRole('button', { name: /Dark/ })).toBeVisible()
     await expect(themeGroup.getByRole('button', { name: /Light/ })).toBeVisible()
@@ -124,6 +125,68 @@ test.describe('mocked release and settings regressions', () => {
     await expect(page.locator('html')).toHaveAttribute('data-custom-theme', 'true')
     await expect(page.locator('html')).toHaveAttribute('data-custom-theme-mode', 'dark')
     await expect(page.locator('html')).toHaveCSS('--user-theme-bg-primary', generatedBackground)
+  })
+
+  test('keeps member, voice, callbar, and image-preview chrome readable across themes', async ({ page }) => {
+    const state = createMockCoreState({ friends: buildFriends(2) })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+
+    await page.goto('/social')
+    await page.evaluate(() => {
+      const fixture = document.createElement('div')
+      fixture.id = 'appearance-contract-fixture'
+      fixture.style.cssText = 'position:fixed;left:-10000px;top:0;width:480px;'
+      fixture.innerHTML = `
+        <span class="appearance-primary-reference">Primary</span>
+        <span class="appearance-secondary-reference">Secondary</span>
+        <aside class="member-sidebar">
+          <div class="member-item"><span class="member-name">Readable member</span></div>
+        </aside>
+        <div class="voice-stage-tile">
+          <span class="voice-stage-name">Voice member</span>
+          <span class="voice-stage-sub">In voice</span>
+        </div>
+        <div class="active-call-bar">
+          <button class="active-call-title-btn">Voice channel</button>
+          <button class="callbar-control-btn">Control</button>
+        </div>
+        <div class="chat-image-preview-modal">
+          <div class="chat-image-preview-toolbar">
+            <span class="chat-image-preview-title">Image preview</span>
+          </div>
+          <div class="chat-image-preview-stage"></div>
+        </div>
+      `
+      fixture.querySelector<HTMLElement>('.appearance-primary-reference')!.style.color = 'var(--text-primary)'
+      fixture.querySelector<HTMLElement>('.appearance-secondary-reference')!.style.color = 'var(--text-secondary)'
+      document.body.appendChild(fixture)
+    })
+
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('button', { name: 'Appearance' }).click()
+    const modal = page.locator('.user-settings-modal')
+
+    await modal.locator('.theme-option', { hasText: 'Dark' }).click()
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+    const dark = await readSettledSemanticThemeSnapshot(page)
+
+    await modal.locator('.theme-option', { hasText: 'Light' }).click()
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light')
+    const light = await readSettledSemanticThemeSnapshot(page)
+
+    await modal.getByRole('button', { name: /Custom/ }).click()
+    const customInput = modal.getByRole('textbox', { name: 'Custom theme hex color' })
+    await customInput.fill('#8d50ca')
+    await customInput.press('Enter')
+    await expect(page.locator('html')).toHaveAttribute('data-custom-theme', 'true')
+    const custom = await readSettledSemanticThemeSnapshot(page)
+
+    expect(light.memberSurface).not.toBe(dark.memberSurface)
+    expect(light.voiceSurface).not.toBe(dark.voiceSurface)
+    expect(light.callbarSurface).not.toBe(dark.callbarSurface)
+    expect(light.previewSurface).not.toBe(dark.previewSurface)
+    expect(custom.voiceSurface).not.toBe(dark.voiceSurface)
   })
 
   test('shows feedback entry points on Social without replacing conversation content', async ({ page }) => {
@@ -240,4 +303,51 @@ async function readAppearanceThemeSnapshot(page: import('@playwright/test').Page
       jumpToLatest: backgroundOf('.theme-contract-probe'),
     }
   })
+}
+
+type SemanticThemeSnapshot = Awaited<ReturnType<typeof readSemanticThemeSnapshot>>
+
+async function readSemanticThemeSnapshot(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const style = (selector: string) => {
+      const target = document.querySelector(selector)
+      if (!target) throw new Error(`Missing semantic theme target: ${selector}`)
+      return getComputedStyle(target)
+    }
+    return {
+      primary: style('.appearance-primary-reference').color,
+      secondary: style('.appearance-secondary-reference').color,
+      memberText: style('#appearance-contract-fixture .member-name').color,
+      voiceName: style('#appearance-contract-fixture .voice-stage-name').color,
+      voiceSub: style('#appearance-contract-fixture .voice-stage-sub').color,
+      callbarText: style('#appearance-contract-fixture .active-call-title-btn').color,
+      previewText: style('#appearance-contract-fixture .chat-image-preview-title').color,
+      memberSurface: style('#appearance-contract-fixture .member-item').background,
+      voiceSurface: style('#appearance-contract-fixture .voice-stage-tile').background,
+      callbarSurface: style('#appearance-contract-fixture .active-call-bar').background,
+      previewSurface: style('#appearance-contract-fixture .chat-image-preview-modal').background,
+    }
+  })
+}
+
+function assertSemanticTextContract(snapshot: SemanticThemeSnapshot) {
+  expect(snapshot.memberText).toBe(snapshot.primary)
+  expect(snapshot.voiceName).toBe(snapshot.primary)
+  expect(snapshot.voiceSub).toBe(snapshot.secondary)
+  expect(snapshot.callbarText).toBe(snapshot.secondary)
+  expect(snapshot.previewText).toBe(snapshot.secondary)
+}
+
+async function readSettledSemanticThemeSnapshot(page: import('@playwright/test').Page) {
+  await expect.poll(async () => {
+    const snapshot = await readSemanticThemeSnapshot(page)
+    return snapshot.memberText === snapshot.primary
+      && snapshot.voiceName === snapshot.primary
+      && snapshot.voiceSub === snapshot.secondary
+      && snapshot.callbarText === snapshot.secondary
+      && snapshot.previewText === snapshot.secondary
+  }).toBe(true)
+  const snapshot = await readSemanticThemeSnapshot(page)
+  assertSemanticTextContract(snapshot)
+  return snapshot
 }

--- a/apps/web/src/components/ThemeSettings.tsx
+++ b/apps/web/src/components/ThemeSettings.tsx
@@ -12,7 +12,12 @@ import {
   type ThemePreference,
 } from '../theme'
 
-const VISIBLE_THEME_OPTIONS = THEME_OPTIONS.filter((option) => option.id !== 'rose')
+const THEME_GRID_OPTIONS = [
+  THEME_OPTIONS.find((option) => option.id === 'voxpery')!,
+  'custom',
+  THEME_OPTIONS.find((option) => option.id === 'dark')!,
+  THEME_OPTIONS.find((option) => option.id === 'light')!,
+] as const
 
 export default function ThemeSettings() {
   const [preference, setPreference] = useState<ThemePreference>(() => getStoredThemePreference())
@@ -94,7 +99,42 @@ export default function ThemeSettings() {
         </button>
       </div>
       <div className="theme-option-grid" role="group" aria-label="Theme">
-        {VISIBLE_THEME_OPTIONS.map((option) => {
+        {THEME_GRID_OPTIONS.map((option) => {
+          if (option === 'custom') {
+            return (
+              <button
+                key="custom"
+                type="button"
+                className={`theme-option ${preference.customThemeColor ? 'is-selected' : ''}`}
+                onClick={() => selectCustomThemeColor(themeColorDraft)}
+                aria-pressed={Boolean(preference.customThemeColor)}
+              >
+                <span
+                  className="theme-option-preview"
+                  style={{
+                    '--theme-preview-bg': customThemePalette.backgroundColor,
+                    '--theme-preview-surface': customThemePalette.surfaceColor,
+                    '--theme-preview-accent': customThemePalette.accentColor,
+                    '--theme-preview-text': customThemePalette.textColor,
+                  } as CSSProperties}
+                  aria-hidden
+                >
+                  <span className="theme-option-preview-sidebar" />
+                  <span className="theme-option-preview-content">
+                    <span />
+                    <span />
+                  </span>
+                </span>
+                <span className="theme-option-meta">
+                  <span className="theme-option-label">
+                    Custom
+                    {preference.customThemeColor && <Check size={14} aria-hidden />}
+                  </span>
+                  <span className="theme-option-description">Pick one color and Voxpery handles the rest.</span>
+                </span>
+              </button>
+            )
+          }
           const selected = !preference.customThemeColor && preference.theme === option.id
           return (
             <button
@@ -130,36 +170,6 @@ export default function ThemeSettings() {
             </button>
           )
         })}
-        <button
-          type="button"
-          className={`theme-option ${preference.customThemeColor ? 'is-selected' : ''}`}
-          onClick={() => selectCustomThemeColor(themeColorDraft)}
-          aria-pressed={Boolean(preference.customThemeColor)}
-        >
-          <span
-            className="theme-option-preview"
-            style={{
-              '--theme-preview-bg': customThemePalette.backgroundColor,
-              '--theme-preview-surface': customThemePalette.surfaceColor,
-              '--theme-preview-accent': customThemePalette.accentColor,
-              '--theme-preview-text': customThemePalette.textColor,
-            } as CSSProperties}
-            aria-hidden
-          >
-            <span className="theme-option-preview-sidebar" />
-            <span className="theme-option-preview-content">
-              <span />
-              <span />
-            </span>
-          </span>
-          <span className="theme-option-meta">
-            <span className="theme-option-label">
-              Custom
-              {preference.customThemeColor && <Check size={14} aria-hidden />}
-            </span>
-            <span className="theme-option-description">Pick one color and Voxpery handles the rest.</span>
-          </span>
-        </button>
       </div>
 
       {preference.customThemeColor && <div className="theme-custom-panel is-active" aria-label="Custom theme controls">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13789,6 +13789,151 @@ a.community-open-btn:hover {
   color: var(--text-secondary);
 }
 
+/* Member surfaces must remain readable in light and generated themes. */
+.member-sidebar:not(.member-sidebar--sheet) .member-category,
+.member-sidebar:not(.member-sidebar--sheet) .member-category-offline,
+.member-sidebar--sheet .member-category,
+.member-sidebar--sheet .member-category-offline {
+  background: rgba(var(--ui-contrast-rgb), 0.045);
+}
+
+.member-sidebar:not(.member-sidebar--sheet) .member-item,
+.member-sidebar--sheet .member-item {
+  border-color: rgba(var(--ui-contrast-rgb), 0.05);
+  background: rgba(var(--ui-contrast-rgb), 0.03);
+  box-shadow: inset 0 1px rgba(var(--ui-contrast-rgb), 0.02);
+}
+
+.member-sidebar:not(.member-sidebar--sheet) .member-item:hover,
+.member-sidebar--sheet .member-item:hover {
+  border-color: rgba(var(--ui-contrast-rgb), 0.09);
+  background: rgba(var(--ui-contrast-rgb), 0.065);
+}
+
+.member-sidebar:not(.member-sidebar--sheet) .member-name {
+  color: var(--text-primary);
+}
+
+.member-role-btn {
+  border-color: rgba(var(--ui-contrast-rgb), 0.16);
+}
+
+.mobile-member-sheet {
+  border-color: rgba(var(--ui-contrast-rgb), 0.1);
+  background: color-mix(in srgb, var(--bg-popover) 96%, var(--accent-primary) 4%);
+  box-shadow: var(--shadow-high);
+}
+
+.mobile-member-sheet-header {
+  border-color: rgba(var(--ui-contrast-rgb), 0.08);
+  background: rgba(var(--ui-contrast-rgb), 0.025);
+}
+
+.mobile-member-sheet-copy p,
+.mobile-member-sheet-close {
+  border-color: rgba(var(--ui-contrast-rgb), 0.08);
+  background: rgba(var(--ui-contrast-rgb), 0.05);
+}
+
+/* Voice stage and call controls use the same semantic surfaces as the app shell. */
+.voice-stage-tile {
+  border-color: rgba(var(--ui-contrast-rgb), 0.12);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent-primary) 7%, var(--bg-elevated)), var(--bg-surface));
+  box-shadow: var(--shadow-medium);
+}
+
+.voice-stage-avatar {
+  color: var(--btn-primary-text);
+}
+
+.voice-stage-hidden-media-tile {
+  border-color: rgba(var(--ui-contrast-rgb), 0.2);
+  background: linear-gradient(180deg, var(--bg-elevated), var(--bg-surface));
+  color: var(--text-secondary);
+}
+
+.active-call-bar {
+  border-color: color-mix(in srgb, var(--text-positive) 34%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--text-positive) 5%, var(--bg-popover)), var(--bg-popover));
+  box-shadow: var(--shadow-medium), inset 0 0 0 1px color-mix(in srgb, var(--text-positive) 7%, transparent);
+}
+
+.active-call-title-btn {
+  color: var(--text-secondary);
+}
+
+.active-call-subtitle::before {
+  background: rgba(var(--ui-contrast-rgb), 0.3);
+}
+
+.callbar-ping-chip,
+.callbar-control-btn {
+  border-color: rgba(var(--ui-contrast-rgb), 0.12);
+  background: rgba(var(--ui-contrast-rgb), 0.06);
+  color: var(--text-secondary);
+}
+
+.callbar-controls-center {
+  background: rgba(var(--ui-contrast-rgb), 0.04);
+}
+
+.callbar-control-btn:hover:not(:disabled) {
+  border-color: rgba(var(--ui-contrast-rgb), 0.3);
+  background: rgba(var(--ui-contrast-rgb), 0.14);
+  color: var(--text-primary);
+}
+
+.callbar-control-btn.is-live,
+.callbar-control-btn.danger,
+.callbar-control-btn.is-off {
+  border-color: color-mix(in srgb, var(--text-danger) 65%, transparent);
+  background: color-mix(in srgb, var(--text-danger) 22%, transparent);
+  color: var(--text-danger);
+}
+
+.callbar-control-btn.media-control.is-live {
+  border-color: color-mix(in srgb, var(--text-positive) 62%, transparent);
+  background: color-mix(in srgb, var(--text-positive) 20%, transparent);
+  color: var(--text-positive);
+}
+
+.callbar-control-btn.is-server-off {
+  border-color: color-mix(in srgb, var(--text-warning) 58%, transparent);
+  background: color-mix(in srgb, var(--text-warning) 22%, transparent);
+  color: var(--text-warning);
+}
+
+/* Image preview chrome follows the selected palette; only the media remains neutral. */
+.chat-image-preview-backdrop {
+  background: var(--overlay-backdrop);
+}
+
+.chat-image-preview-modal {
+  border-color: rgba(var(--ui-contrast-rgb), 0.12);
+  background: var(--bg-popover);
+  box-shadow: var(--shadow-high);
+}
+
+.chat-image-preview-toolbar {
+  border-color: rgba(var(--ui-contrast-rgb), 0.1);
+}
+
+.chat-image-preview-stage,
+.chat-image-preview-image {
+  background: var(--bg-chat);
+}
+
+.chat-image-preview-close {
+  border-color: rgba(var(--ui-contrast-rgb), 0.12);
+  background: rgba(var(--ui-contrast-rgb), 0.06);
+  color: var(--text-secondary);
+}
+
+.chat-image-preview-close:hover {
+  background: rgba(var(--ui-contrast-rgb), 0.1);
+  color: var(--text-primary);
+}
+
 .server-welcome-guide__copy h2,
 .server-welcome-guide__copy p {
   color: var(--text-primary);


### PR DESCRIPTION
## Summary
- fix text contrast across Default, Dark, Light, and Custom themes
- apply semantic theme colors to member lists, voice stage, callbar, and image preview
- reorder theme cards as Default + Custom, then Dark + Light
- add Playwright regression coverage for theme readability and surfaces

## Validation
- npm run lint
- npm run test:run (223 tests)
- npm run build
- release settings E2E (8/8)
- mobile smoke (3/3)
- UI smoke (39/39)