### PR TITLE
chore: prepare v0.2.6 release

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5389,7 +5389,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.4"
+version = "0.2.6"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.4"
+version = "0.2.6"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3143,7 +3143,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.4"
+version = "0.2.6"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.4"
+version = "0.2.6"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.4",
+      "version": "0.2.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.4",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.6",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,10 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-08-09
+
+### Added
+- Added persistent, user-scoped text drafts for server channels and direct messages, including safe restoration after reload or desktop restart.
+- Added release smoke coverage for draft isolation, failed-send preservation, and low-idle-traffic behavior.
+
 ### Changed
+- Reduced idle REST traffic by removing six-second friend-request polling, deduplicating DM subscriptions, and extending the event-driven fallback refresh interval.
+- Improved screen-share capture and publish adaptation for high-motion 1080p presets while retaining network-aware degradation behavior.
+- Updated voice media controls so hiding remote camera or screen share is local, reversible, and does not disconnect microphone audio.
+- Refined camera, screen-share, join, and leave audio cues so call events are easier to distinguish without adding stop-event noise.
+- Synchronized web, server, and desktop package metadata to `0.2.6` after the `v0.2.5` tag relied on tag-derived build versions.
+
+### Fixed
+- Completed desktop Google OAuth handoff recovery and made callback processing idempotent across startup and runtime deep-link delivery.
+- Improved microphone device recovery and remote-media attachment reliability across desktop, web, and reconnect paths.
+- Prevented first-message content from shifting after server confirmation.
+- Completed Light and custom theme contrast coverage across member lists, overlays, modals, and feedback surfaces.
+- Corrected attachment signature tampering coverage so the backend regression test always mutates the tested signature.
+
+## [0.2.5] - 2026-08-08
+
+### Added
+- Added Default, Dark, Light, and single-color Custom appearance themes with persistent preferences and reset-to-default behavior.
+- Added a compact, theme-aware feedback dock linking users to the matching GitHub bug and feature request templates.
+- Added privacy-safe, feature-gated operational observability with a fixed event schema.
+
+### Changed
+- Sorted open direct messages by recent activity, added persistent DM pinning, and moved pin actions into a compact context menu.
+- Reworked channel and category creation into Discord-style compact menus, category actions, and sidebar context menus.
+- Tuned the default voice suppression profiles for more natural speech while retaining the noisy-room option.
 - Migrated declarative routing imports to React Router 8 and updated the frontend lint dependency chain to ESLint 10.
 - Preserved original error causes when wrapping network and microphone-access failures for clearer diagnostics.
 - Reduced scheduled dependency audits from daily to weekly while retaining audits on every pull request and manual dispatch.
+
+### Fixed
+- Reconciled LiveKit disconnects with sidebar voice presence so departed users no longer remain visible in voice channels.
+- Fixed landing login/register navigation and completed the desktop OAuth return flow.
+- Stabilized first-message avatar and content alignment and aligned application surfaces with the selected appearance theme.
 
 ### Security
 - Updated React Router to `8.3.0` to address `GHSA-qwww-vcr4-c8h2`.


### PR DESCRIPTION
## Summary

- bump web, server, and desktop metadata to `0.2.6`
- add the missing `0.2.5` changelog history
- document messaging, voice, screen-share, OAuth, theme, and reliability changes included in `0.2.6`
- keep Cargo, npm, Tauri, and changelog versions synchronized

## Validation

- `npm run lint`
- `npm run test:run` — 246 passed
- `npm run build`
- `cargo check --locked` — server and desktop
- `cargo test --locked` — 134 passed, 4 ignored
- release version synchronization check
- Graphify update