### PR TITLE
fix: refresh deployed web releases without hard reload

### DIFF
--- a/.github/scripts/validate-security-policies.mjs
+++ b/.github/scripts/validate-security-policies.mjs
@@ -17,6 +17,24 @@ function requireText(label, text, expected) {
   if (!text.includes(expected)) failures.push(`${label} must include: ${expected}`)
 }
 
+function locationBlock(config, location) {
+  const marker = `location ${location} {`
+  const start = config.indexOf(marker)
+  if (start < 0) return ''
+  const bodyStart = start + marker.length
+  const bodyEnd = config.indexOf('}', bodyStart)
+  return bodyEnd < 0 ? '' : config.slice(bodyStart, bodyEnd)
+}
+
+function requireLocationText(label, config, location, expected) {
+  const block = locationBlock(config, location)
+  if (!block) {
+    failures.push(`${label} must include location ${location}`)
+    return
+  }
+  requireText(`${label} location ${location}`, block, expected)
+}
+
 function includesLocalBackendTarget(value) {
   return /(^|[^a-z0-9.-])(localhost|127\.0\.0\.1)(?::|\/|\\|\*|"|$)/i.test(value)
 }
@@ -35,6 +53,16 @@ function validateNginx(path, { production }) {
   requireText(label, config, "script-src 'self' 'wasm-unsafe-eval'")
   requireText(label, config, 'location = /healthz {')
   requireText(label, config, 'default_type text/plain;')
+  requireLocationText(label, config, '= /index.html', 'expires -1;')
+  requireLocationText(label, config, '= /index.html', 'try_files $uri =404;')
+  requireLocationText(label, config, '= /sw.js', 'expires -1;')
+  requireLocationText(label, config, '= /sw.js', 'try_files $uri =404;')
+  requireLocationText(label, config, '= /assets/rnnoise-worklet.js', 'expires -1;')
+  requireLocationText(label, config, '= /assets/rnnoise-worklet.js', 'try_files $uri =404;')
+  requireLocationText(label, config, '^~ /assets/', 'expires 1y;')
+  requireLocationText(label, config, '^~ /assets/', 'try_files $uri =404;')
+  requireLocationText(label, config, '/', 'expires -1;')
+  requireLocationText(label, config, '/', 'try_files $uri $uri/ /index.html;')
 
   if (production) {
     requireText(label, config, 'add_header Strict-Transport-Security "max-age=31536000" always;')
@@ -80,6 +108,10 @@ validateNginx('apps/web/nginx.production.conf', { production: true })
 validateNginx('apps/web/nginx.development.conf', { production: false })
 validateTauri('apps/desktop/src-tauri/tauri.conf.json', { production: true })
 validateTauri('apps/desktop/src-tauri/tauri.dev.conf.json', { production: false })
+
+const pwaRegistration = read('apps/web/src/pwa.ts')
+requireText('apps/web/src/pwa.ts', pwaRegistration, "register('/sw.js', { updateViaCache: 'none' })")
+requireText('apps/web/src/pwa.ts', pwaRegistration, 'registration.update()')
 
 const apiFixture = new Response(null, {
   headers: {

--- a/apps/web/nginx.development.conf
+++ b/apps/web/nginx.development.conf
@@ -17,7 +17,28 @@ server {
         return 200 "ok\n";
     }
 
+    location = /index.html {
+        expires -1;
+        try_files $uri =404;
+    }
+
+    location = /sw.js {
+        expires -1;
+        try_files $uri =404;
+    }
+
+    location = /assets/rnnoise-worklet.js {
+        expires -1;
+        try_files $uri =404;
+    }
+
+    location ^~ /assets/ {
+        expires 1y;
+        try_files $uri =404;
+    }
+
     location / {
+        expires -1;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/apps/web/nginx.production.conf
+++ b/apps/web/nginx.production.conf
@@ -18,7 +18,32 @@ server {
         return 200 "ok\n";
     }
 
+    # Release entry points must be revalidated so a normal reload discovers
+    # the current hashed bundle instead of keeping an older app shell.
+    location = /index.html {
+        expires -1;
+        try_files $uri =404;
+    }
+
+    location = /sw.js {
+        expires -1;
+        try_files $uri =404;
+    }
+
+    # This worklet has a stable URL and therefore cannot use immutable caching.
+    location = /assets/rnnoise-worklet.js {
+        expires -1;
+        try_files $uri =404;
+    }
+
+    # Vite fingerprints production JS/CSS assets, so they are safe to retain.
+    location ^~ /assets/ {
+        expires 1y;
+        try_files $uri =404;
+    }
+
     location / {
+        expires -1;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/apps/web/scripts/release-deploy-smoke.mjs
+++ b/apps/web/scripts/release-deploy-smoke.mjs
@@ -63,17 +63,40 @@ function assetUrls(html, webBase) {
   return [...urls]
 }
 
+function cacheControl(response) {
+  return response.headers.get('cache-control')?.toLowerCase() || ''
+}
+
+function assertRevalidated(response, label) {
+  const value = cacheControl(response)
+  assert(
+    value.includes('no-cache') || value.includes('no-store') || /(?:^|,)\s*max-age=0(?:\s*,|$)/.test(value),
+    `${label} must be revalidated on normal reload; received Cache-Control: ${value || '<missing>'}`
+  )
+}
+
+function assertLongLived(response, label) {
+  const value = cacheControl(response)
+  const maxAge = Number(value.match(/(?:^|,)\s*max-age=(\d+)/)?.[1] || 0)
+  assert(maxAge >= 31_536_000, `${label} must use long-lived caching; received Cache-Control: ${value || '<missing>'}`)
+}
+
 async function checkVersionInDeployedAssets() {
   const rootRes = await getOk(`${WEB_BASE}/`, 'web root')
+  assertRevalidated(rootRes, 'web root')
   const html = await rootRes.text()
   const assets = assetUrls(html, WEB_BASE)
   assert(assets.length > 0, 'No JS/CSS assets found in deployed web root')
+
+  const serviceWorkerRes = await getOk(`${WEB_BASE}/sw.js`, 'service worker')
+  assertRevalidated(serviceWorkerRes, 'service worker')
 
   const needles = [EXPECTED_BADGE, EXPECTED_IMAGE_TAG].filter(Boolean)
   const seen = new Set()
 
   for (const asset of assets) {
     const res = await getOk(asset, `asset ${asset}`)
+    assertLongLived(res, `asset ${asset}`)
     const text = await res.text()
     for (const needle of needles) {
       if (text.includes(needle)) seen.add(needle)

--- a/apps/web/src/pwa.ts
+++ b/apps/web/src/pwa.ts
@@ -7,8 +7,11 @@ export function registerPwaServiceWorker(): void {
   if (isTauri()) return
 
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {
-      // PWA support should never block the authenticated app shell.
-    })
+    navigator.serviceWorker
+      .register('/sw.js', { updateViaCache: 'none' })
+      .then((registration) => registration.update())
+      .catch(() => {
+        // PWA support should never block the authenticated app shell.
+      })
   })
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Made normal browser reloads revalidate the web app shell, service worker, and stable RNNoise worklet URL so newly deployed releases no longer require a hard refresh, while retaining long-lived caching for fingerprinted assets.
+
 ## [0.2.6] - 2026-08-09
 
 ### Added

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -268,6 +268,14 @@ deployed main candidates). For manual image builds, pass
 `--build-arg VITE_APP_VERSION=<tag>` to keep the visible badge aligned with the
 image tag.
 
+The web container requires release entry points (`/`, `/index.html`, and
+`/sw.js`) and the stable RNNoise worklet URL to be revalidated on every normal
+reload. Fingerprinted `/assets/` files are cached for one year because a new
+build produces new URLs. Do not override the entry-point headers with a CDN
+browser-cache rule: the release smoke workflow verifies that the app shell and
+service worker return a revalidation policy, preventing stale releases from
+requiring `Ctrl+F5`.
+
 ## 8) Backups
 
 ```bash

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -76,7 +76,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Appearance offers Default, Dark, Light, and Custom choices; Custom generates a readable palette from one valid hex color, persists after reload, and `Reset defaults` restores the original Voxpery palette without horizontal overflow on desktop or mobile.
 - [ ] The fixed bottom-right feedback dock shows theme-aligned `Report a bug` and `Request a feature` actions that open the matching GitHub issue templates on web and desktop; it stays outside information sidebars and is hidden on mobile so chat/composer width is unchanged.
 - [ ] Login and registration do not open a native notification permission prompt; the delayed in-app prompt requests permission only after the user selects `Enable`, and `Not now` suppresses it during the snooze window.
-- [ ] Web app is installable as a PWA and the service worker does not cache API, auth, WebSocket, or navigation responses.
+- [ ] Web app is installable as a PWA; a normal reload (without `Ctrl+F5`) discovers the current release; the app shell and `/sw.js` require revalidation; and the service worker does not cache API, auth, WebSocket, or navigation responses.
 - [ ] Production voice call with noise suppression on does not reuse a stale cached RNNoise worklet after deploy.
 - [ ] Uploaded chat image attachments render inline after channel/server navigation and open only in the in-app preview modal on web and desktop, with no external tab/browser navigation.
 - [ ] Automated core UI smoke includes invite/join, server settings, social/friend, auth/account, release/settings, permission, and desktop-runtime regressions.


### PR DESCRIPTION
## Summary

- revalidate the web app shell and service worker on normal browser reloads
- keep fingerprinted production assets long-lived while refreshing stable asset URLs
- bypass the HTTP cache during service worker update checks
- validate cache headers in CI and release smoke checks
- document the production cache contract

## Validation

- `npm run lint`
- `npm run test:run` (246 tests)
- `npm run build`
- production Docker image build
- runtime Nginx cache and security header verification