### PR TITLE
feat: persist message drafts and reduce idle traffic

### DIFF
--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -3202,7 +3202,8 @@ async fn attachment_upload_stores_file_and_returns_signed_url() {
     );
 
     let tampered_path = if let Some((prefix, sig)) = signed_path.rsplit_once("sig=") {
-        let bad_sig = format!("{}0", &sig[..sig.len().saturating_sub(1)]);
+        let replacement = if sig.ends_with('0') { '1' } else { '0' };
+        let bad_sig = format!("{}{replacement}", &sig[..sig.len().saturating_sub(1)]);
         format!("{prefix}sig={bad_sig}")
     } else {
         panic!("signed URL must include sig param");

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -2469,6 +2469,7 @@ export default function ChatArea({
                         ref={textareaRef}
                         className="message-input"
                         value={messageInput}
+                        maxLength={4000}
                         disabled={!canSendMessages}
                         onChange={(e) => handleInputChange(e.target.value, e.target.selectionStart)}
                         onKeyDown={handleKeyDown}

--- a/apps/web/src/messageDrafts.test.ts
+++ b/apps/web/src/messageDrafts.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearMessageDraftIfUnchanged,
+  flushMessageDrafts,
+  MESSAGE_DRAFT_MAX_ENTRIES,
+  MESSAGE_DRAFT_MAX_LENGTH,
+  MESSAGE_DRAFT_STORAGE_KEY,
+  MESSAGE_DRAFT_TTL_MS,
+  readMessageDraft,
+  resetMessageDraftCacheForTests,
+  saveMessageDraft,
+} from './messageDrafts'
+
+describe('message drafts', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    resetMessageDraftCacheForTests()
+  })
+
+  it('isolates channel and DM drafts by user and conversation', () => {
+    saveMessageDraft('user-a', 'channel', 'channel-1', 'server draft')
+    saveMessageDraft('user-a', 'dm', 'channel-1', 'dm draft')
+    saveMessageDraft('user-b', 'channel', 'channel-1', 'other user draft')
+
+    expect(readMessageDraft('user-a', 'channel', 'channel-1')).toBe('server draft')
+    expect(readMessageDraft('user-a', 'dm', 'channel-1')).toBe('dm draft')
+    expect(readMessageDraft('user-b', 'channel', 'channel-1')).toBe('other user draft')
+    expect(readMessageDraft('user-a', 'channel', 'channel-2')).toBe('')
+  })
+
+  it('survives a storage reload and clears only the matching sent draft', () => {
+    saveMessageDraft('user-a', 'channel', 'channel-1', 'send me')
+    saveMessageDraft('user-a', 'channel', 'channel-2', 'keep me')
+    flushMessageDrafts()
+    resetMessageDraftCacheForTests()
+
+    expect(readMessageDraft('user-a', 'channel', 'channel-1')).toBe('send me')
+    clearMessageDraftIfUnchanged('user-a', 'channel', 'channel-1', 'different text')
+    expect(readMessageDraft('user-a', 'channel', 'channel-1')).toBe('send me')
+
+    clearMessageDraftIfUnchanged('user-a', 'channel', 'channel-1', 'send me')
+    expect(readMessageDraft('user-a', 'channel', 'channel-1')).toBe('')
+    expect(readMessageDraft('user-a', 'channel', 'channel-2')).toBe('keep me')
+  })
+
+  it('drops expired, blank, oversized, and excess entries', () => {
+    const now = Date.now()
+    saveMessageDraft('user-a', 'dm', 'expired', 'old', now - MESSAGE_DRAFT_TTL_MS - 1)
+    saveMessageDraft('user-a', 'dm', 'blank', '   ', now)
+    saveMessageDraft('user-a', 'dm', 'long', 'x'.repeat(MESSAGE_DRAFT_MAX_LENGTH + 20), now)
+    expect(readMessageDraft('user-a', 'dm', 'long', now)).toHaveLength(MESSAGE_DRAFT_MAX_LENGTH)
+    for (let index = 0; index < MESSAGE_DRAFT_MAX_ENTRIES + 5; index += 1) {
+      saveMessageDraft('user-a', 'channel', `channel-${index}`, `draft-${index}`, now + index)
+    }
+    flushMessageDrafts()
+    resetMessageDraftCacheForTests()
+
+    expect(readMessageDraft('user-a', 'dm', 'expired', now)).toBe('')
+    expect(readMessageDraft('user-a', 'dm', 'blank', now)).toBe('')
+
+    const stored = JSON.parse(localStorage.getItem(MESSAGE_DRAFT_STORAGE_KEY) ?? '{}') as {
+      entries?: Record<string, unknown>
+    }
+    expect(Object.keys(stored.entries ?? {})).toHaveLength(MESSAGE_DRAFT_MAX_ENTRIES)
+  })
+})

--- a/apps/web/src/messageDrafts.ts
+++ b/apps/web/src/messageDrafts.ts
@@ -1,0 +1,178 @@
+export type MessageDraftScope = 'channel' | 'dm'
+
+export const MESSAGE_DRAFT_STORAGE_KEY = 'voxpery-message-drafts-v1'
+export const MESSAGE_DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000
+export const MESSAGE_DRAFT_MAX_ENTRIES = 80
+export const MESSAGE_DRAFT_MAX_LENGTH = 4000
+
+type MessageDraftEntry = {
+  userId: string
+  scope: MessageDraftScope
+  conversationId: string
+  text: string
+  updatedAt: number
+}
+
+type MessageDraftStore = {
+  version: 1
+  entries: Record<string, MessageDraftEntry>
+}
+
+let cachedStore: MessageDraftStore | null = null
+let flushTimer: ReturnType<typeof window.setTimeout> | null = null
+let listenersInstalled = false
+
+function storageAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+function draftKey(userId: string, scope: MessageDraftScope, conversationId: string): string {
+  return JSON.stringify([userId, scope, conversationId])
+}
+
+function emptyStore(): MessageDraftStore {
+  return { version: 1, entries: {} }
+}
+
+function validEntry(value: unknown): value is MessageDraftEntry {
+  if (!value || typeof value !== 'object') return false
+  const entry = value as Partial<MessageDraftEntry>
+  return (
+    typeof entry.userId === 'string'
+    && typeof entry.scope === 'string'
+    && (entry.scope === 'channel' || entry.scope === 'dm')
+    && typeof entry.conversationId === 'string'
+    && typeof entry.text === 'string'
+    && typeof entry.updatedAt === 'number'
+    && Number.isFinite(entry.updatedAt)
+  )
+}
+
+function pruneStore(store: MessageDraftStore, now: number): MessageDraftStore {
+  const freshEntries = Object.entries(store.entries)
+    .filter(([, entry]) => (
+      validEntry(entry)
+      && entry.text.trim().length > 0
+      && entry.updatedAt > now - MESSAGE_DRAFT_TTL_MS
+    ))
+    .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+    .slice(0, MESSAGE_DRAFT_MAX_ENTRIES)
+
+  return {
+    version: 1,
+    entries: Object.fromEntries(freshEntries),
+  }
+}
+
+function loadStore(now = Date.now()): MessageDraftStore {
+  if (cachedStore) {
+    cachedStore = pruneStore(cachedStore, now)
+    return cachedStore
+  }
+  if (!storageAvailable()) {
+    cachedStore = emptyStore()
+    return cachedStore
+  }
+
+  try {
+    const raw = window.localStorage.getItem(MESSAGE_DRAFT_STORAGE_KEY)
+    const parsed = raw ? JSON.parse(raw) as Partial<MessageDraftStore> : null
+    cachedStore = parsed?.version === 1 && parsed.entries && typeof parsed.entries === 'object'
+      ? pruneStore({ version: 1, entries: parsed.entries as Record<string, MessageDraftEntry> }, now)
+      : emptyStore()
+  } catch {
+    cachedStore = emptyStore()
+  }
+  return cachedStore
+}
+
+function installFlushListeners(): void {
+  if (!storageAvailable() || listenersInstalled) return
+  listenersInstalled = true
+  window.addEventListener('pagehide', flushMessageDrafts)
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flushMessageDrafts()
+  })
+  window.addEventListener('storage', (event) => {
+    if (event.key === MESSAGE_DRAFT_STORAGE_KEY && !flushTimer) cachedStore = null
+  })
+}
+
+function scheduleFlush(): void {
+  if (!storageAvailable()) return
+  installFlushListeners()
+  if (flushTimer) window.clearTimeout(flushTimer)
+  flushTimer = window.setTimeout(flushMessageDrafts, 250)
+}
+
+export function flushMessageDrafts(): void {
+  if (flushTimer) {
+    window.clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  if (!storageAvailable() || !cachedStore) return
+  try {
+    window.localStorage.setItem(
+      MESSAGE_DRAFT_STORAGE_KEY,
+      JSON.stringify(pruneStore(cachedStore, Date.now())),
+    )
+  } catch {
+    // Draft persistence is best-effort and must never block chat input.
+  }
+}
+
+export function readMessageDraft(
+  userId: string | null | undefined,
+  scope: MessageDraftScope,
+  conversationId: string | null | undefined,
+  now = Date.now(),
+): string {
+  if (!userId || !conversationId) return ''
+  return loadStore(now).entries[draftKey(userId, scope, conversationId)]?.text ?? ''
+}
+
+export function saveMessageDraft(
+  userId: string | null | undefined,
+  scope: MessageDraftScope,
+  conversationId: string | null | undefined,
+  text: string,
+  now = Date.now(),
+): void {
+  if (!userId || !conversationId) return
+  const store = loadStore(now)
+  const key = draftKey(userId, scope, conversationId)
+  const boundedText = text.slice(0, MESSAGE_DRAFT_MAX_LENGTH)
+  if (!boundedText.trim()) {
+    delete store.entries[key]
+  } else {
+    store.entries[key] = {
+      userId,
+      scope,
+      conversationId,
+      text: boundedText,
+      updatedAt: now,
+    }
+  }
+  cachedStore = pruneStore(store, now)
+  scheduleFlush()
+}
+
+export function clearMessageDraftIfUnchanged(
+  userId: string | null | undefined,
+  scope: MessageDraftScope,
+  conversationId: string | null | undefined,
+  expectedText: string,
+): void {
+  if (!userId || !conversationId) return
+  const store = loadStore()
+  const key = draftKey(userId, scope, conversationId)
+  if (store.entries[key]?.text !== expectedText.slice(0, MESSAGE_DRAFT_MAX_LENGTH)) return
+  delete store.entries[key]
+  flushMessageDrafts()
+}
+
+export function resetMessageDraftCacheForTests(): void {
+  if (flushTimer && typeof window !== 'undefined') window.clearTimeout(flushTimer)
+  flushTimer = null
+  cachedStore = null
+}

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -31,6 +31,11 @@ import {
     type DraftAttachmentItem,
 } from '../draftAttachments'
 import { mergeRemoteWithRetryableLocals, reconcileConfirmedMessage } from '../messageResilience'
+import {
+    clearMessageDraftIfUnchanged,
+    readMessageDraft,
+    saveMessageDraft,
+} from '../messageDrafts'
 import { playMessageNotificationSound, shouldPlayNotificationSound } from '../notificationSound'
 import {
     getServerNotificationPreference,
@@ -378,6 +383,16 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [isMobileViewport, setIsMobileViewport] = useState(() =>
         typeof window !== 'undefined' ? window.matchMedia('(max-width: 700px)').matches : false,
     )
+
+    useEffect(() => {
+        setMessageInput(readMessageDraft(user?.id, 'channel', activeChannelId))
+        setDraftAttachments([])
+    }, [activeChannelId, user?.id])
+
+    const handleMessageInputChange = useCallback((value: string) => {
+        setMessageInput(value)
+        saveMessageDraft(user?.id, 'channel', activeChannelId, value)
+    }, [activeChannelId, user?.id])
     const [serverSettingsName, setServerSettingsName] = useState('')
     const [serverSettingsDescription, setServerSettingsDescription] = useState('')
     const [serverSettingsIconDraft, setServerSettingsIconDraft] = useState<string | null | undefined>(undefined)
@@ -944,9 +959,13 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         if (!activeChannelId) return
         const draft = sessionStorage.getItem('voxpery-draft-mention')
         if (!draft) return
-        setMessageInput((prev) => (prev.trim() ? prev : draft))
+        setMessageInput((prev) => {
+            if (prev.trim()) return prev
+            saveMessageDraft(user?.id, 'channel', activeChannelId, draft)
+            return draft
+        })
         sessionStorage.removeItem('voxpery-draft-mention')
-    }, [activeChannelId])
+    }, [activeChannelId, user?.id])
 
     // ─── WebSocket ─────────────────────────────
 
@@ -1275,7 +1294,8 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             return
         }
         const attachments = getUploadedDraftAttachments(draftAttachments)
-        const inputValue = typeof forceContent === 'string' ? forceContent : messageInput
+        const isForcedContent = typeof forceContent === 'string'
+        const inputValue = isForcedContent ? forceContent : messageInput
         if ((!inputValue.trim() && attachments.length === 0)) return
         const bodyText = inputValue.trim()
         const content = replyingTo
@@ -1303,7 +1323,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             clientId,
             clientStatus: 'sending',
         }
-        setMessageInput('')
+        if (!isForcedContent) setMessageInput('')
         setDraftAttachments([])
         setMessages((prev) => {
             const next = [...prev, optimistic]
@@ -1324,6 +1344,9 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             } else {
                 messagesByChannelRef.current[channelId] = applySentMessage(messagesByChannelRef.current[channelId] ?? [])
             }
+            if (!isForcedContent) {
+                clearMessageDraftIfUnchanged(user?.id, 'channel', channelId, inputValue)
+            }
         } catch (err) {
             console.error('Failed to send:', err)
             const applyFailedMessage = (current: UiMessage[]) =>
@@ -1340,6 +1363,9 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 })
             } else {
                 messagesByChannelRef.current[channelId] = applyFailedMessage(messagesByChannelRef.current[channelId] ?? [])
+            }
+            if (!isForcedContent && activeChannelIdRef.current === channelId) {
+                setMessageInput((current) => current || inputValue)
             }
         } finally {
             pendingMessageFingerprintsRef.current.delete(sendFingerprint)
@@ -2983,7 +3009,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 onPickAttachments={handleAttachmentPick}
                 onRemoveAttachment={(index) => setDraftAttachments((prev) => prev.filter((_, i) => i !== index))}
                 onRetryAttachment={handleRetryDraftAttachment}
-                onMessageInputChange={setMessageInput}
+                onMessageInputChange={handleMessageInputChange}
                 onSendMessage={handleSendMessage}
                 onRetryMessage={handleRetryMessage}
                 onDeleteMessage={(messageId) => setDeleteMessageConfirmId(messageId)}

--- a/apps/web/src/pages/AppShell.test.tsx
+++ b/apps/web/src/pages/AppShell.test.tsx
@@ -154,7 +154,8 @@ describe('AppShell social refresh', () => {
       expect(apiMocks.listDmChannels).toHaveBeenCalledTimes(1)
       expect(apiMocks.listFriends).toHaveBeenCalledTimes(1)
     })
-    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000)
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60_000)
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 6_000)
     expect(useAppStore.getState().socialDataReady).toBe(true)
 
     act(() => {

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -34,6 +34,8 @@ import { setPersistedSocialView } from '../socialView'
 import { formatAppVersionBadge } from '../appVersion'
 
 const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+const SOCIAL_FALLBACK_SYNC_INTERVAL_MS = 5 * 60 * 1000
+const SOCIAL_FOREGROUND_STALE_MS = 30 * 1000
 const BUILD_APP_VERSION = formatAppVersionBadge(import.meta.env.VITE_APP_VERSION)
 
 export default function AppShell() {
@@ -102,6 +104,9 @@ export default function AppShell() {
   const [showQuickSwitcher, setShowQuickSwitcher] = useState(false)
   const [desktopAppVersion, setDesktopAppVersion] = useState<string | null>(null)
   const appVersionBadge = BUILD_APP_VERSION ?? desktopAppVersion
+  const socialSyncInFlightRef = useRef<Promise<void> | null>(null)
+  const socialSyncQueuedRef = useRef(false)
+  const lastSocialSyncAtRef = useRef(0)
 
   useEffect(() => {
     if (BUILD_APP_VERSION || !isTauri()) return
@@ -244,35 +249,49 @@ export default function AppShell() {
     return () => unsubscribe()
   }, [])
 
-  const syncSocial = useCallback(async () => {
+  const syncSocial = useCallback(async function runSocialSync(force = false) {
     if (!userId) return
-    try {
-      const [channels, friendList] = await Promise.all([
-        dmApi.listChannels(token),
-        friendApi.list(token),
-      ])
+    if (!force && Date.now() - lastSocialSyncAtRef.current < SOCIAL_FOREGROUND_STALE_MS) return
+    if (socialSyncInFlightRef.current) {
+      if (force) socialSyncQueuedRef.current = true
+      return socialSyncInFlightRef.current
+    }
+
+    const request = Promise.all([
+      dmApi.listChannels(token),
+      friendApi.list(token),
+    ]).then(([channels, friendList]) => {
       setDmChannelIds(channels.map((c) => c.id))
       setDmChannels(channels)
       setDmUnreadFromChannels(channels)
       setFriends(friendList)
       setSocialDataReady(true)
-    } catch {
-      // ignore transient failures
-    }
+      lastSocialSyncAtRef.current = Date.now()
+    }).catch(() => {
+      // Keep the latest snapshot on transient failures.
+    }).finally(() => {
+      if (socialSyncInFlightRef.current === request) socialSyncInFlightRef.current = null
+      if (socialSyncQueuedRef.current) {
+        socialSyncQueuedRef.current = false
+        window.setTimeout(() => { void runSocialSync(true) }, 0)
+      }
+    })
+    socialSyncInFlightRef.current = request
+    return request
   }, [setDmChannelIds, setDmChannels, setDmUnreadFromChannels, setFriends, setSocialDataReady, token, userId])
 
   useEffect(() => {
     if (!userId) return
-    void syncSocial()
+    void syncSocial(true)
     const id = window.setInterval(() => {
       if (document.visibilityState === 'hidden') return
       void syncSocial()
-    }, 60000)
+    }, SOCIAL_FALLBACK_SYNC_INTERVAL_MS)
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') void syncSocial()
     }
     const unsubscribeReconnect = onReconnect(() => {
-      void syncSocial()
+      void syncSocial(true)
     })
     document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
@@ -412,7 +431,7 @@ export default function AppShell() {
         if (e?.type === 'FriendUpdate') {
           const payload = e.data as { user_id?: string }
           if (!payload.user_id || payload.user_id === userId) {
-            void syncSocial()
+            void syncSocial(true)
           }
         }
         if (e?.type === 'NewMessage') {

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -8,6 +8,11 @@ import { useAuthStore } from '../stores/auth'
 import { useSocketStore } from '../stores/socket'
 import { useToastStore } from '../stores/toast'
 import { clearDmMessageCacheForTests } from '../dmMessageCache'
+import {
+  flushMessageDrafts,
+  resetMessageDraftCacheForTests,
+  saveMessageDraft,
+} from '../messageDrafts'
 import HomePage from './HomePage'
 
 const apiMocks = vi.hoisted(() => ({
@@ -70,11 +75,12 @@ vi.mock('../api', () => ({
 }))
 
 vi.mock('../components/ChatArea', () => ({
-  default: ({ loading, messages }: { loading?: boolean; messages: unknown[] }) => (
+  default: ({ loading, messages, messageInput }: { loading?: boolean; messages: unknown[]; messageInput: string }) => (
     <div
       data-testid="dm-chat"
       data-loading={String(!!loading)}
       data-message-count={String(messages.length)}
+      data-message-input={messageInput}
     >
       DM chat
     </div>
@@ -132,6 +138,7 @@ describe('HomePage friends list', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     clearDmMessageCacheForTests()
+    resetMessageDraftCacheForTests()
     localStorage.clear()
     sessionStorage.clear()
     window.scrollTo = vi.fn()
@@ -181,6 +188,20 @@ describe('HomePage friends list', () => {
     })
     expect(useAppStore.getState().dmChannels[0]?.id).toBe('dm-cilo')
     expect(screen.getByTestId('dm-chat')).not.toBeNull()
+  })
+
+  it('restores the current user draft when a DM is opened', async () => {
+    apiMocks.getOrCreateDmChannel.mockResolvedValue(dmChannel('dm-cilo'))
+    saveMessageDraft('user-1', 'dm', 'dm-cilo', 'remember this locally')
+    flushMessageDrafts()
+    resetMessageDraftCacheForTests()
+
+    renderHomePage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Message cilo' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dm-chat').getAttribute('data-message-input')).toBe('remember this locally')
+    })
   })
 
   it('opens a DM from the friend action button', async () => {

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -30,6 +30,11 @@ import {
   type DraftAttachmentItem,
 } from '../draftAttachments'
 import { mergeRemoteWithRetryableLocals, reconcileConfirmedMessage } from '../messageResilience'
+import {
+  clearMessageDraftIfUnchanged,
+  readMessageDraft,
+  saveMessageDraft,
+} from '../messageDrafts'
 import { type SocialView, getPersistedSocialView, setPersistedSocialView } from '../socialView'
 import { formatBadgeCount } from '../formatUnreadBadgeCount'
 import { createReplyContentSnippet } from '../replyPreview'
@@ -100,7 +105,7 @@ function OnboardingCard({
 export default function HomePage({ isMessagesView = true }: { isMessagesView?: boolean }) {
   const { token, user } = useAuthStore()
   const userId = user?.id ?? null
-  const { subscribe, send, isConnected, onReconnect } = useSocketStore()
+  const { subscribe, onReconnect } = useSocketStore()
   const {
     servers: storeServers,
     setServersLoading,
@@ -219,6 +224,16 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const pendingDmMessageFingerprintsRef = useRef(new Set<string>())
   const isDmConversationVisibleRef = useRef(isDmConversationVisible)
   const dmMessagesRequestRef = useRef(0)
+
+  useEffect(() => {
+    setDmInput(readMessageDraft(userId, 'dm', activeDmChannelId))
+    setDmDraftAttachments([])
+  }, [activeDmChannelId, userId])
+
+  const handleDmInputChange = useCallback((value: string) => {
+    setDmInput(value)
+    saveMessageDraft(userId, 'dm', activeDmChannelId, value)
+  }, [activeDmChannelId, userId])
   const pushToast = useToastStore((s) => s.pushToast)
   useEffect(() => { activeDmChannelIdRef.current = activeDmChannelId }, [activeDmChannelId])
   useEffect(() => { isDmConversationVisibleRef.current = isDmConversationVisible }, [isDmConversationVisible])
@@ -299,11 +314,19 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     }
   }, [setDmChannelIds, setDmUnreadFromChannels, setIncomingRequestCount, setServers, setServersLoading, setSocialDataReady, setStoreFriends, setStoreDmChannels, token, userId])
 
-  useEffect(() => {
+  const refreshFriendRequests = useCallback(async () => {
     if (!userId) return
+    const req = await friendApi.requests(token)
+    setIncomingRequests(req.incoming)
+    setIncomingRequestCount(req.incoming.length)
+    setOutgoingRequests(req.outgoing)
+  }, [setIncomingRequestCount, token, userId])
+
+  useEffect(() => {
+    if (!userId || !isMessagesView) return
     if (!useAppStore.getState().socialDataReady) setSocialBootstrapLoading(true)
     refreshServersAndFriends().catch(console.error)
-  }, [refreshServersAndFriends, userId])
+  }, [isMessagesView, refreshServersAndFriends, userId])
 
   const openOfficialCommunity = useCallback(async () => {
     if (voxperyServer) {
@@ -440,7 +463,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   useEffect(() => {
     if (!user) return
     const unsubscribe = onReconnect(() => {
-      void refreshServersAndFriends().catch(() => {})
+      if (isMessagesView) void refreshFriendRequests().catch(() => {})
 
       const currentDmChannelId = activeDmChannelIdRef.current
       if (currentDmChannelId) {
@@ -455,7 +478,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       }
     })
     return () => unsubscribe()
-  }, [onReconnect, refreshActiveDmConversation, refreshServersAndFriends, token, user])
+  }, [isMessagesView, onReconnect, refreshActiveDmConversation, refreshFriendRequests, token, user])
 
   const handlePinDmMessage = useCallback(async (messageId: string) => {
     if (!user || !activeDmChannelId) return
@@ -505,15 +528,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     window.scrollTo(0, 0)
       ; (document.activeElement as HTMLElement | null)?.blur()
   }, [view])
-
-  useEffect(() => {
-    if (!isConnected || dmChannels.length === 0) return
-    const ids = dmChannels.map((c) => c.id)
-    send('Subscribe', { channel_ids: ids })
-    return () => {
-      send('Unsubscribe', { channel_ids: ids })
-    }
-  }, [dmChannels, isConnected, send])
 
   useEffect(() => {
     const unsub = subscribe((evt: unknown) => {
@@ -575,16 +589,16 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
 
   // Instant social refresh when friend requests/friendships change on either side.
   useEffect(() => {
-    if (!userId) return
+    if (!userId || !isMessagesView) return
     const unsub = subscribe((evt: unknown) => {
       const e = evt as { type?: string; data?: { user_id?: string } }
       if (e?.type !== 'FriendUpdate') return
       const uid = e.data?.user_id
       if (uid !== userId) return
-      refreshServersAndFriends().catch(() => { })
+      refreshFriendRequests().catch(() => { })
     })
     return () => unsub()
-  }, [refreshServersAndFriends, subscribe, userId])
+  }, [isMessagesView, refreshFriendRequests, subscribe, userId])
 
   const openMessageForFriend = useCallback(async (friendId: string) => {
     if (!user || openingDmPeerId) return
@@ -640,7 +654,11 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const acceptRequest = async (requestId: string) => {
     if (!user) return
     await friendApi.acceptRequest(requestId, token)
-    await refreshServersAndFriends()
+    const [friendList] = await Promise.all([
+      friendApi.list(token),
+      refreshFriendRequests(),
+    ])
+    setStoreFriends(friendList)
   }
 
   const rejectRequest = async (requestId: string) => {
@@ -816,7 +834,8 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       })
       return
     }
-    const inputValue = typeof forceContent === 'string' ? forceContent : dmInput
+    const isForcedContent = typeof forceContent === 'string'
+    const inputValue = isForcedContent ? forceContent : dmInput
     const bodyText = inputValue.trim()
     const attachmentsToSend = getUploadedDraftAttachments(dmDraftAttachments)
     if (!bodyText && attachmentsToSend.length === 0) return
@@ -827,7 +846,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     if (pendingDmMessageFingerprintsRef.current.has(sendFingerprint)) return
     pendingDmMessageFingerprintsRef.current.add(sendFingerprint)
     setReplyingToDm(null)
-    setDmInput('')
+    if (!isForcedContent) setDmInput('')
     setDmDraftAttachments([])
     const clientId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     const optimisticId = `local-${clientId}`
@@ -869,6 +888,9 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       } else {
         rememberDmMessages(channelId, applySentDm(dmMessagesByChannelRef.current[channelId] ?? []))
       }
+      if (!isForcedContent) {
+        clearMessageDraftIfUnchanged(userId, 'dm', channelId, inputValue)
+      }
     } catch (err) {
       const applyFailedDm = (current: UiDmMessage[]) =>
         current.map((m) =>
@@ -884,6 +906,9 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         })
       } else {
         rememberDmMessages(channelId, applyFailedDm(dmMessagesByChannelRef.current[channelId] ?? []))
+      }
+      if (!isForcedContent && activeDmChannelIdRef.current === channelId) {
+        setDmInput((current) => current || inputValue)
       }
     } finally {
       pendingDmMessageFingerprintsRef.current.delete(sendFingerprint)
@@ -1408,7 +1433,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                 onPickAttachments={handleDmAttachmentPick}
                 onRemoveAttachment={(index) => setDmDraftAttachments((prev) => prev.filter((_, i) => i !== index))}
                 onRetryAttachment={handleRetryDmAttachment}
-                onMessageInputChange={setDmInput}
+                onMessageInputChange={handleDmInputChange}
                 onSendMessage={handleSendDm}
                 onRetryMessage={handleRetryDmMessage}
                 onDeleteMessage={setDeleteDmConfirmMessageId}

--- a/apps/web/src/pages/UnifiedLayout.test.tsx
+++ b/apps/web/src/pages/UnifiedLayout.test.tsx
@@ -1,0 +1,93 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '../stores/app'
+import { useAuthStore } from '../stores/auth'
+import { useSocketStore } from '../stores/socket'
+import UnifiedLayout from './UnifiedLayout'
+
+const apiMocks = vi.hoisted(() => ({
+  requests: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  friendApi: { requests: apiMocks.requests },
+}))
+
+vi.mock('../components/UnifiedSidebar', () => ({
+  default: ({ incomingRequestCount }: { incomingRequestCount: number }) => (
+    <div data-testid="incoming-count">{incomingRequestCount}</div>
+  ),
+}))
+vi.mock('./HomePage', () => ({ default: () => <div /> }))
+vi.mock('./AppLayout', () => ({ default: () => <div /> }))
+vi.mock('../notificationSound', () => ({
+  playMessageNotificationSound: vi.fn(),
+  shouldPlayNotificationSound: vi.fn(() => false),
+}))
+vi.mock('../pushNotifications', () => ({
+  shouldShowPushNotification: vi.fn(() => false),
+  showPushNotification: vi.fn(),
+}))
+
+describe('UnifiedLayout friend request synchronization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.setState({
+      token: 'token',
+      user: {
+        id: 'user-local',
+        username: 'local',
+        email: 'local@example.test',
+        email_verified: true,
+        status: 'online',
+      },
+      loggingOut: false,
+    })
+    useAppStore.getState().resetSessionState()
+    useSocketStore.setState({
+      socket: null,
+      isConnected: true,
+      token: 'token',
+      shouldReconnect: true,
+      listeners: new Set(),
+      reconnectListeners: new Set(),
+      reconnectAttempt: 0,
+      reconnectTimer: null,
+      connectionId: 1,
+      wasConnectedBefore: true,
+    })
+    apiMocks.requests.mockResolvedValue({ incoming: [], outgoing: [] })
+  })
+
+  it('uses FriendUpdate and reconnect events without six-second polling', async () => {
+    const setIntervalSpy = vi.spyOn(window, 'setInterval')
+    render(
+      <MemoryRouter initialEntries={['/channels/@me']}>
+        <UnifiedLayout />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(apiMocks.requests).toHaveBeenCalledTimes(1))
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 6_000)
+
+    act(() => {
+      useSocketStore.getState().listeners.forEach((listener) => {
+        listener({ type: 'FriendUpdate', data: { user_id: 'another-user' } })
+      })
+    })
+    expect(apiMocks.requests).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      useSocketStore.getState().listeners.forEach((listener) => {
+        listener({ type: 'FriendUpdate', data: { user_id: 'user-local' } })
+      })
+    })
+    await waitFor(() => expect(apiMocks.requests).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      useSocketStore.getState().reconnectListeners.forEach((listener) => listener())
+    })
+    await waitFor(() => expect(apiMocks.requests).toHaveBeenCalledTimes(3))
+  })
+})

--- a/apps/web/src/pages/UnifiedLayout.tsx
+++ b/apps/web/src/pages/UnifiedLayout.tsx
@@ -29,7 +29,7 @@ export default function UnifiedLayout() {
   const { user, token } = useAuthStore()
   const userId = user?.id ?? null
   const userStatus = user?.status
-  const { onReconnect } = useSocketStore()
+  const { onReconnect, subscribe } = useSocketStore()
   const {
     activeServerId,
     setActiveServer,
@@ -92,10 +92,18 @@ export default function UnifiedLayout() {
       return
     }
     let cancelled = false
-    const refresh = async () => {
-      try {
-        const req = await friendApi.requests(token)
+    let inFlight: Promise<void> | null = null
+    let refreshQueued = false
+    let lastRefreshAt = 0
+    function refresh(force = false): Promise<void> {
+      if (!force && Date.now() - lastRefreshAt < 30_000) return Promise.resolve()
+      if (inFlight) {
+        if (force) refreshQueued = true
+        return inFlight
+      }
+      inFlight = friendApi.requests(token).then((req) => {
         if (cancelled) return
+        lastRefreshAt = Date.now()
         setIncomingRequestCount(req.incoming.length)
         if (req.incoming.length > previousIncomingCountRef.current) {
           if (shouldPlayNotificationSound(userStatus)) {
@@ -112,29 +120,38 @@ export default function UnifiedLayout() {
           }
         }
         previousIncomingCountRef.current = req.incoming.length
-      } catch {
-        if (!cancelled) resetIncomingRequestCount()
-      }
+      }).catch(() => {
+        // Keep the latest count on transient network failures.
+      }).finally(() => {
+        inFlight = null
+        if (refreshQueued && !cancelled) {
+          refreshQueued = false
+          void refresh(true)
+        }
+      })
+      return inFlight
     }
-    void refresh()
-    const id = window.setInterval(() => {
-      void refresh()
-    }, 6000)
+    void refresh(true)
+    const unsubscribeEvents = subscribe((event: unknown) => {
+      const message = event as { type?: string; data?: { user_id?: string } }
+      if (message.type !== 'FriendUpdate') return
+      if (message.data?.user_id && message.data.user_id !== userId) return
+      void refresh(true)
+    })
+    const unsubscribeReconnect = onReconnect(() => {
+      void refresh(true)
+    })
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') void refresh()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
       cancelled = true
-      window.clearInterval(id)
+      unsubscribeEvents()
+      unsubscribeReconnect()
+      document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [resetIncomingRequestCount, setIncomingRequestCount, token, userId, userStatus])
-
-  useEffect(() => {
-    if (!userId) return
-    const unsubscribe = onReconnect(() => {
-      friendApi.requests(token)
-        .then((req) => setIncomingRequestCount(req.incoming.length))
-        .catch(() => {})
-    })
-    return () => unsubscribe()
-  }, [onReconnect, setIncomingRequestCount, token, userId])
+  }, [onReconnect, resetIncomingRequestCount, setIncomingRequestCount, subscribe, token, userId, userStatus])
 
   const handleOpenServerSettings = (id: string, initialTab: ServerSettingsTab = 'overview') => {
     setOpenServerSettingsForServerTab(initialTab)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -88,6 +88,9 @@ npm run rate-limit:check
 
 Appearance changes must follow the semantic token and startup rules in [THEMING.md](THEMING.md).
 
+Desktop bandwidth investigations must use the scenario controls and diagnostics
+in [NETWORK_USAGE_BENCHMARK.md](NETWORK_USAGE_BENCHMARK.md).
+
 ## CI Workflows
 
 ### `.github/workflows/ci.yml`

--- a/docs/NETWORK_USAGE_BENCHMARK.md
+++ b/docs/NETWORK_USAGE_BENCHMARK.md
@@ -1,0 +1,66 @@
+# Network Usage Benchmark
+
+Use this checklist when a desktop build appears to consume more bandwidth than
+the web client or another voice application. Compare the same machine, network,
+channel size, and elapsed time after a clean restart.
+
+## Fixed idle traffic baseline
+
+Before August 2026, authenticated clients requested friend requests every six
+seconds and refreshed the DM/friend snapshot every minute. That produced up to
+720 REST requests per idle hour before normal WebSocket traffic. Friend request
+updates are now driven by the authenticated `FriendUpdate` WebSocket event,
+reconnect, and foreground recovery. DM/friend snapshots use those events plus a
+five-minute visible-tab fallback, reducing the fixed fallback baseline to at
+most 24 REST requests per hour. The social page also no longer duplicates the
+global DM channel WebSocket subscription.
+
+The frontend tests reject reintroducing the six-second poll and protect the
+five-minute fallback cadence. Desktop updater checks remain event-independent
+and run at most once every six hours. Observability remains event-driven and is
+disabled by default for self-hosted deployments.
+
+## Measurement scenarios
+
+Measure at least five stable minutes per row after excluding startup and update
+downloads. Record process bytes sent/received and average kbps.
+
+| Scenario | Required state |
+| --- | --- |
+| Idle | No open voice room; no typing or navigation |
+| Text chat | One DM or server channel; text only |
+| Voice idle | Joined voice; microphones quiet; camera/share off |
+| Voice active | Two users speaking normally |
+| Camera | One 720p camera publisher and one viewer |
+| Screen share | Test Auto, Video, and Gaming profiles separately |
+
+For media scenarios, enable temporary voice diagnostics before joining:
+
+```js
+localStorage.setItem('voxperyVoiceDiagnostics', '1')
+location.reload()
+```
+
+Inspect `window.__VOXPERY_VOICE_DIAGNOSTICS__`. Screen-share measurements must
+include actual capture resolution/FPS, outbound bitrate, codec, scalability
+mode, and `qualityLimitationReason`. A lower measured FPS or bitrate than the
+selected profile can be caused by browser capture, CPU, network congestion, or
+the SFU; do not classify it as an application regression without those fields.
+
+Disable diagnostics after the benchmark:
+
+```js
+localStorage.removeItem('voxperyVoiceDiagnostics')
+location.reload()
+```
+
+## Regression triage
+
+1. Confirm there is one `/ws` connection and no reconnect loop.
+2. Confirm `/api/friends/requests` is event-driven rather than periodic.
+3. Check that hidden or explicitly hidden remote video tracks are unsubscribed;
+   remote audio stays subscribed while joined.
+4. Separate REST/WebSocket traffic from LiveKit media traffic.
+5. Confirm repeated attachment URLs are served from normal browser cache rather
+   than downloaded again.
+6. Exclude updater downloads and release installation from steady-state totals.

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -125,6 +125,9 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Production web CSP `connect-src` does not include `localhost` or `127.0.0.1` loopback targets.
 - [ ] Desktop release preflight confirms restrictive `object-src`, `base-uri`, `form-action`, `frame-ancestors`, and media CSP directives.
 - [ ] During the real production voice call, after enabling `localStorage.setItem("voxperyVoiceDiagnostics", "1")` and reloading, DevTools `window.__VOXPERY_VOICE_DIAGNOSTICS__` reports `rnnoiseStatus: "ready"` and `aggressiveIsolation: true` when suppression is on.
+- [ ] Unsent text restores independently after switching between two server channels and two DMs, survives reload/desktop restart for the same user, and is absent for another user on the same device.
+- [ ] A successful send clears only that conversation's text draft; a failed send preserves it, and file attachments are never restored as persistent drafts.
+- [ ] Desktop idle traffic follows [NETWORK_USAGE_BENCHMARK.md](NETWORK_USAGE_BENCHMARK.md): there is one WebSocket connection and no six-second friend-request polling.
 - [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` when suppression, CSP, service workers, build output, or production deployment config changed.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -416,6 +416,11 @@ npm audit fix
 
 For privacy policy, see main README or project website.
 
+Unsent message text is stored only in browser/desktop local storage, scoped by
+user and channel/DM identity. Drafts are never sent to the backend, do not retain
+file attachments, are limited to 4,000 characters and 80 entries, and expire
+after 30 days.
+
 ---
 
 Last verified against code on 2026-05-12.

--- a/docs/WEBSOCKET_EVENTS.md
+++ b/docs/WEBSOCKET_EVENTS.md
@@ -142,6 +142,8 @@ Legacy custom signaling event.
 ### Friends
 
 - `FriendUpdate`
+  - Targeted to each affected user after request, accept, reject, cancel, or remove operations.
+  - Clients refresh friend/request snapshots from this event, with reconnect, foreground, and a five-minute visible-session fallback for recovery; do not add short-interval polling.
 
 ### Server Membership / Roles / Channels
 


### PR DESCRIPTION
## Summary
- persist user- and conversation-scoped channel/DM text drafts locally
- preserve drafts across reloads and failed sends
- clear only the successfully sent conversation draft
- replace aggressive friend-request polling with event-driven synchronization
- remove duplicate DM subscriptions and hidden social refresh traffic
- document network benchmarking and draft privacy behavior

## Validation
- `npm run lint`
- `npm run test:run` (246 tests)
- `npm run build`
- `graphify update .`