### PR TITLE
fix: harden desktop oauth and media reliability

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -6,12 +6,14 @@ use image::{
 };
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use tauri::Manager;
 
 struct DesktopRuntimeState {
     minimize_to_tray_on_close: AtomicBool,
     allow_close_for_update: AtomicBool,
     tray_icon_variant: AtomicBool,
+    pending_deep_links: Mutex<Vec<String>>,
 }
 
 impl Default for DesktopRuntimeState {
@@ -20,6 +22,7 @@ impl Default for DesktopRuntimeState {
             minimize_to_tray_on_close: AtomicBool::new(true),
             allow_close_for_update: AtomicBool::new(false),
             tray_icon_variant: AtomicBool::new(false),
+            pending_deep_links: Mutex::new(Vec::new()),
         }
     }
 }
@@ -226,6 +229,17 @@ fn desktop_prepare_for_update_install(state: tauri::State<'_, DesktopRuntimeStat
 }
 
 #[tauri::command]
+fn desktop_take_pending_deep_links(
+    state: tauri::State<'_, DesktopRuntimeState>,
+) -> Vec<String> {
+    state
+        .pending_deep_links
+        .lock()
+        .map(|mut pending| std::mem::take(&mut *pending))
+        .unwrap_or_default()
+}
+
+#[tauri::command]
 fn desktop_update_unread_feedback(
     unread_count: u32,
     unread_increased: bool,
@@ -314,6 +328,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             desktop_set_minimize_to_tray_on_close,
             desktop_prepare_for_update_install,
+            desktop_take_pending_deep_links,
             desktop_update_unread_feedback,
             desktop_open_media_permission_settings
         ]);
@@ -329,6 +344,34 @@ fn main() {
         let window_state_flags = StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED;
 
         builder = builder
+            // Register single-instance handling before the other desktop plugins so an OAuth
+            // protocol launch cannot race the webview's JavaScript listener during startup.
+            .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+                let deep_link = args
+                    .iter()
+                    .find(|arg| arg.starts_with("voxpery://auth/"))
+                    .cloned();
+                let is_startup_instance = args.iter().any(|arg| arg == "--autostart");
+
+                if deep_link.is_some() || !is_startup_instance {
+                    show_main_window(app);
+                }
+
+                if let Some(url) = deep_link {
+                    if let Ok(mut pending) = app
+                        .state::<DesktopRuntimeState>()
+                        .pending_deep_links
+                        .lock()
+                    {
+                        if !pending.contains(&url) {
+                            pending.push(url.clone());
+                        }
+                    }
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.emit("custom-deep-link", url);
+                    }
+                }
+            }))
             .plugin(tauri_plugin_http::init())
             .plugin(tauri_plugin_secure_storage::init())
             .plugin(tauri_plugin_opener::init())
@@ -346,26 +389,6 @@ fn main() {
                     tauri_plugin_autostart::MacosLauncher::LaunchAgent,
                     Some(vec!["--autostart"]),
                 ))?;
-
-                let _ =
-                    app.handle()
-                        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-                            let deep_link = args
-                                .iter()
-                                .find(|arg| arg.starts_with("voxpery://"))
-                                .cloned();
-                            let is_startup_instance = args.iter().any(|arg| arg == "--autostart");
-
-                            if deep_link.is_some() || !is_startup_instance {
-                                show_main_window(app);
-                            }
-
-                            if let Some(w) = app.get_webview_window("main") {
-                                if let Some(arg) = deep_link {
-                                    let _ = w.emit("custom-deep-link", arg);
-                                }
-                            }
-                        }));
 
                 // System tray: icon + menu (Show, Quit)
                 let show_i = MenuItem::with_id(app, "show", "Show Voxpery", true, None::<&str>)?;

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{ConnectInfo, Query, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     middleware,
-    response::{Html, IntoResponse, Redirect},
+    response::{Html, IntoResponse, Redirect, Response},
     routing::{delete, get, patch, post},
     Extension, Json, Router,
 };
@@ -157,41 +157,90 @@ fn javascript_string_literal(value: &str) -> String {
         .replace('>', "\\u003e")
 }
 
-fn desktop_oauth_handoff_html(redirect_url: &str) -> String {
+fn desktop_oauth_handoff_html(redirect_url: &str, succeeded: bool) -> String {
     let href = escape_html_attribute(redirect_url);
     let app_url = javascript_string_literal(redirect_url);
+    let (eyebrow, title, message, action) = if succeeded {
+        (
+            "Desktop sign-in",
+            "You are signed in",
+            "Voxpery should open automatically. Keep this page open until the desktop app appears.",
+            "Open Voxpery",
+        )
+    } else {
+        (
+            "Desktop sign-in",
+            "Sign-in could not be completed",
+            "Return to Voxpery to review the error and try again.",
+            "Return to Voxpery",
+        )
+    };
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Opening Voxpery...</title>
+<meta name="color-scheme" content="dark">
+<title>{title} - Voxpery</title>
 <style>
-    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: #1e1e2e; color: #cdd6f4; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; text-align: center; }}
-    .card {{ background: #313244; padding: 2rem; border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.3); max-width: 400px; }}
-    h1 {{ color: #89b4fa; margin-bottom: 1rem; }}
-    p {{ line-height: 1.5; color: #a6adc8; }}
-    .btn {{ display: inline-block; margin-top: 1.5rem; padding: 0.75rem 1.5rem; background: #89b4fa; color: #1e1e2e; text-decoration: none; border-radius: 6px; font-weight: bold; transition: opacity 0.2s; }}
-    .btn:hover {{ opacity: 0.9; }}
+    :root {{ font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #f4f7ff; background: #11182d; }}
+    * {{ box-sizing: border-box; }}
+    body {{ min-height: 100vh; margin: 0; display: grid; place-items: center; padding: 24px; background: #11182d; }}
+    .card {{ width: min(100%, 460px); padding: 32px; border: 1px solid rgba(170, 196, 255, .18); border-radius: 8px; background: #1b2544; box-shadow: 0 22px 64px rgba(2, 7, 20, .45); text-align: left; }}
+    .brand {{ display: flex; align-items: center; gap: 10px; margin-bottom: 28px; font-weight: 800; font-size: 18px; }}
+    .mark {{ display: grid; place-items: center; width: 34px; height: 34px; border-radius: 9px; background: #4f7fd8; color: white; }}
+    .eyebrow {{ margin: 0 0 8px; color: #9fbae9; font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0; }}
+    h1 {{ margin: 0; color: #ffffff; font-size: clamp(24px, 6vw, 32px); line-height: 1.15; }}
+    p {{ margin: 14px 0 0; color: #bdc9e3; line-height: 1.55; }}
+    .status {{ min-height: 20px; margin-top: 18px; color: #9fbae9; font-size: 13px; }}
+    .btn {{ display: inline-flex; align-items: center; justify-content: center; width: 100%; min-height: 44px; margin-top: 20px; padding: 10px 16px; border: 1px solid #8bb4ff; border-radius: 8px; background: #4f7fd8; color: #ffffff; text-decoration: none; font-weight: 800; transition: background .15s ease, border-color .15s ease; }}
+    .btn:hover {{ background: #6090e5; border-color: #b2ceff; }}
+    .btn:focus-visible {{ outline: 3px solid rgba(160, 197, 255, .55); outline-offset: 3px; }}
+    @media (max-width: 480px) {{ body {{ padding: 14px; }} .card {{ padding: 24px 20px; }} }}
 </style>
 </head>
 <body>
 <main class="card">
-    <h1>Login Successful!</h1>
-    <p>You are being redirected to the Voxpery desktop app.</p>
-    <p>If the app does not open automatically, use the button below.</p>
-    <a id="open-voxpery" href="{href}" class="btn">Open Voxpery</a>
+    <div class="brand"><span class="mark" aria-hidden="true">V</span><span>Voxpery</span></div>
+    <p class="eyebrow">{eyebrow}</p>
+    <h1>{title}</h1>
+    <p>{message}</p>
+    <p id="handoff-status" class="status" role="status" aria-live="polite">Opening the desktop app...</p>
+    <a id="open-voxpery" href="{href}" class="btn">{action}</a>
 </main>
 <script>
     const appUrl = {app_url};
-    window.addEventListener("load", () => {{
-        window.setTimeout(() => window.location.replace(appUrl), 100);
-    }}, {{ once: true }});
+    const status = document.getElementById("handoff-status");
+    const openButton = document.getElementById("open-voxpery");
+    const openDesktop = () => {{
+        window.location.assign(appUrl);
+    }};
+    openButton.addEventListener("click", () => {{
+        status.textContent = "Opening Voxpery...";
+    }});
+    openDesktop();
+    window.setTimeout(() => {{
+        if (document.visibilityState === "visible") {{
+            status.textContent = "If Voxpery did not open, use the button below.";
+        }}
+    }}, 900);
 </script>
 </body>
 </html>"#
     )
+}
+
+fn oauth_callback_response(origin: &str, redirect_path: &str, error: Option<&str>) -> Response {
+    let path = error
+        .map(|code| append_query_param(redirect_path, "error", code))
+        .unwrap_or_else(|| redirect_path.to_string());
+    let redirect_url = format!("{}{}", origin, path);
+    if is_desktop_oauth_origin(origin) {
+        Html(desktop_oauth_handoff_html(&redirect_url, error.is_none())).into_response()
+    } else {
+        Redirect::temporary(&redirect_url).into_response()
+    }
 }
 
 fn is_valid_pkce_component(value: &str) -> bool {
@@ -288,7 +337,7 @@ async fn consume_desktop_oauth_code(
 mod oauth_pkce_tests {
     use super::{
         constant_time_eq, desktop_oauth_handoff_html, is_valid_pkce_component,
-        normalize_oauth_username_seed, pkce_s256_challenge,
+        normalize_oauth_username_seed, oauth_callback_response, pkce_s256_challenge,
     };
 
     #[test]
@@ -343,13 +392,33 @@ mod oauth_pkce_tests {
     fn desktop_oauth_handoff_keeps_automatic_and_manual_open_paths_safe() {
         let html = desktop_oauth_handoff_html(
             "voxpery://auth/servers?next=\"</script><script>alert(1)</script>&code=abc",
+            true,
         );
 
         assert!(html.contains("id=\"open-voxpery\""));
-        assert!(html.contains("window.location.replace(appUrl)"));
+        assert!(html.contains("window.location.assign(appUrl)"));
+        assert!(html.contains("You are signed in"));
         assert!(html.contains("&quot;&lt;/script&gt;"));
         assert!(html.contains("\\u003c/script\\u003e"));
         assert!(!html.contains("<script>alert(1)</script>"));
+    }
+
+    #[test]
+    fn desktop_oauth_failure_uses_the_branded_handoff_page() {
+        let response = oauth_callback_response(
+            "voxpery://auth",
+            "/servers",
+            Some("oauth_failed"),
+        );
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/html; charset=utf-8")
+        );
     }
 }
 
@@ -1708,10 +1777,12 @@ async fn google_oauth_callback(
             "OAuth CSRF check failed (state mismatch or missing cookie). has_cookie_state={}",
             found_oauth_state.is_some()
         );
-        let redirect_error = format!("{}?error=oauth_failed_csrf", redirect_path);
         let clear_cookie = clear_oauth_state_cookie_header(&state);
-        let mut response =
-            Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+        let mut response = oauth_callback_response(
+            &origin,
+            &redirect_path,
+            Some("oauth_failed_csrf"),
+        );
         if let Ok(v) = HeaderValue::from_str(&clear_cookie) {
             response.headers_mut().insert(header::SET_COOKIE, v);
         }
@@ -1731,8 +1802,7 @@ async fn google_oauth_callback(
         Ok(r) => r,
         Err(e) => {
             tracing::warn!("Google token exchange failed: {}", e);
-            let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-            return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+            return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
         }
     };
     if !token_res.status().is_success() {
@@ -1743,15 +1813,13 @@ async fn google_oauth_callback(
             status,
             body_len
         );
-        let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-        return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+        return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
     }
     let token_data: GoogleTokenResponse = match token_res.json().await {
         Ok(d) => d,
         Err(e) => {
             tracing::warn!("Google token parse failed: {}", e);
-            let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-            return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+            return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
         }
     };
 
@@ -1765,15 +1833,12 @@ async fn google_oauth_callback(
             Ok(u) => u,
             Err(e) => {
                 tracing::warn!("Google userinfo parse failed: {}", e);
-                let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-                return Redirect::temporary(&format!("{}{}", origin, redirect_error))
-                    .into_response();
+                return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
             }
         },
         _ => {
             tracing::warn!("Google userinfo request failed");
-            let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-            return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+            return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
         }
     };
 
@@ -1789,8 +1854,11 @@ async fn google_oauth_callback(
             "Google OAuth login rejected: unverified email ({})",
             redact_email_for_log(&email)
         );
-        let redirect_error = format!("{}?error=oauth_unverified_email", redirect_path);
-        return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+        return oauth_callback_response(
+            &origin,
+            &redirect_path,
+            Some("oauth_unverified_email"),
+        );
     }
 
     let user = sqlx::query_as::<_, User>(
@@ -1864,8 +1932,7 @@ async fn google_oauth_callback(
             .await
             {
                 tracing::warn!("Google OAuth insert user failed: {}", e);
-                let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-                return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+                return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
             }
             let user = match sqlx::query_as::<_, User>("SELECT * FROM users WHERE google_id = $1")
                 .bind(&google_id)
@@ -1874,9 +1941,7 @@ async fn google_oauth_callback(
             {
                 Ok(u) => u,
                 Err(_) => {
-                    let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-                    return Redirect::temporary(&format!("{}{}", origin, redirect_error))
-                        .into_response();
+                    return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
                 }
             };
             if let Err(e) = ensure_default_server_join(&state.db, user.id).await {
@@ -1886,8 +1951,7 @@ async fn google_oauth_callback(
         }
         Err(e) => {
             tracing::warn!("Google OAuth db lookup failed: {}", e);
-            let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-            return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+            return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
         }
     };
 
@@ -1901,8 +1965,7 @@ async fn google_oauth_callback(
         Ok(t) => t,
         Err(e) => {
             tracing::warn!("JWT generate failed: {}", e);
-            let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-            return Redirect::temporary(&format!("{}{}", origin, redirect_error)).into_response();
+            return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
         }
     };
 
@@ -1917,18 +1980,14 @@ async fn google_oauth_callback(
             Some(value) => value,
             None => {
                 tracing::warn!("Desktop OAuth callback missing PKCE challenge in state");
-                let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-                return Redirect::temporary(&format!("{}{}", origin, redirect_error))
-                    .into_response();
+                return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
             }
         };
         let exchange_code = match issue_desktop_oauth_code(&state, &token, challenge).await {
             Ok(code) => code,
             Err(e) => {
                 tracing::warn!("Failed to issue desktop OAuth code: {}", e);
-                let redirect_error = format!("{}?error=oauth_failed", redirect_path);
-                return Redirect::temporary(&format!("{}{}", origin, redirect_error))
-                    .into_response();
+                return oauth_callback_response(&origin, &redirect_path, Some("oauth_failed"));
             }
         };
         let path_with_code = append_query_param(&redirect_path, "code", &exchange_code);
@@ -1938,7 +1997,7 @@ async fn google_oauth_callback(
     };
 
     let mut response = if is_desktop {
-        Html(desktop_oauth_handoff_html(&redirect_url)).into_response()
+        Html(desktop_oauth_handoff_html(&redirect_url, true)).into_response()
     } else {
         Redirect::temporary(&redirect_url).into_response()
     };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -142,13 +142,15 @@ function App() {
 
       const bootstrapDesktopSession = async () => {
         await restoreSecureSession()
-        const [deepLink, event] = await Promise.all([
+        const [deepLink, event, core] = await Promise.all([
           import('@tauri-apps/plugin-deep-link'),
           import('@tauri-apps/api/event'),
+          import('@tauri-apps/api/core'),
         ])
         const cleanup = await registerDesktopOAuthDeepLinks(
           {
             getCurrent: deepLink.getCurrent,
+            getPending: () => core.invoke<string[]>('desktop_take_pending_deep_links'),
             onOpenUrl: deepLink.onOpenUrl,
             listenCustom: (handler) => event.listen<string>(
               'custom-deep-link',

--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -5,6 +5,7 @@ import type { MemberInfo } from '../api'
 import type { Channel, Server, User } from '../types'
 import { useAppStore } from '../stores/app'
 import { useAuthStore } from '../stores/auth'
+import { useToastStore } from '../stores/toast'
 import { useLiveKitVoice } from '../webrtc/useLiveKitVoice'
 import {
   GLOBAL_MUTE_SHORTCUT_EVENT,
@@ -106,7 +107,7 @@ function renderActiveCallBar(overrides?: Record<string, unknown>) {
     state: voiceState(overrides),
     joinVoice: vi.fn(),
     leaveVoice: vi.fn(),
-    startScreenShare: vi.fn(),
+    startScreenShare: vi.fn().mockResolvedValue({ hasAudio: true, audioPublished: true }),
     stopScreenShare: vi.fn(),
     startCamera: vi.fn(),
     stopCamera: vi.fn(),
@@ -133,6 +134,7 @@ describe('ActiveCallBar regressions', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
+    useToastStore.setState({ toasts: [] })
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
     Object.defineProperty(HTMLMediaElement.prototype, 'play', {
       configurable: true,
@@ -206,6 +208,23 @@ describe('ActiveCallBar regressions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Share screen' }))
     fireEvent.click(screen.getAllByRole('button', { name: 'Share screen' }).at(-1)!)
     await waitFor(() => expect(voice.playVoiceCue).toHaveBeenCalledWith('screen-start'))
+  })
+
+  it('explains when the selected screen source has no publishable audio track', async () => {
+    const { voice } = renderActiveCallBar()
+    voice.startScreenShare.mockResolvedValueOnce({ hasAudio: false, audioPublished: false })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share screen' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Share screen' }).at(-1)!)
+
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts).toEqual([
+        expect.objectContaining({
+          level: 'info',
+          title: 'Sharing without audio',
+        }),
+      ])
+    })
   })
 
   it('plays separate confirmations when local camera and screen sharing stop', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -23,6 +23,10 @@ import { ROUTES } from '../routes'
 import { attachMediaStreamPreview } from '../mediaStreamPreview'
 import { resolveAvatarUrl } from '../api'
 import { createRemoteAudioKindPlaybackStream, remoteMediaVisibilityKey, type RemoteMediaKind } from '../webrtc/remoteMediaControls'
+import {
+  attachRemoteVideoElement,
+  type VoxperyMediaStreamTrack,
+} from '../webrtc/livekitVideoAttachment'
 import { isTauri } from '../secureStorage'
 import {
   getStoredGlobalMuteShortcut,
@@ -31,11 +35,7 @@ import {
   keyboardEventMatchesShortcut,
 } from '../globalMuteShortcut'
 
-interface VoxperyTrack extends MediaStreamTrack {
-  __voxpery_isCamera?: boolean
-  __voxpery_isScreenShare?: boolean
-  __voxpery_isScreenShareAudio?: boolean
-}
+type VoxperyTrack = VoxperyMediaStreamTrack
 
 interface VoxperyAudioElement extends HTMLAudioElement {
   __voxpery_trackIds?: string
@@ -70,9 +70,21 @@ function readScreenShareQuality(): ScreenShareQuality {
 
 function screenShareQualitySummary(mode: ScreenShareQuality) {
   if (mode === 'presentation') return '1080p30 · 4 Mbps · detail'
-  if (mode === 'video') return '1080p60 · 6 Mbps · motion'
-  if (mode === 'gaming') return '1080p60 · 8 Mbps · high motion'
-  return 'Auto uses a balanced profile up to 1080p60 · 6 Mbps.'
+  if (mode === 'video') return '1080p60 · 8 Mbps · motion'
+  if (mode === 'gaming') return '1080p60 · 12 Mbps · high motion'
+  return 'Auto uses an adaptive profile up to 1080p60 · 8 Mbps.'
+}
+
+function RemoteVideoTrack({ track }: { track: MediaStreamTrack }) {
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+
+  useEffect(() => {
+    const element = videoRef.current
+    if (!element) return
+    return attachRemoteVideoElement(element, track)
+  }, [track])
+
+  return <video ref={videoRef} autoPlay muted playsInline />
 }
 
 export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId }: ActiveCallBarProps) {
@@ -231,7 +243,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const micTestPrevMutedRef = useRef(false)
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
-  const remoteVideoStreamByTrackIdRef = useRef<Map<string, MediaStream>>(new Map())
   // Per-playback WebAudio nodes for amplification above 100% (GainNode allows gain > 1.0).
   // Microphone and screen-share audio are separate playback paths so their volumes cannot affect each other.
   const perPeerAudioCtxRef = useRef<Map<string, { ctx: AudioContext; source: MediaElementAudioSourceNode; gain: GainNode }>>(new Map())
@@ -637,13 +648,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
-    const remoteVideoStreams = remoteVideoStreamByTrackIdRef.current
     return () => {
       for (const t of retryTimers.values()) {
         window.clearTimeout(t)
       }
       retryTimers.clear()
-      remoteVideoStreams.clear()
     }
   }, [])
 
@@ -1265,7 +1274,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                 if (isHidden) return null
                 return (
                   <div key={tileKey} className="screen-share-preview remote-screen-preview voice-stage-share-tile" data-fullscreen-key={tileKey} onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
-                    <video autoPlay muted playsInline ref={(el) => { if (!el) return; let stream = remoteVideoStreamByTrackIdRef.current.get(track.id); if (!stream) { stream = new MediaStream([track]); remoteVideoStreamByTrackIdRef.current.set(track.id, stream) }; if (el.srcObject !== stream) el.srcObject = stream; void el.play().catch(() => { }) }} />
+                    <RemoteVideoTrack track={track} />
                     <div className="screen-share-info-overlay"><span className="screen-share-info-text">{label} · {owner}</span></div>
                     <div className="screen-share-controls-bar">
                       <div className="screen-share-controls-left">

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -974,8 +974,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       void 0
     }
     try {
-      await startScreenShare()
+      const result = await startScreenShare()
       playVoiceCue('screen-start')
+      if (!result.audioPublished) {
+        pushToast({
+          level: 'info',
+          title: 'Sharing without audio',
+          message: 'No system or tab audio track was provided. Choose a supported tab or enable audio in the share picker to include sound.',
+        })
+      }
     } catch (e) {
       const permissionDenied = isMediaPermissionDeniedError(e, 'screen')
       const message = permissionDenied

--- a/apps/web/src/desktopOAuth.test.ts
+++ b/apps/web/src/desktopOAuth.test.ts
@@ -89,6 +89,7 @@ describe('desktop OAuth deep links', () => {
     const disposeCustom = vi.fn()
     const sources: DesktopOAuthDeepLinkSources = {
       getCurrent: vi.fn().mockResolvedValue([`voxpery://auth/servers?code=${code}`]),
+      getPending: vi.fn().mockResolvedValue([]),
       onOpenUrl: vi.fn(async (handler) => {
         opened = handler
         return disposeOpen
@@ -110,5 +111,21 @@ describe('desktop OAuth deep links', () => {
     dispose()
     expect(disposeOpen).toHaveBeenCalledTimes(1)
     expect(disposeCustom).toHaveBeenCalledTimes(1)
+  })
+
+  it('drains deep links received before the webview listener was ready', async () => {
+    const pendingUrl = `voxpery://auth/servers?code=${code}`
+    const sources: DesktopOAuthDeepLinkSources = {
+      getCurrent: vi.fn().mockResolvedValue([]),
+      getPending: vi.fn().mockResolvedValue([pendingUrl]),
+      onOpenUrl: vi.fn().mockResolvedValue(vi.fn()),
+      listenCustom: vi.fn().mockResolvedValue(vi.fn()),
+    }
+    const handler = vi.fn().mockResolvedValue(true)
+
+    await registerDesktopOAuthDeepLinks(sources, handler)
+
+    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledWith(pendingUrl)
   })
 })

--- a/apps/web/src/desktopOAuth.ts
+++ b/apps/web/src/desktopOAuth.ts
@@ -26,6 +26,7 @@ interface DesktopOAuthHandlerDependencies {
 
 export interface DesktopOAuthDeepLinkSources {
   getCurrent: () => Promise<string[] | null>
+  getPending: () => Promise<string[]>
   onOpenUrl: (handler: (urls: string[]) => void) => Promise<() => void>
   listenCustom: (handler: (url: string) => void) => Promise<() => void>
 }
@@ -143,6 +144,15 @@ export async function registerDesktopOAuthDeepLinks(
 
   try {
     cleanup.push(await sources.listenCustom(dispatch))
+  } catch (error) {
+    onError(error)
+  }
+
+  try {
+    const pendingUrls = await sources.getPending()
+    for (const url of pendingUrls) {
+      await handler(url)
+    }
   } catch (error) {
     onError(error)
   }

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -30,14 +30,14 @@ describe('screen share quality profiles', () => {
     expect(resolveScreenShareProfileForMode('video')).toEqual({
       resolution: '1080p',
       framerate: 60,
-      bitrate: 6_000_000,
+      bitrate: 8_000_000,
       contentHint: 'motion',
       degradationPreference: 'maintain-framerate',
     })
     expect(resolveScreenShareProfileForMode('gaming')).toEqual({
       resolution: '1080p',
       framerate: 60,
-      bitrate: 8_000_000,
+      bitrate: 12_000_000,
       contentHint: 'motion',
       degradationPreference: 'maintain-framerate',
     })

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -5,6 +5,7 @@ import {
   SCREEN_SHARE_PRESET_PROFILE,
   SCREEN_SHARE_CAPTURE_READY_EVENT,
   toScreenShareDisplayMediaOptions,
+  toScreenShareCaptureDiagnostics,
   toScreenShareConstraintsForProfile,
 } from './useLocalMedia'
 
@@ -72,5 +73,37 @@ describe('screen share quality profiles', () => {
       },
     })
     expect(SCREEN_SHARE_CAPTURE_READY_EVENT).toBe('voxpery-screen-share-capture-ready')
+  })
+
+  it('records requested and actual capture quality without device identifiers', () => {
+    const track = {
+      getSettings: () => ({
+        width: 1440,
+        height: 900,
+        frameRate: 28,
+        displaySurface: 'window',
+        deviceId: 'private-display-id',
+      }),
+    } as unknown as MediaStreamTrack
+
+    expect(toScreenShareCaptureDiagnostics(
+      SCREEN_SHARE_PRESET_PROFILE.presentation,
+      track,
+      false,
+      false,
+    )).toEqual({
+      requestedWidth: 1920,
+      requestedHeight: 1080,
+      requestedFramerate: 30,
+      actualWidth: 1440,
+      actualHeight: 900,
+      actualFramerate: 28,
+      displaySurface: 'window',
+      constraintsApplied: false,
+      audioCaptured: false,
+      videoPublished: false,
+      audioPublished: false,
+      simulcast: true,
+    })
   })
 })

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -45,14 +45,14 @@ export const SCREEN_SHARE_PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'au
     video: {
         resolution: '1080p',
         framerate: 60,
-        bitrate: 6_000_000,
+        bitrate: 8_000_000,
         contentHint: 'motion',
         degradationPreference: 'maintain-framerate',
     },
     gaming: {
         resolution: '1080p',
         framerate: 60,
-        bitrate: 8_000_000,
+        bitrate: 12_000_000,
         contentHint: 'motion',
         degradationPreference: 'maintain-framerate',
     },

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -5,6 +5,10 @@ import {
     getStoredVoiceInputDeviceId,
 } from '../../voiceDevices'
 import { reportObservabilityEvent } from '../../observability'
+import {
+    updateVoiceDiagnostics,
+    type ScreenShareCaptureDiagnostics,
+} from '../voiceDiagnostics'
 
 export const SCREEN_SHARE_QUALITY_KEY = 'voxpery-settings-screen-share-quality'
 export const SCREEN_SHARE_CAPTURE_READY_EVENT = 'voxpery-screen-share-capture-ready'
@@ -23,6 +27,11 @@ export type ScreenShareProfile = {
     bitrate: number
     contentHint: 'detail' | 'motion'
     degradationPreference: ScreenShareDegradationPreference
+}
+
+export type ScreenShareCaptureResult = {
+    stream: MediaStream
+    diagnostics: ScreenShareCaptureDiagnostics
 }
 
 export const SCREEN_SHARE_PRESET_PROFILE: Record<Exclude<ScreenShareQuality, 'auto'>, ScreenShareProfile> = {
@@ -94,6 +103,37 @@ export function toScreenShareDisplayMediaOptions(
     }
 }
 
+function finiteSetting(value: number | undefined): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export function toScreenShareCaptureDiagnostics(
+    profile: ScreenShareProfile,
+    videoTrack: MediaStreamTrack,
+    audioCaptured: boolean,
+    constraintsApplied: boolean,
+): ScreenShareCaptureDiagnostics {
+    const settings = videoTrack.getSettings?.() ?? {}
+    const requested = toScreenShareConstraintsForProfile(profile)
+    const requestedWidth = requested.width as { ideal?: number } | undefined
+    const requestedHeight = requested.height as { ideal?: number } | undefined
+    const requestedFrameRate = requested.frameRate as { ideal?: number } | undefined
+    return {
+        requestedWidth: finiteSetting(requestedWidth?.ideal),
+        requestedHeight: finiteSetting(requestedHeight?.ideal),
+        requestedFramerate: finiteSetting(requestedFrameRate?.ideal),
+        actualWidth: finiteSetting(settings.width),
+        actualHeight: finiteSetting(settings.height),
+        actualFramerate: finiteSetting(settings.frameRate),
+        displaySurface: settings.displaySurface,
+        constraintsApplied,
+        audioCaptured,
+        videoPublished: false,
+        audioPublished: false,
+        simulcast: true,
+    }
+}
+
 export function useLocalMedia() {
     const cachedMicStreamRef = useRef<MediaStream | null>(null)
     const cachedMicDeviceIdRef = useRef<string>('')
@@ -122,17 +162,18 @@ export function useLocalMedia() {
         return toScreenShareConstraints(profile)
     }, [resolveQualityMode, resolveScreenShareProfile, toScreenShareConstraints])
 
-    const applyScreenShareTrackProfile = useCallback(async (videoTrack: MediaStreamTrack | undefined) => {
-        if (!videoTrack) return
+    const applyScreenShareTrackProfile = useCallback(async (videoTrack: MediaStreamTrack) => {
         const profile = resolveScreenShareProfile(videoTrack.getSettings?.().displaySurface)
         if ('contentHint' in videoTrack) {
             try { videoTrack.contentHint = profile.contentHint } catch { /* ignore */ }
         }
+        let constraintsApplied = true
         try {
             await videoTrack.applyConstraints(toScreenShareConstraints(profile))
         } catch {
-            // Browsers may refuse post-selection display constraints; publish encoding still caps bandwidth/FPS.
+            constraintsApplied = false
         }
+        return { profile, constraintsApplied }
     }, [resolveScreenShareProfile, toScreenShareConstraints])
 
     // Apply browser-level mic constraints.
@@ -231,11 +272,22 @@ export function useLocalMedia() {
         throw new Error('Unable to access camera')
     }, [])
 
-    const getScreenStream = useCallback(async (): Promise<MediaStream> => {
+    const getScreenStream = useCallback(async (): Promise<ScreenShareCaptureResult> => {
         const cached = cachedScreenStreamRef.current
         if (cached) {
             const video = cached.getVideoTracks()[0]
-            if (video?.readyState === 'live') return cached
+            if (video?.readyState === 'live') {
+                const profile = resolveScreenShareProfile(video.getSettings?.().displaySurface)
+                return {
+                    stream: cached,
+                    diagnostics: toScreenShareCaptureDiagnostics(
+                        profile,
+                        video,
+                        cached.getAudioTracks().some((track) => track.readyState === 'live'),
+                        true,
+                    ),
+                }
+            }
             cached.getTracks().forEach((t) => t.stop())
             cachedScreenStreamRef.current = null
         }
@@ -244,16 +296,28 @@ export function useLocalMedia() {
             const stream = await navigator.mediaDevices.getDisplayMedia(
                 toScreenShareDisplayMediaOptions(videoConstraints),
             )
-            await applyScreenShareTrackProfile(stream.getVideoTracks()[0])
+            const videoTrack = stream.getVideoTracks()[0]
+            if (!videoTrack) {
+                stream.getTracks().forEach((track) => track.stop())
+                throw new Error('No screen video track was captured')
+            }
+            const { profile, constraintsApplied } = await applyScreenShareTrackProfile(videoTrack)
+            const diagnostics = toScreenShareCaptureDiagnostics(
+                profile,
+                videoTrack,
+                stream.getAudioTracks().some((track) => track.readyState === 'live'),
+                constraintsApplied,
+            )
             cachedScreenStreamRef.current = stream
             window.dispatchEvent(new Event(SCREEN_SHARE_CAPTURE_READY_EVENT))
             reportObservabilityEvent('media_screen_share_started')
-            return stream
+            updateVoiceDiagnostics({ screenShare: diagnostics })
+            return { stream, diagnostics }
         } catch (error) {
             reportObservabilityEvent('media_screen_share_failed')
             throw error
         }
-    }, [applyScreenShareTrackProfile, getScreenShareConstraints])
+    }, [applyScreenShareTrackProfile, getScreenShareConstraints, resolveScreenShareProfile])
 
     /** Returns LiveKit-compatible videoEncoding and content hint based on quality mode. */
     const getScreenShareEncoding = useCallback((videoTrack?: MediaStreamTrack): {

--- a/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.test.ts
+++ b/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { extractScreenShareOutboundSample } from './useWebrtcDiagnostics'
+
+describe('screen share outbound diagnostics', () => {
+  it('aggregates simulcast layers for the active screen track only', () => {
+    const reports = [
+      {
+        id: 'source-screen',
+        type: 'media-source',
+        timestamp: 2_000,
+        trackIdentifier: 'screen-track',
+      },
+      {
+        id: 'screen-low',
+        type: 'outbound-rtp',
+        timestamp: 2_000,
+        kind: 'video',
+        mediaSourceId: 'source-screen',
+        frameWidth: 640,
+        frameHeight: 360,
+        framesPerSecond: 15,
+        bytesSent: 10_000,
+        packetsSent: 100,
+        qualityLimitationReason: 'bandwidth',
+      },
+      {
+        id: 'screen-high',
+        type: 'outbound-rtp',
+        timestamp: 2_000,
+        kind: 'video',
+        mediaSourceId: 'source-screen',
+        frameWidth: 1280,
+        frameHeight: 720,
+        framesPerSecond: 30,
+        bytesSent: 30_000,
+        packetsSent: 200,
+        qualityLimitationReason: 'none',
+      },
+      {
+        id: 'camera',
+        type: 'outbound-rtp',
+        timestamp: 2_000,
+        kind: 'video',
+        trackIdentifier: 'camera-track',
+        bytesSent: 99_000,
+      },
+    ] as unknown as RTCStats[]
+
+    expect(extractScreenShareOutboundSample(reports, 'screen-track')).toEqual({
+      width: 1280,
+      height: 720,
+      framesPerSecond: 30,
+      packetsSent: 300,
+      packetsLost: undefined,
+      qualityLimitationReason: 'bandwidth',
+      bytesSent: 40_000,
+      timestamp: 2_000,
+    })
+  })
+
+  it('returns null when stats do not belong to the screen track', () => {
+    expect(extractScreenShareOutboundSample([
+      {
+        id: 'camera',
+        type: 'outbound-rtp',
+        timestamp: 1_000,
+        kind: 'video',
+        trackIdentifier: 'camera-track',
+      } as RTCStats,
+    ], 'screen-track')).toBeNull()
+  })
+})

--- a/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.ts
+++ b/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
-import { Room } from 'livekit-client'
-import { updateVoiceDiagnostics } from '../voiceDiagnostics'
+import { Room, Track } from 'livekit-client'
+import {
+    updateVoiceDiagnostics,
+    type ScreenShareOutboundDiagnostics,
+} from '../voiceDiagnostics'
 
 const PING_WINDOW_SIZE = 7
 const RTC_BURST_SAMPLE_COUNT = 6
@@ -9,6 +12,87 @@ const RTC_STEADY_INTERVAL_MS = 2500
 const WS_PING_INTERVAL_MS = 2500
 
 type PingSource = 'rtc' | 'ws' | null
+
+export interface ScreenShareOutboundSample extends ScreenShareOutboundDiagnostics {
+    bytesSent?: number
+    timestamp?: number
+}
+
+function finiteNumber(value: unknown): number | undefined {
+    const numeric = Number(value)
+    return Number.isFinite(numeric) ? numeric : undefined
+}
+
+export function extractScreenShareOutboundSample(
+    reports: RTCStats[],
+    trackIdentifier: string,
+): ScreenShareOutboundSample | null {
+    const byId = new Map(reports.map((report) => [report.id, report]))
+    const matches: ScreenShareOutboundSample[] = []
+    for (const report of reports) {
+        if (report.type !== 'outbound-rtp') continue
+        const outbound = report as RTCOutboundRtpStreamStats & {
+            mediaType?: string
+            mediaSourceId?: string
+            trackId?: string
+            trackIdentifier?: string
+            qualityLimitationReason?: string
+            isRemote?: boolean
+        }
+        if ((outbound.kind ?? outbound.mediaType) !== 'video' || outbound.isRemote) continue
+
+        const source = outbound.mediaSourceId ? byId.get(outbound.mediaSourceId) : undefined
+        const legacyTrack = outbound.trackId ? byId.get(outbound.trackId) : undefined
+        const sourceIdentifier = String(
+            outbound.trackIdentifier
+            ?? (source as (RTCStats & { trackIdentifier?: string }) | undefined)?.trackIdentifier
+            ?? (legacyTrack as (RTCStats & { trackIdentifier?: string }) | undefined)?.trackIdentifier
+            ?? '',
+        )
+        if (sourceIdentifier !== trackIdentifier) continue
+
+        const remoteInbound = reports.find((candidate) => (
+            candidate.type === 'remote-inbound-rtp'
+            && (candidate as RTCStats & { localId?: string }).localId === outbound.id
+        )) as (RTCStats & { packetsLost?: number }) | undefined
+
+        matches.push({
+            width: finiteNumber(outbound.frameWidth),
+            height: finiteNumber(outbound.frameHeight),
+            framesPerSecond: finiteNumber(outbound.framesPerSecond),
+            packetsSent: finiteNumber(outbound.packetsSent),
+            packetsLost: finiteNumber(remoteInbound?.packetsLost),
+            qualityLimitationReason: outbound.qualityLimitationReason,
+            bytesSent: finiteNumber(outbound.bytesSent),
+            timestamp: finiteNumber(outbound.timestamp),
+        })
+    }
+    if (matches.length === 0) return null
+
+    const sum = (key: 'bytesSent' | 'packetsSent' | 'packetsLost') => {
+        const values = matches.map((match) => match[key]).filter((value): value is number => value != null)
+        return values.length > 0 ? values.reduce((total, value) => total + value, 0) : undefined
+    }
+    const max = (key: 'width' | 'height' | 'framesPerSecond' | 'timestamp') => {
+        const values = matches.map((match) => match[key]).filter((value): value is number => value != null)
+        return values.length > 0 ? Math.max(...values) : undefined
+    }
+    const limitation = matches
+        .map((match) => match.qualityLimitationReason)
+        .find((reason) => reason && reason !== 'none')
+        ?? matches[0]?.qualityLimitationReason
+
+    return {
+        width: max('width'),
+        height: max('height'),
+        framesPerSecond: max('framesPerSecond'),
+        packetsSent: sum('packetsSent'),
+        packetsLost: sum('packetsLost'),
+        qualityLimitationReason: limitation,
+        bytesSent: sum('bytesSent'),
+        timestamp: max('timestamp'),
+    }
+}
 
 const clamp = (value: number, min: number, max: number) =>
     Math.min(max, Math.max(min, value))
@@ -85,6 +169,7 @@ export function useWebrtcDiagnostics(options: {
     const rtcPingJitterMsRef = useRef<number | null>(null)
     const selectedPingSourceRef = useRef<PingSource>(null)
     const prevInboundTotalsRef = useRef<InboundTotals | null>(null)
+    const previousScreenShareOutboundRef = useRef<ScreenShareOutboundSample | null>(null)
 
     // WS ping/pong — kept as fallback while RTC path is unavailable.
     useEffect(() => {
@@ -146,6 +231,7 @@ export function useWebrtcDiagnostics(options: {
             rtcSmoothedRef.current = null
             rtcPingJitterMsRef.current = null
             prevInboundTotalsRef.current = null
+            previousScreenShareOutboundRef.current = null
             return
         }
 
@@ -185,6 +271,46 @@ export function useWebrtcDiagnostics(options: {
                     stats.forEach((report) => {
                         if (report?.id) byId.set(report.id, report)
                     })
+
+                    const screenPublication = room.localParticipant.getTrackPublication(Track.Source.ScreenShare)
+                    const screenTrackIdentifier = screenPublication?.track?.mediaStreamTrack.id
+                    if (screenTrackIdentifier) {
+                        const sample = extractScreenShareOutboundSample(
+                            Array.from(stats.values()),
+                            screenTrackIdentifier,
+                        )
+                        if (sample) {
+                            const previous = previousScreenShareOutboundRef.current
+                            let bitrateKbps: number | undefined
+                            if (
+                                previous?.bytesSent != null
+                                && previous.timestamp != null
+                                && sample.bytesSent != null
+                                && sample.timestamp != null
+                                && sample.timestamp > previous.timestamp
+                                && sample.bytesSent >= previous.bytesSent
+                            ) {
+                                bitrateKbps = Math.round(
+                                    ((sample.bytesSent - previous.bytesSent) * 8)
+                                    / (sample.timestamp - previous.timestamp),
+                                )
+                            }
+                            previousScreenShareOutboundRef.current = sample
+                            updateVoiceDiagnostics({
+                                screenShareOutbound: {
+                                    width: sample.width,
+                                    height: sample.height,
+                                    framesPerSecond: sample.framesPerSecond,
+                                    bitrateKbps,
+                                    packetsSent: sample.packetsSent,
+                                    packetsLost: sample.packetsLost,
+                                    qualityLimitationReason: sample.qualityLimitationReason,
+                                },
+                            })
+                        }
+                    } else {
+                        previousScreenShareOutboundRef.current = null
+                    }
 
                     // Transport-selected candidate pair (Chromium/WebKit).
                     stats.forEach((report) => {

--- a/apps/web/src/webrtc/livekitVideoAttachment.test.ts
+++ b/apps/web/src/webrtc/livekitVideoAttachment.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  associateLiveKitVideoTrack,
+  attachRemoteVideoElement,
+} from './livekitVideoAttachment'
+
+function videoTrack(id = 'screen-track') {
+  return {
+    id,
+    kind: 'video',
+    enabled: true,
+    muted: false,
+    readyState: 'live',
+  } as MediaStreamTrack
+}
+
+describe('livekitVideoAttachment', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue()
+  })
+
+  it('uses the LiveKit attach lifecycle required by adaptive stream', () => {
+    const element = document.createElement('video')
+    const track = videoTrack()
+    const liveKitTrack = {
+      attach: vi.fn((target: HTMLMediaElement) => target),
+      detach: vi.fn((target: HTMLMediaElement) => target),
+    }
+    associateLiveKitVideoTrack(track, liveKitTrack)
+
+    const cleanup = attachRemoteVideoElement(element, track)
+
+    expect(liveKitTrack.attach).toHaveBeenCalledWith(element)
+    cleanup()
+    expect(liveKitTrack.detach).toHaveBeenCalledWith(element)
+  })
+
+  it('keeps a MediaStream fallback for non-LiveKit video tracks', () => {
+    const element = document.createElement('video')
+    const track = videoTrack('fallback-track')
+
+    const cleanup = attachRemoteVideoElement(element, track)
+
+    expect((element.srcObject as MediaStream).getVideoTracks()).toEqual([track])
+    cleanup()
+    expect(element.srcObject).toBeNull()
+  })
+})

--- a/apps/web/src/webrtc/livekitVideoAttachment.ts
+++ b/apps/web/src/webrtc/livekitVideoAttachment.ts
@@ -1,0 +1,46 @@
+export interface AttachableLiveKitVideoTrack {
+  attach(element: HTMLMediaElement): HTMLMediaElement
+  detach(element: HTMLMediaElement): HTMLMediaElement
+}
+
+export interface VoxperyMediaStreamTrack extends MediaStreamTrack {
+  __voxpery_isCamera?: boolean
+  __voxpery_isScreenShare?: boolean
+  __voxpery_isScreenShareAudio?: boolean
+  __voxpery_livekitVideoTrack?: AttachableLiveKitVideoTrack
+}
+
+export function associateLiveKitVideoTrack(
+  mediaTrack: MediaStreamTrack,
+  liveKitTrack: AttachableLiveKitVideoTrack,
+): void {
+  Object.defineProperty(mediaTrack, '__voxpery_livekitVideoTrack', {
+    value: liveKitTrack,
+    writable: true,
+    configurable: true,
+  })
+}
+
+export function attachRemoteVideoElement(
+  element: HTMLVideoElement,
+  mediaTrack: MediaStreamTrack,
+): () => void {
+  const voxperyTrack = mediaTrack as VoxperyMediaStreamTrack
+  const liveKitTrack = voxperyTrack.__voxpery_livekitVideoTrack
+
+  if (liveKitTrack) {
+    liveKitTrack.attach(element)
+    void element.play().catch(() => undefined)
+    return () => {
+      liveKitTrack.detach(element)
+      if (element.srcObject) element.srcObject = null
+    }
+  }
+
+  const stream = new MediaStream([mediaTrack])
+  element.srcObject = stream
+  void element.play().catch(() => undefined)
+  return () => {
+    if (element.srcObject === stream) element.srcObject = null
+  }
+}

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   clearRemoteMediaStartCue,
   getMicrophonePublishOptions,
+  getPreferredScreenShareCodec,
   getScreenSharePublishOptions,
   reconcileFinalMediaDisconnect,
   remoteMediaKindForSource,
@@ -13,7 +14,7 @@ import {
   shouldPlayRemoteMediaStopCue,
   shouldRecoverMicrophoneTrack,
 } from './useLiveKitVoice'
-import { AudioPresets, ScreenSharePresets, Track } from 'livekit-client'
+import { AudioPresets, Track } from 'livekit-client'
 
 describe('microphone publish options', () => {
   it('uses a high-quality mono Opus profile with resilience enabled', () => {
@@ -28,20 +29,46 @@ describe('microphone publish options', () => {
 })
 
 describe('media reliability', () => {
-  it('publishes adaptive screen-share layers instead of one all-or-nothing layer', () => {
-    expect(getScreenSharePublishOptions({
-      maxBitrate: 6_000_000,
+  it('keeps 60 FPS on the VP8 fallback layers instead of dropping motion to 30 FPS', () => {
+    const options = getScreenSharePublishOptions({
+      maxBitrate: 8_000_000,
       maxFramerate: 60,
       contentHint: 'motion',
       degradationPreference: 'maintain-framerate',
-    })).toMatchObject({
+    }, 'vp8')
+
+    expect(options).toMatchObject({
       source: Track.Source.ScreenShare,
       simulcast: true,
-      screenShareEncoding: { maxBitrate: 6_000_000, maxFramerate: 60 },
-      screenShareSimulcastLayers: [
-        ScreenSharePresets.h360fps15,
-        ScreenSharePresets.h720fps30,
-      ],
+      videoCodec: 'vp8',
+      screenShareEncoding: { maxBitrate: 8_000_000, maxFramerate: 60 },
+    })
+    expect(options.screenShareSimulcastLayers).toHaveLength(2)
+    expect(options.screenShareSimulcastLayers?.map((preset) => ({
+      width: preset.width,
+      height: preset.height,
+      maxFramerate: preset.encoding.maxFramerate,
+    }))).toEqual([
+      { width: 640, height: 360, maxFramerate: 30 },
+      { width: 1280, height: 720, maxFramerate: 60 },
+    ])
+  })
+
+  it('uses VP9 SVC when supported and retains VP8 as the compatibility fallback', () => {
+    expect(getPreferredScreenShareCodec(true)).toBe('vp9')
+    expect(getPreferredScreenShareCodec(false)).toBe('vp8')
+
+    expect(getScreenSharePublishOptions({
+      maxBitrate: 8_000_000,
+      maxFramerate: 60,
+      contentHint: 'motion',
+      degradationPreference: 'maintain-framerate',
+    }, 'vp9')).toMatchObject({
+      videoCodec: 'vp9',
+      backupCodec: true,
+      scalabilityMode: 'L3T3_KEY',
+      simulcast: false,
+      screenShareSimulcastLayers: undefined,
     })
   })
 

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   clearRemoteMediaStartCue,
   getMicrophonePublishOptions,
+  getScreenSharePublishOptions,
   reconcileFinalMediaDisconnect,
   remoteMediaKindForSource,
   remoteMediaStartCueKey,
@@ -10,8 +11,9 @@ import {
   shouldSubscribeRemoteTrack,
   shouldPlayRemoteMediaStartCue,
   shouldPlayRemoteMediaStopCue,
+  shouldRecoverMicrophoneTrack,
 } from './useLiveKitVoice'
-import { AudioPresets, Track } from 'livekit-client'
+import { AudioPresets, ScreenSharePresets, Track } from 'livekit-client'
 
 describe('microphone publish options', () => {
   it('uses a high-quality mono Opus profile with resilience enabled', () => {
@@ -22,6 +24,35 @@ describe('microphone publish options', () => {
       red: true,
       forceStereo: false,
     })
+  })
+})
+
+describe('media reliability', () => {
+  it('publishes adaptive screen-share layers instead of one all-or-nothing layer', () => {
+    expect(getScreenSharePublishOptions({
+      maxBitrate: 6_000_000,
+      maxFramerate: 60,
+      contentHint: 'motion',
+      degradationPreference: 'maintain-framerate',
+    })).toMatchObject({
+      source: Track.Source.ScreenShare,
+      simulcast: true,
+      screenShareEncoding: { maxBitrate: 6_000_000, maxFramerate: 60 },
+      screenShareSimulcastLayers: [
+        ScreenSharePresets.h360fps15,
+        ScreenSharePresets.h720fps30,
+      ],
+    })
+  })
+
+  it('recovers only the active ended microphone in a joined call', () => {
+    const activeTrack = { readyState: 'ended' } as MediaStreamTrack
+    const staleTrack = { readyState: 'ended' } as MediaStreamTrack
+
+    expect(shouldRecoverMicrophoneTrack(activeTrack, activeTrack, 'voice-1', false)).toBe(true)
+    expect(shouldRecoverMicrophoneTrack(staleTrack, activeTrack, 'voice-1', false)).toBe(false)
+    expect(shouldRecoverMicrophoneTrack(activeTrack, activeTrack, null, false)).toBe(false)
+    expect(shouldRecoverMicrophoneTrack(activeTrack, activeTrack, 'voice-1', true)).toBe(false)
   })
 })
 

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -5,6 +5,7 @@ import {
   RemoteParticipant,
   Room,
   RoomEvent,
+  ScreenSharePresets,
   setLogLevel,
   Track,
   type RemoteTrackPublication,
@@ -16,7 +17,7 @@ import { useAppStore } from '../stores/app'
 import { useSocketStore } from '../stores/socket'
 import { startAudioLevelMonitor } from './audioLevelMonitor'
 import { useAudioEngine } from './hooks/useAudioEngine'
-import { useLocalMedia } from './hooks/useLocalMedia'
+import { useLocalMedia, type ScreenShareCaptureResult } from './hooks/useLocalMedia'
 import { useVoiceActivity } from './hooks/useVoiceActivity'
 import { useWebrtcDiagnostics } from './hooks/useWebrtcDiagnostics'
 import { getStoredVoiceInputDeviceId, VOICE_SETTINGS_CHANGED_EVENT } from '../voiceDevices'
@@ -52,6 +53,47 @@ export function getMicrophonePublishOptions(): TrackPublishOptions {
     red: true,
     forceStereo: false,
   }
+}
+
+type ScreenShareEncoding = {
+  maxBitrate: number
+  maxFramerate: number
+  contentHint: 'detail' | 'motion'
+  degradationPreference: 'maintain-resolution' | 'maintain-framerate'
+}
+
+export interface ScreenShareStartResult {
+  hasAudio: boolean
+  audioPublished: boolean
+}
+
+export function getScreenSharePublishOptions(
+  encoding: ScreenShareEncoding,
+): TrackPublishOptions {
+  return {
+    source: Track.Source.ScreenShare,
+    screenShareEncoding: {
+      maxBitrate: encoding.maxBitrate,
+      maxFramerate: encoding.maxFramerate,
+    },
+    screenShareSimulcastLayers: encoding.maxFramerate >= 50
+      ? [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps30]
+      : [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps15],
+    degradationPreference: encoding.degradationPreference,
+    simulcast: true,
+  }
+}
+
+export function shouldRecoverMicrophoneTrack(
+  endedTrack: MediaStreamTrack,
+  currentTrack: MediaStreamTrack | null,
+  joinedChannelId: string | null,
+  recoveryInFlight: boolean,
+): boolean {
+  return !!joinedChannelId
+    && endedTrack === currentTrack
+    && endedTrack.readyState === 'ended'
+    && !recoveryInFlight
 }
 
 export function shouldSubscribeRemoteTrack(
@@ -220,6 +262,9 @@ export function useLiveKitVoice() {
   const finalMediaDisconnectHandlerRef = useRef<(isCurrentRoom: boolean) => void>(() => undefined)
   const desiredMicMutedRef = useRef(false)
   const activeInputDeviceIdRef = useRef(getStoredVoiceInputDeviceId())
+  const microphoneRecoveryInFlightRef = useRef(false)
+  const microphoneEndedHandlerRef = useRef<(track: MediaStreamTrack) => void>(() => undefined)
+  const microphoneDeviceChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const [joinedChannelId, setJoinedChannelId] = useState<string | null>(null)
   const isJoiningRef = useRef(false)
@@ -445,6 +490,7 @@ export function useLiveKitVoice() {
     let ownsSourceStream = false
     let nextTrack: MediaStreamTrack | null = null
     let nextGateCancel: (() => void) | null = null
+    let trackReplaced = false
 
     try {
       if (!forceNewDeviceStream && previousRawTrack && previousRawTrack.readyState === 'live') {
@@ -467,19 +513,22 @@ export function useLiveKitVoice() {
       )
       nextTrack = built.track
       nextGateCancel = built.cancelGate
+      const nextRawTrack = rawMicTrackRef.current
+      if (nextRawTrack) {
+        nextRawTrack.onended = () => microphoneEndedHandlerRef.current(nextRawTrack)
+      }
 
-      await room.localParticipant.unpublishTrack(previousTrack)
-      previousTrack.stop()
-
-      const publication = await room.localParticipant.publishTrack(nextTrack, getMicrophonePublishOptions())
+      await previousTrack.replaceTrack(nextTrack)
+      trackReplaced = true
       previousGateCancel?.()
       gateCancelRef.current = nextGateCancel
-      localAudioTrackRef.current = publication.track as LocalAudioTrack
+      localAudioTrackRef.current = previousTrack
       vadStreamRef.current = built.vadStream
 
       if (forceNewDeviceStream) {
         activeInputDeviceIdRef.current = getStoredVoiceInputDeviceId()
         if (previousRawTrack && previousRawTrack !== rawMicTrackRef.current) {
+          previousRawTrack.onended = null
           previousRawTrack.stop()
         }
       }
@@ -489,7 +538,7 @@ export function useLiveKitVoice() {
       await setLocalMicMuted(desiredMicMutedRef.current)
     } catch (error) {
       nextGateCancel?.()
-      if (nextTrack) {
+      if (nextTrack && !trackReplaced) {
         try {
           nextTrack.stop()
         } catch {
@@ -497,7 +546,10 @@ export function useLiveKitVoice() {
         }
       }
       if (ownsSourceStream) {
-        sourceStream?.getTracks().forEach((track) => track.stop())
+        sourceStream?.getTracks().forEach((track) => {
+          track.onended = null
+          track.stop()
+        })
       }
       rawMicTrackRef.current = previousRawTrack
       inputGainNodeRef.current = previousInputGainNode
@@ -509,6 +561,67 @@ export function useLiveKitVoice() {
   const switchMicrophoneDevice = useCallback(async () => {
     await rebuildPublishedMicrophoneTrack({ forceNewDeviceStream: true })
   }, [rebuildPublishedMicrophoneTrack])
+
+  const recoverMicrophoneCapture = useCallback(async () => {
+    if (microphoneRecoveryInFlightRef.current || !joinedChannelIdRef.current) return
+    microphoneRecoveryInFlightRef.current = true
+    try {
+      await rebuildPublishedMicrophoneTrack({ forceNewDeviceStream: true })
+    } finally {
+      microphoneRecoveryInFlightRef.current = false
+    }
+  }, [rebuildPublishedMicrophoneTrack])
+
+  useEffect(() => {
+    microphoneEndedHandlerRef.current = (endedTrack) => {
+      if (!shouldRecoverMicrophoneTrack(
+        endedTrack,
+        rawMicTrackRef.current,
+        joinedChannelIdRef.current,
+        microphoneRecoveryInFlightRef.current,
+      )) return
+      void recoverMicrophoneCapture()
+    }
+  }, [recoverMicrophoneCapture])
+
+  useEffect(() => {
+    const mediaDevices = navigator.mediaDevices
+    if (!mediaDevices?.addEventListener) return
+
+    const handleDeviceChange = () => {
+      if (!joinedChannelIdRef.current) return
+      if (microphoneDeviceChangeTimerRef.current) {
+        clearTimeout(microphoneDeviceChangeTimerRef.current)
+      }
+      microphoneDeviceChangeTimerRef.current = setTimeout(() => {
+        microphoneDeviceChangeTimerRef.current = null
+        void (async () => {
+          const preferredDeviceId = getStoredVoiceInputDeviceId()
+          if (preferredDeviceId && mediaDevices.enumerateDevices) {
+            try {
+              const devices = await mediaDevices.enumerateDevices()
+              const preferredStillExists = devices.some(
+                (device) => device.kind === 'audioinput' && device.deviceId === preferredDeviceId,
+              )
+              if (preferredStillExists) return
+            } catch {
+              // Re-capture below; getUserMedia provides the authoritative fallback result.
+            }
+          }
+          await recoverMicrophoneCapture()
+        })()
+      }, 350)
+    }
+
+    mediaDevices.addEventListener('devicechange', handleDeviceChange)
+    return () => {
+      mediaDevices.removeEventListener('devicechange', handleDeviceChange)
+      if (microphoneDeviceChangeTimerRef.current) {
+        clearTimeout(microphoneDeviceChangeTimerRef.current)
+        microphoneDeviceChangeTimerRef.current = null
+      }
+    }
+  }, [recoverMicrophoneCapture])
 
   const cancelRemoteScreenStopCue = useCallback((peerId: PeerId) => {
     const timer = remoteScreenStopCueTimersRef.current.get(peerId)
@@ -650,6 +763,10 @@ export function useLiveKitVoice() {
         noiseSuppressionEnabled,
       )
       gateCancelRef.current = cancelGate
+      const activeRawMicTrack = rawMicTrackRef.current
+      if (activeRawMicTrack) {
+        activeRawMicTrack.onended = () => microphoneEndedHandlerRef.current(activeRawMicTrack)
+      }
 
       // Keep vadStream ref so we can pass it to the speaking monitor after room connect
       vadStreamRef.current = vadStream
@@ -665,7 +782,10 @@ export function useLiveKitVoice() {
           red: true,
           forceStereo: false,
           screenShareEncoding: getScreenShareEncoding(),
-          screenShareSimulcastLayers: [],
+          screenShareSimulcastLayers: [
+            ScreenSharePresets.h360fps15,
+            ScreenSharePresets.h720fps15,
+          ],
           videoEncoding: { maxBitrate: 3_000_000, maxFramerate: 30 },
         },
       })
@@ -932,6 +1052,7 @@ export function useLiveKitVoice() {
     localAudioTrackRef.current?.stop()
     localAudioTrackRef.current = null
     destroyRnnoise()
+    if (rawMicTrackRef.current) rawMicTrackRef.current.onended = null
     rawMicTrackRef.current?.stop()
     rawMicTrackRef.current = null
     vadStreamRef.current = null
@@ -981,31 +1102,63 @@ export function useLiveKitVoice() {
     send('SetVoiceControl', { muted: !!control?.muted, deafened: !!control?.deafened, screen_sharing: false, camera_on: !!control?.cameraOn })
   }, [refreshLocalStreams, send, userId])
 
-  const startScreenShare = useCallback(async () => {
+  const startScreenShare = useCallback(async (): Promise<ScreenShareStartResult> => {
     const room = roomRef.current
     if (!room) throw new Error('Join a voice channel before sharing your screen')
     stopScreenShare()
 
-    const stream = await getScreenStream()
+    const capture: ScreenShareCaptureResult = await getScreenStream()
+    const { stream, diagnostics } = capture
     const tracks = stream.getTracks()
     localScreenTracksRef.current = tracks
+    const publishedTracks: MediaStreamTrack[] = []
+    let videoPublished = false
+    let audioPublished = false
 
-    for (const track of tracks) {
-      const source = track.kind === 'audio' ? Track.Source.ScreenShareAudio : Track.Source.ScreenShare
-      const screenVideo = track.kind === 'video' ? getScreenShareEncoding(track) : undefined
-      if (track.kind === 'video' && screenVideo && 'contentHint' in track) {
-        try { track.contentHint = screenVideo.contentHint } catch { /* ignore */ }
+    try {
+      for (const track of tracks) {
+        const source = track.kind === 'audio' ? Track.Source.ScreenShareAudio : Track.Source.ScreenShare
+        const screenVideo = track.kind === 'video' ? getScreenShareEncoding(track) : undefined
+        if (track.kind === 'video' && screenVideo && 'contentHint' in track) {
+          try { track.contentHint = screenVideo.contentHint } catch { /* ignore */ }
+        }
+        const options = screenVideo
+          ? getScreenSharePublishOptions(screenVideo)
+          : { source }
+        await room.localParticipant.publishTrack(track, options)
+        publishedTracks.push(track)
+        if (track.kind === 'video') videoPublished = true
+        if (track.kind === 'audio') audioPublished = true
       }
-      await room.localParticipant.publishTrack(track, {
-        source,
-        // Screen share tracks use screenShareEncoding (not videoEncoding)
-        screenShareEncoding: screenVideo
-          ? { maxBitrate: screenVideo.maxBitrate, maxFramerate: screenVideo.maxFramerate }
-          : undefined,
-        degradationPreference: screenVideo?.degradationPreference,
-        simulcast: false,  // Screen share: full quality, no simulcast layers
+    } catch (error) {
+      await Promise.allSettled(publishedTracks.map((track) => (
+        room.localParticipant.unpublishTrack(track)
+      )))
+      tracks.forEach((track) => {
+        track.onended = null
+        track.stop()
       })
+      localScreenTracksRef.current = []
+      updateVoiceDiagnostics({
+        screenShare: {
+          ...diagnostics,
+          videoPublished: false,
+          audioPublished: false,
+          simulcast: true,
+        },
+      })
+      refreshLocalStreams()
+      throw error
     }
+
+    updateVoiceDiagnostics({
+      screenShare: {
+        ...diagnostics,
+        videoPublished,
+        audioPublished,
+        simulcast: true,
+      },
+    })
     const videoTrack = stream.getVideoTracks()[0]
     if (videoTrack) {
       videoTrack.onended = () => {
@@ -1031,6 +1184,10 @@ export function useLiveKitVoice() {
     refreshLocalStreams()
     const control = useAppStore.getState().voiceControls[userId ?? '']
     send('SetVoiceControl', { muted: !!control?.muted, deafened: !!control?.deafened, screen_sharing: true, camera_on: !!control?.cameraOn })
+    return {
+      hasAudio: diagnostics.audioCaptured === true,
+      audioPublished,
+    }
   }, [getScreenShareEncoding, getScreenStream, refreshLocalStreams, send, stopScreenShare, userId])
 
   const startCamera = useCallback(async () => {

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -7,9 +7,12 @@ import {
   RoomEvent,
   ScreenSharePresets,
   setLogLevel,
+  supportsVP9,
   Track,
+  VideoPreset,
   type RemoteTrackPublication,
   type TrackPublishOptions,
+  type VideoCodec,
 } from 'livekit-client'
 import { webrtcApi } from '../api'
 import { useAuthStore } from '../stores/auth'
@@ -29,6 +32,7 @@ import {
 import { updateVoiceDiagnostics } from './voiceDiagnostics'
 import type { RemoteMediaKind } from './remoteMediaControls'
 import { reportObservabilityEvent } from '../observability'
+import { associateLiveKitVideoTrack } from './livekitVideoAttachment'
 
 if (import.meta.env.PROD) {
   setLogLevel('silent')
@@ -67,20 +71,34 @@ export interface ScreenShareStartResult {
   audioPublished: boolean
 }
 
+const SCREEN_SHARE_MOTION_360P = new VideoPreset(640, 360, 1_000_000, 30)
+const SCREEN_SHARE_MOTION_720P = new VideoPreset(1280, 720, 4_000_000, 60)
+
+export function getPreferredScreenShareCodec(vp9Supported = supportsVP9()): VideoCodec {
+  return vp9Supported ? 'vp9' : 'vp8'
+}
+
 export function getScreenSharePublishOptions(
   encoding: ScreenShareEncoding,
+  codec: VideoCodec = getPreferredScreenShareCodec(),
 ): TrackPublishOptions {
+  const usesSvc = codec === 'vp9' || codec === 'av1'
   return {
     source: Track.Source.ScreenShare,
     screenShareEncoding: {
       maxBitrate: encoding.maxBitrate,
       maxFramerate: encoding.maxFramerate,
     },
-    screenShareSimulcastLayers: encoding.maxFramerate >= 50
-      ? [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps30]
-      : [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps15],
+    screenShareSimulcastLayers: usesSvc
+      ? undefined
+      : encoding.maxFramerate >= 50
+        ? [SCREEN_SHARE_MOTION_360P, SCREEN_SHARE_MOTION_720P]
+        : [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps30],
     degradationPreference: encoding.degradationPreference,
-    simulcast: true,
+    videoCodec: codec,
+    backupCodec: usesSvc,
+    scalabilityMode: usesSvc ? 'L3T3_KEY' : undefined,
+    simulcast: !usesSvc,
   }
 }
 
@@ -774,7 +792,10 @@ export function useLiveKitVoice() {
       const { ws_url, token: lkToken } = await webrtcApi.getLivekitToken(channelId, token ?? null)
 
       const room = new Room({
-        adaptiveStream: true,
+        adaptiveStream: {
+          pixelDensity: 'screen',
+          pauseVideoInBackground: true,
+        },
         dynacast: true,
         publishDefaults: {
           audioPreset: AudioPresets.musicHighQuality,
@@ -784,7 +805,7 @@ export function useLiveKitVoice() {
           screenShareEncoding: getScreenShareEncoding(),
           screenShareSimulcastLayers: [
             ScreenSharePresets.h360fps15,
-            ScreenSharePresets.h720fps15,
+            ScreenSharePresets.h720fps30,
           ],
           videoEncoding: { maxBitrate: 3_000_000, maxFramerate: 30 },
         },
@@ -835,6 +856,10 @@ export function useLiveKitVoice() {
 
           const combined = remoteStreamsRef.current.get(peerId) ?? new MediaStream()
           const mediaTrack = track.mediaStreamTrack
+
+          if (track.kind === Track.Kind.Video) {
+            associateLiveKitVideoTrack(mediaTrack, track)
+          }
 
           if (pub.source === Track.Source.ScreenShare) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShare', { value: true, writable: true, configurable: true })
@@ -1114,6 +1139,9 @@ export function useLiveKitVoice() {
     const publishedTracks: MediaStreamTrack[] = []
     let videoPublished = false
     let audioPublished = false
+    let publishedCodec: string | undefined
+    let publishedScalabilityMode: string | undefined
+    let publishedWithSimulcast = false
 
     try {
       for (const track of tracks) {
@@ -1122,9 +1150,14 @@ export function useLiveKitVoice() {
         if (track.kind === 'video' && screenVideo && 'contentHint' in track) {
           try { track.contentHint = screenVideo.contentHint } catch { /* ignore */ }
         }
-        const options = screenVideo
+        const options: TrackPublishOptions = screenVideo
           ? getScreenSharePublishOptions(screenVideo)
           : { source }
+        if (track.kind === 'video') {
+          publishedCodec = options.videoCodec
+          publishedScalabilityMode = options.scalabilityMode
+          publishedWithSimulcast = options.simulcast !== false
+        }
         await room.localParticipant.publishTrack(track, options)
         publishedTracks.push(track)
         if (track.kind === 'video') videoPublished = true
@@ -1144,7 +1177,9 @@ export function useLiveKitVoice() {
           ...diagnostics,
           videoPublished: false,
           audioPublished: false,
-          simulcast: true,
+          simulcast: publishedWithSimulcast,
+          codec: publishedCodec,
+          scalabilityMode: publishedScalabilityMode,
         },
       })
       refreshLocalStreams()
@@ -1156,7 +1191,9 @@ export function useLiveKitVoice() {
         ...diagnostics,
         videoPublished,
         audioPublished,
-        simulcast: true,
+        simulcast: publishedWithSimulcast,
+        codec: publishedCodec,
+        scalabilityMode: publishedScalabilityMode,
       },
     })
     const videoTrack = stream.getVideoTracks()[0]

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -79,6 +79,8 @@ export interface ScreenShareCaptureDiagnostics {
   videoPublished?: boolean
   audioPublished?: boolean
   simulcast?: boolean
+  codec?: string
+  scalabilityMode?: string
 }
 
 export interface ScreenShareOutboundDiagnostics {

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -66,6 +66,31 @@ export interface VoiceLivekitDiagnostics {
   microphoneForceStereo?: boolean
 }
 
+export interface ScreenShareCaptureDiagnostics {
+  requestedWidth?: number
+  requestedHeight?: number
+  requestedFramerate?: number
+  actualWidth?: number
+  actualHeight?: number
+  actualFramerate?: number
+  displaySurface?: string
+  constraintsApplied?: boolean
+  audioCaptured?: boolean
+  videoPublished?: boolean
+  audioPublished?: boolean
+  simulcast?: boolean
+}
+
+export interface ScreenShareOutboundDiagnostics {
+  width?: number
+  height?: number
+  framesPerSecond?: number
+  bitrateKbps?: number
+  packetsSent?: number
+  packetsLost?: number
+  qualityLimitationReason?: string
+}
+
 export interface VoiceRuntimeDiagnostics {
   benchmarkSchemaVersion?: number
   rnnoiseStatus?: RnnoiseRuntimeStatus
@@ -87,6 +112,8 @@ export interface VoiceRuntimeDiagnostics {
   voiceActivity?: VoiceActivityDiagnostics
   network?: VoiceNetworkDiagnosticsSnapshot
   livekit?: VoiceLivekitDiagnostics
+  screenShare?: ScreenShareCaptureDiagnostics
+  screenShareOutbound?: ScreenShareOutboundDiagnostics
   updatedAt?: string
 }
 

--- a/docs/DESKTOP_RELEASE_HARDENING.md
+++ b/docs/DESKTOP_RELEASE_HARDENING.md
@@ -24,8 +24,9 @@ This document defines Voxpery desktop release hardening policy for metadata, dee
 - Backend CORS allowlist must include `voxpery://auth`.
 - Desktop deep-link scheme in Tauri config must include `voxpery`.
 - The desktop client must process both cold-start URLs from the deep-link plugin's `getCurrent()` API and runtime URLs from `onOpenUrl`/single-instance events.
+- The single-instance plugin must be registered before other desktop plugins, and runtime links received before the webview listener is ready must be drained from the native pending-link queue.
 - OAuth callback codes are single-use. Duplicate delivery through multiple desktop event sources must be deduplicated before exchange.
-- The browser handoff page must attempt to open Voxpery automatically, keep an explicit user-gesture fallback, and safely encode the generated deep-link URL.
+- The responsive browser handoff page must attempt to open Voxpery automatically, keep an accessible explicit user-gesture fallback, safely encode the generated deep-link URL, and use the same branded status UI for success and failure callbacks.
 - Release preflight validates:
   - deep-link scheme setup
   - frontend OAuth origin behavior

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -94,6 +94,8 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] With Voxpery closed, Google OAuth opens the browser, starts the desktop app via `voxpery://`, and completes sign-in without requiring a second callback click.
 - [ ] With Voxpery already running, Google OAuth returns to and focuses the existing desktop instance.
 - [ ] If the browser blocks automatic external-protocol navigation, the `Open Voxpery` fallback completes the same sign-in flow.
+- [ ] OAuth cancellation/failure renders the branded responsive handoff state, and `Return to Voxpery` opens the desktop login error state without exposing tokens or raw provider errors.
+- [ ] Repeating the same callback through native pending links, `getCurrent()`, and runtime events exchanges its one-time code only once.
 - [ ] Session is restored after OAuth callback, the one-time code is not exchanged twice, and the user lands on the requested authenticated route.
 - [ ] If updater artifacts are enabled, signing keys and updater pubkey are configured (see `docs/DESKTOP_RELEASE_HARDENING.md`).
 - [ ] Desktop release workflow ran against the exact release tag/ref, with `smoke_checklist_confirmed=yes`.

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -20,6 +20,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] A new/default user joins with the operating system's current default microphone and speaker.
 - [ ] A valid custom microphone and speaker remain selected after reload and voice rejoin.
 - [ ] After a selected custom microphone or speaker is disconnected, the next capture/playback attempt silently uses the system default and Voice Settings shows `Windows Default`.
+- [ ] While already joined, unplugging the active microphone or changing the operating-system default input recovers capture without leaving/rejoining and without removing the existing LiveKit microphone publication first.
 - [ ] In desktop builds, the configured mute shortcut also works while Voxpery is unfocused, minimized, or running in the tray.
 - [ ] On a clean macOS install, the first voice join prompts for microphone access and Voxpery appears in Privacy & Security -> Microphone after the decision.
 - [ ] Rebinding or clearing the mute shortcut takes effect immediately; a conflicting desktop shortcut shows an error without losing the previous working binding.
@@ -51,6 +52,10 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] `Auto` chooses a balanced profile by shared surface: monitor/browser -> video, window/unknown -> presentation.
 - [ ] Monitor/game and browser/video shares stay motion-first under load: frame pacing remains smooth before sharpness is preserved.
 - [ ] User A starts screen share; User B sees the screen tile.
+- [ ] Sharing a supported browser tab/system-audio source publishes both `ScreenShare` and `ScreenShareAudio`; User B hears the shared audio independently from User A's microphone.
+- [ ] Sharing a source/platform that provides no audio still publishes video and shows User A one non-fatal `Sharing without audio` notice.
+- [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio capture/publication, simulcast, outbound bitrate/FPS, packet loss, and quality limitation reason are present without device identifiers.
+- [ ] Under constrained bandwidth, screen share remains watchable by stepping down to a lower simulcast layer instead of freezing on a single high-quality layer.
 - [ ] On a clean macOS install, starting screen share prompts for Screen & System Audio Recording access and Voxpery appears in that Privacy & Security list.
 - [ ] On macOS, opening and closing the native share picker does not lower remote microphone audio; the same level continues without clicking Voxpery again.
 - [ ] User B hears the screen-start cue only once for the screen video track.

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -51,6 +51,8 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] `Gaming` profile publishes at the UI-described 1080p60 behavior with the higher bitrate profile.
 - [ ] `Auto` chooses a balanced profile by shared surface: monitor/browser -> video, window/unknown -> presentation.
 - [ ] Monitor/game and browser/video shares stay motion-first under load: frame pacing remains smooth before sharpness is preserved.
+- [ ] A VP9-capable Chromium/WebView2 publisher reports `codec: vp9` and `scalabilityMode: L3T3_KEY`; a fallback runtime reports `codec: vp8`.
+- [ ] Resizing and fullscreening User B's remote share tile upgrades the received adaptive layer without restarting the share.
 - [ ] User A starts screen share; User B sees the screen tile.
 - [ ] Sharing a supported browser tab/system-audio source publishes both `ScreenShare` and `ScreenShareAudio`; User B hears the shared audio independently from User A's microphone.
 - [ ] Sharing a source/platform that provides no audio still publishes video and shows User A one non-fatal `Sharing without audio` notice.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -205,10 +205,10 @@ Speaker
 
 | Preset        | Resolution | FPS | Bitrate (Mbps) | Use Case         |
 |---------------|------------|-----|----------------|------------------|
-| Auto          | 1080p      | 30/60 | 4-6          | Balanced selection by shared surface |
+| Auto          | 1080p      | 30/60 | 4-8          | Balanced selection by shared surface |
 | Presentation  | 1080p      | 30  | 4.0            | Slides, docs, IDEs |
-| Video         | 1080p      | 60  | 6.0            | Browser tabs, monitors, and video |
-| Gaming        | 1080p      | 60  | 8.0            | Explicit high-motion mode |
+| Video         | 1080p      | 60  | 8.0            | Browser tabs, monitors, and video |
+| Gaming        | 1080p      | 60  | 12.0           | Explicit high-motion mode |
 
 ### Implementation
 
@@ -219,24 +219,28 @@ const stream = await navigator.mediaDevices.getDisplayMedia({
 })
 await room.localParticipant.publishTrack(videoTrack, {
   source: Track.Source.ScreenShare,
-  screenShareEncoding: { maxBitrate: 7_000_000, maxFramerate: 60 },
-  simulcast: true,
-  screenShareSimulcastLayers: [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps30]
+  screenShareEncoding: { maxBitrate: 8_000_000, maxFramerate: 60 },
+  videoCodec: supportsVP9() ? 'vp9' : 'vp8',
+  scalabilityMode: supportsVP9() ? 'L3T3_KEY' : undefined,
+  simulcast: !supportsVP9(),
+  screenShareSimulcastLayers: supportsVP9()
+    ? undefined
+    : [screenShare360p30, screenShare720p60]
 })
 ```
 
-Screen publishing uses adaptive lower layers so LiveKit can preserve motion and continuity when bandwidth drops instead of relying on one all-or-nothing high-resolution layer. Firefox and runtimes for which LiveKit disables screen simulcast continue to use the SDK's platform fallback.
+Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast with 360p30 and 720p60 intermediate layers. Remote LiveKit video tracks are rendered through `RemoteVideoTrack.attach()` so adaptive stream can select a layer from the element's actual dimensions and visibility. Incompatible runtimes retain the VP8 path.
 
 ### Content Hints
 
 - **Auto screen share**: Starts with a 1080p60 capture envelope, then reapplies the selected surface profile after `displaySurface` is known.
 - **Presentation/window share**: `contentHint = 'detail'` at 1080p30 and `maintain-resolution` degradation to preserve text sharpness while limiting traffic.
-- **Browser tab/video and Auto monitor share**: `contentHint = 'motion'` at 1080p60 with a balanced 6 Mbps cap and `maintain-framerate` degradation.
-- **Gaming share**: Explicit 1080p60 high-motion mode with an 8 Mbps cap for users who prefer quality over bandwidth.
+- **Browser tab/video and Auto monitor share**: `contentHint = 'motion'` at 1080p60 with an 8 Mbps cap and `maintain-framerate` degradation.
+- **Gaming share**: Explicit 1080p60 high-motion mode with a 12 Mbps cap for users who prefer quality over bandwidth.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
 - A share is not published without a live video track. If the selected platform/source does not provide a system or tab audio track, video sharing continues and the sender receives a non-fatal `Sharing without audio` notice with source-picker guidance.
 - Publishing is rollback-safe: if any selected screen track fails to publish, already-published tracks from that attempt are unpublished and the local capture is stopped.
-- Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio capture/publication, simulcast state, and outbound resolution/FPS/bitrate/packet/quality-limitation samples without device identifiers.
+- Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio capture/publication, codec/scalability mode, simulcast state, and outbound resolution/FPS/bitrate/packet/quality-limitation samples without device identifiers.
 
 ### Remote Viewing Controls
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -128,6 +128,7 @@ Room.localParticipant.publishTrack
   - The processed microphone track is published with LiveKit's high-quality mono Opus preset.
   - DTX remains enabled to avoid sending unnecessary silence, and RED remains enabled for packet-loss resilience.
   - Stereo is forced off for microphone audio so bitrate stays focused on voice clarity rather than duplicate channels.
+  - If the raw capture track ends or the operating-system default input changes during a call, Voxpery re-captures the preferred/default device and atomically replaces the existing LiveKit sender track. The working publication remains in place until the replacement is ready.
 - **Why RNNoise?**
   - Browser native `noiseSuppression` is too weak for noisy backgrounds
   - Krisp required LiveKit Cloud (self-hosted setups can't use it)
@@ -194,6 +195,7 @@ Speaker
 - New users and users who leave device selection on `Windows Default` follow the current system default microphone and speaker.
 - Explicit microphone and speaker selections remain stored and are reused while those devices are available.
 - If a stored custom device is unplugged, removed, or no longer exposed by the browser, Voxpery clears only that stale preference and silently retries with the system default.
+- Device changes are reconciled during an active call. Existing custom inputs remain selected while available; a removed custom input or changed system default triggers a debounced capture rebuild.
 - Permission failures, devices that are temporarily busy, and output-selection policy failures do not overwrite a valid custom preference.
 - The same microphone fallback is used by call preflight, LiveKit capture, the microphone test, and the legacy WebRTC path.
 
@@ -218,9 +220,12 @@ const stream = await navigator.mediaDevices.getDisplayMedia({
 await room.localParticipant.publishTrack(videoTrack, {
   source: Track.Source.ScreenShare,
   screenShareEncoding: { maxBitrate: 7_000_000, maxFramerate: 60 },
-  simulcast: false  // Full quality, no layering
+  simulcast: true,
+  screenShareSimulcastLayers: [ScreenSharePresets.h360fps15, ScreenSharePresets.h720fps30]
 })
 ```
+
+Screen publishing uses adaptive lower layers so LiveKit can preserve motion and continuity when bandwidth drops instead of relying on one all-or-nothing high-resolution layer. Firefox and runtimes for which LiveKit disables screen simulcast continue to use the SDK's platform fallback.
 
 ### Content Hints
 
@@ -229,6 +234,9 @@ await room.localParticipant.publishTrack(videoTrack, {
 - **Browser tab/video and Auto monitor share**: `contentHint = 'motion'` at 1080p60 with a balanced 6 Mbps cap and `maintain-framerate` degradation.
 - **Gaming share**: Explicit 1080p60 high-motion mode with an 8 Mbps cap for users who prefer quality over bandwidth.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
+- A share is not published without a live video track. If the selected platform/source does not provide a system or tab audio track, video sharing continues and the sender receives a non-fatal `Sharing without audio` notice with source-picker guidance.
+- Publishing is rollback-safe: if any selected screen track fails to publish, already-published tracks from that attempt are unpublished and the local capture is stopped.
+- Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio capture/publication, simulcast state, and outbound resolution/FPS/bitrate/packet/quality-limitation samples without device identifiers.
 
 ### Remote Viewing Controls
 
@@ -306,7 +314,7 @@ When debugging a production voice report, capture:
 
 1. The call bar ping color and visible ping.
 2. Whether the room was connected, connecting, or reconnecting.
-3. Enable temporary diagnostics with `localStorage.setItem("voxperyVoiceDiagnostics", "1")`, reload, then inspect `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active.
+3. Enable temporary diagnostics with `localStorage.setItem("voxperyVoiceDiagnostics", "1")`, reload, then inspect `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active. During screen share, `screenShare` and `screenShareOutbound` show actual capture/publish quality and network limitation signals.
 4. Whether the user recently changed microphone, camera, VPN, firewall, or network.
 
 ### Voice cues


### PR DESCRIPTION
## Summary

- recover active microphone capture when the selected device ends, disappears, or the system default changes
- publish replacement microphone tracks atomically without interrupting the existing LiveKit publication
- validate screen capture audio and video, roll back partial publication failures, and use adaptive simulcast layers
- record actual screen capture and outbound WebRTC quality diagnostics
- improve desktop Google OAuth handoff with automatic deep-link opening, native pending-link recovery, and an accessible fallback page
- update desktop OAuth and voice release smoke documentation

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`
- targeted ActiveCallBar tests: 9 passed
- server library tests: 87 passed, 4 ignored
- targeted OAuth tests: 7 passed
- desktop `cargo check --locked`
- `graphify update .`