### PR TITLE
fix: improve screen share audio quality

### DIFF
--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -34,6 +34,13 @@ import {
   isEditableShortcutTarget,
   keyboardEventMatchesShortcut,
 } from '../globalMuteShortcut'
+import {
+  DEFAULT_REMOTE_PLAYBACK_VOLUME,
+  normalizeRemotePlaybackVolume,
+  readRemotePlaybackVolumes,
+  REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT,
+  writeRemotePlaybackVolumes,
+} from '../webrtc/remotePlaybackVolume'
 
 type VoxperyTrack = VoxperyMediaStreamTrack
 
@@ -204,26 +211,12 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const DEFAULT_OUTPUT_VOLUME = 80
   const SETTINGS_CHANGED_EVENT = VOICE_SETTINGS_CHANGED_EVENT
   const MIC_TEST_AUTO_DEAFEN_EVENT = 'voxpery-mic-test-auto-deafen'
-  const PEER_VOLUME_KEY = 'voxpery-voice-peer-volume'
-  const PEER_VOLUME_CHANGED_EVENT = 'voxpery-voice-peer-volume-changed'
   const [outputVolume, setOutputVolume] = useState(() =>
     Math.min(100, Math.max(1, Number(localStorage.getItem(OUTPUT_VOL_KEY)) || DEFAULT_OUTPUT_VOLUME))
   )
-  const [peerVolumeByUserId, setPeerVolumeByUserId] = useState<Record<string, number>>(() => {
-    try {
-      const raw = localStorage.getItem(PEER_VOLUME_KEY)
-      if (!raw) return {}
-      const parsed = JSON.parse(raw) as Record<string, unknown>
-      const next: Record<string, number> = {}
-      for (const [key, value] of Object.entries(parsed)) {
-        if (typeof value !== 'number' || !Number.isFinite(value)) continue
-        next[key] = Math.min(200, Math.max(0, Math.round(value)))
-      }
-      return next
-    } catch {
-      return {}
-    }
-  })
+  const [peerVolumeByUserId, setPeerVolumeByUserId] = useState<Record<string, number>>(
+    () => readRemotePlaybackVolumes(),
+  )
   const [fullscreenTileKey, setFullscreenTileKey] = useState<string | null>(null)
   const [hiddenRemoteMediaKeys, setHiddenRemoteMediaKeys] = useState<Set<string>>(() => new Set())
   const [remoteMediaPlaceholders, setRemoteMediaPlaceholders] = useState<Map<string, RemoteMediaPlaceholder>>(() => new Map())
@@ -243,9 +236,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const micTestPrevMutedRef = useRef(false)
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
-  // Per-playback WebAudio nodes for amplification above 100% (GainNode allows gain > 1.0).
-  // Microphone and screen-share audio are separate playback paths so their volumes cannot affect each other.
-  const perPeerAudioCtxRef = useRef<Map<string, { ctx: AudioContext; source: MediaElementAudioSourceNode; gain: GainNode }>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
   const cameraPreviewCleanupRef = useRef<(() => void) | null>(null)
@@ -315,8 +305,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     const volumeKey = resolvePeerVolumeKey(peerId)
     const storageKey = kind === 'screen' ? `screen:${volumeKey}` : volumeKey
     const raw = peerVolumeByUserId[storageKey]
-    const bounded = typeof raw === 'number' && Number.isFinite(raw) ? Math.min(200, Math.max(0, raw)) : 100
-    return bounded / 100  // returns 0.0–2.0
+    return normalizeRemotePlaybackVolume(raw) / 100
   }, [peerVolumeByUserId, resolvePeerVolumeKey])
 
   const ensureRemoteAudioPlayback = useCallback((peerId: string, el: HTMLAudioElement) => {
@@ -378,56 +367,10 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     for (const [playbackKey, el] of remoteAudioRefsRef.current.entries()) {
       try {
         const { peerId, kind } = parseRemoteAudioPlaybackKey(playbackKey)
-        const peerFactor = getPlaybackVolumeFactor(peerId, kind)  // 0.0–2.0
+        const peerFactor = getPlaybackVolumeFactor(peerId, kind)
         const combined = isDeafened ? 0 : global * peerFactor
-        if (peerFactor <= 1.0) {
-          // Normal range: use plain audio.volume (0–1)
-          el.volume = Math.min(1, Math.max(0, combined))
-          // Tear down any existing GainNode for this peer (they lowered it back)
-          const existing = perPeerAudioCtxRef.current.get(playbackKey)
-          if (existing) {
-            try { existing.source.disconnect(); existing.gain.disconnect() } catch { /* ignore */ }
-            void existing.ctx.close().catch(() => { })
-            perPeerAudioCtxRef.current.delete(playbackKey)
-          }
-        } else {
-          // Amplified range (>100%): route through a GainNode. When captured, el.muted is ignored
-          // by the browser, so we mute by setting gain.gain.value = 0 when deafened.
-          let nodes = perPeerAudioCtxRef.current.get(playbackKey)
-          if (!nodes) {
-            // When deafened (combined === 0), avoid createMediaElementSource so Firefox doesn't warn
-            // about captured MediaElement (volume/mute not supported after capture)
-            if (combined === 0) {
-              el.volume = 0
-              el.muted = true
-              continue
-            }
-            try {
-              const AudioCtor = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
-              if (AudioCtor) {
-                const ctx = new AudioCtor()
-                const source = ctx.createMediaElementSource(el)
-                const gain = ctx.createGain()
-                source.connect(gain)
-                gain.connect(ctx.destination)
-                nodes = { ctx, source, gain }
-                perPeerAudioCtxRef.current.set(playbackKey, nodes)
-              }
-            } catch {
-              // WebAudio unavailable: clamp to 1.0
-              el.volume = 1
-              continue
-            }
-          }
-          if (nodes) {
-            nodes.gain.gain.value = Math.min(4, combined)  // 0 when deafened, else cap at 4×
-            // Do not set el.volume/el.muted: element is captured by Web Audio, Firefox warns and it has no effect
-          }
-        }
-        // Only set el.muted when not using GainNode (captured element ignores it; mute is via gain.gain.value)
-        if (!perPeerAudioCtxRef.current.has(playbackKey)) {
-          el.muted = isDeafened
-        }
+        el.volume = Math.min(1, Math.max(0, combined))
+        el.muted = isDeafened
       } catch {
         // ignore
       }
@@ -437,12 +380,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const recoverRemoteAudioPlayback = useCallback(() => {
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
     applyOutputDeviceToElements()
-
-    for (const nodes of perPeerAudioCtxRef.current.values()) {
-      if (nodes.ctx.state === 'suspended') {
-        void nodes.ctx.resume().catch(() => { })
-      }
-    }
 
     if (deafenedRef.current) return
     for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
@@ -484,25 +421,10 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
   useEffect(() => {
     const onPeerVolumeChanged = () => {
-      try {
-        const raw = localStorage.getItem(PEER_VOLUME_KEY)
-        if (!raw) {
-          setPeerVolumeByUserId({})
-          return
-        }
-        const parsed = JSON.parse(raw) as Record<string, unknown>
-        const next: Record<string, number> = {}
-        for (const [key, value] of Object.entries(parsed)) {
-          if (typeof value !== 'number' || !Number.isFinite(value)) continue
-          next[key] = Math.min(200, Math.max(0, Math.round(value)))
-        }
-        setPeerVolumeByUserId(next)
-      } catch {
-        setPeerVolumeByUserId({})
-      }
+      setPeerVolumeByUserId(readRemotePlaybackVolumes())
     }
-    window.addEventListener(PEER_VOLUME_CHANGED_EVENT, onPeerVolumeChanged)
-    return () => window.removeEventListener(PEER_VOLUME_CHANGED_EVENT, onPeerVolumeChanged)
+    window.addEventListener(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT, onPeerVolumeChanged)
+    return () => window.removeEventListener(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT, onPeerVolumeChanged)
   }, [])
   const effectiveDeafened = deafened || serverDeafened
 
@@ -636,9 +558,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
           el.__voxpery_trackIds = currentTrackIds
           void applyPreferredAudioOutputDevice(el)
         }
-        if (!perPeerAudioCtxRef.current.has(playbackKey)) {
-          el.muted = deafenedRef.current
-        }
+        el.muted = deafenedRef.current
         if (!deafenedRef.current && currentTrackIds) {
           ensureRemoteAudioPlayback(playbackKey, el)
         }
@@ -1267,7 +1187,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               {remoteVideoTrackEntries.map(({ peerId, track, label, kind }) => {
                 const volumeKey = resolvePeerVolumeKey(peerId)
                 const screenVolumeKey = `screen:${volumeKey}`
-                const currentVol = kind === 'screen' ? (peerVolumeByUserId[screenVolumeKey] ?? 100) : (peerVolumeByUserId[volumeKey] ?? 100)
+                const currentVol = normalizeRemotePlaybackVolume(
+                  kind === 'screen' ? peerVolumeByUserId[screenVolumeKey] : peerVolumeByUserId[volumeKey],
+                )
                 const tileKey = `${peerId}-${track.id}`
                 const owner = remoteShareOwner(peerId)
                 const isHidden = isRemoteMediaHidden(peerId, kind)
@@ -1286,25 +1208,25 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                               let newVal: number
                               if (isMuted) {
                                 const savedStr = localStorage.getItem(prevVolumeKey)
-                                const savedVal = savedStr ? Number(savedStr) : 100
-                                newVal = savedVal > 0 ? savedVal : 100
+                                const savedVal = normalizeRemotePlaybackVolume(
+                                  savedStr ? Number(savedStr) : DEFAULT_REMOTE_PLAYBACK_VOLUME,
+                                )
+                                newVal = savedVal > 0 ? savedVal : DEFAULT_REMOTE_PLAYBACK_VOLUME
                               } else {
                                 localStorage.setItem(prevVolumeKey, String(currentVol))
                                 newVal = 0
                               }
-                              const next = { ...peerVolumeByUserId, [screenVolumeKey]: newVal }
+                              const next = writeRemotePlaybackVolumes({ ...peerVolumeByUserId, [screenVolumeKey]: newVal })
                               setPeerVolumeByUserId(next)
-                              localStorage.setItem(PEER_VOLUME_KEY, JSON.stringify(next))
                               applyOutputVolumeToElements(outputVolumeRef.current / 100)
                             }}>
                               {currentVol === 0 ? <VolumeX size={16} /> : <Volume2 size={16} />}
                             </button>
                             <div className="screen-share-volume-slider-wrap">
-                              <input type="range" min={0} max={200} value={currentVol} className="screen-share-volume-slider" title={`Volume: ${currentVol}%`} onChange={(e) => {
-                                const val = Number(e.target.value)
-                                const next = { ...peerVolumeByUserId, [screenVolumeKey]: val }
+                              <input type="range" min={0} max={100} value={currentVol} className="screen-share-volume-slider" title={`Volume: ${currentVol}%`} onChange={(e) => {
+                                const val = normalizeRemotePlaybackVolume(Number(e.target.value))
+                                const next = writeRemotePlaybackVolumes({ ...peerVolumeByUserId, [screenVolumeKey]: val })
                                 setPeerVolumeByUserId(next)
-                                localStorage.setItem(PEER_VOLUME_KEY, JSON.stringify(next))
                                 applyOutputVolumeToElements(outputVolumeRef.current / 100)
                               }} />
                               <span className="screen-share-volume-value">{currentVol}%</span>
@@ -1353,24 +1275,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                           }
                           void applyPreferredAudioOutputDevice(audioEl)
                           const shouldMute = deafenedRef.current
-                          const isCaptured = perPeerAudioCtxRef.current.has(playbackKey)
-                          if (!isCaptured) {
-                            const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-                            const vol = Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
-                            try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
-                            audioEl.muted = shouldMute
-                          }
+                          const peerFactor = getPlaybackVolumeFactor(peerId, kind)
+                          const vol = Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
+                          try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
+                          audioEl.muted = shouldMute
                           if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
                         } else {
                           remoteAudioRefsRef.current.delete(playbackKey)
                           const t = remoteAudioRetryTimerRef.current.get(playbackKey)
                           if (t != null) { window.clearTimeout(t); remoteAudioRetryTimerRef.current.delete(playbackKey) }
-                          const existing = perPeerAudioCtxRef.current.get(playbackKey)
-                          if (existing) {
-                            try { existing.source.disconnect(); existing.gain.disconnect() } catch { /* ignore */ }
-                            void existing.ctx.close().catch(() => { })
-                            perPeerAudioCtxRef.current.delete(playbackKey)
-                          }
                         }
                       }} />
                     )

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -9,6 +9,12 @@ import { useToastStore } from '../stores/toast'
 import { preloadRnnoiseWorklet } from '../webrtc/rnnoise'
 import { formatBadgeCount } from '../formatUnreadBadgeCount'
 import { formatVoiceChannelDuration } from '../voiceChannelDuration'
+import {
+    normalizeRemotePlaybackVolume,
+    readRemotePlaybackVolumes,
+    REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT,
+    writeRemotePlaybackVolumes,
+} from '../webrtc/remotePlaybackVolume'
 
 const PERM_CONNECT_VOICE = 1 << 10
 type ManualJoinWindow = Window & { __voxperyManualJoinActive?: boolean }
@@ -91,21 +97,9 @@ export default function ChannelSidebar({
     const [dragOverCategory, setDragOverCategory] = useState<{ name: string; position: 'before' | 'after' } | null>(null)
     const [dragOverCategoryForChannel, setDragOverCategoryForChannel] = useState<string | null>(null)
     const [durationNow, setDurationNow] = useState(() => Date.now())
-    const [peerVolumeByUserId, setPeerVolumeByUserId] = useState<Record<string, number>>(() => {
-        try {
-            const raw = localStorage.getItem('voxpery-voice-peer-volume')
-            if (!raw) return {}
-            const parsed = JSON.parse(raw) as Record<string, unknown>
-            const next: Record<string, number> = {}
-            for (const [key, value] of Object.entries(parsed)) {
-                if (typeof value !== 'number' || !Number.isFinite(value)) continue
-                next[key] = Math.min(200, Math.max(0, Math.round(value)))
-            }
-            return next
-        } catch {
-            return {}
-        }
-    })
+    const [peerVolumeByUserId, setPeerVolumeByUserId] = useState<Record<string, number>>(
+        () => readRemotePlaybackVolumes(),
+    )
     const menuRef = useRef<HTMLDivElement>(null)
     const participantMenuRef = useRef<HTMLDivElement>(null)
     const sidebarRef = useRef<HTMLDivElement>(null)
@@ -219,11 +213,12 @@ export default function ChannelSidebar({
     }, [voiceChannelActiveSince])
 
     const savePeerVolume = (userId: string, volume: number) => {
-        const bounded = Math.min(200, Math.max(0, Math.round(volume)))
-        const next = { ...peerVolumeByUserId, [userId]: bounded }
+        const next = writeRemotePlaybackVolumes({
+            ...peerVolumeByUserId,
+            [userId]: normalizeRemotePlaybackVolume(volume),
+        })
         setPeerVolumeByUserId(next)
-        localStorage.setItem('voxpery-voice-peer-volume', JSON.stringify(next))
-        window.dispatchEvent(new CustomEvent('voxpery-voice-peer-volume-changed'))
+        window.dispatchEvent(new CustomEvent(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT))
     }
 
     const handleJoinVoice = async (id: string) => {
@@ -789,7 +784,7 @@ export default function ChannelSidebar({
 
             {participantMenu && (() => {
                 const isSelf = participantMenu.userId === user?.id
-                const currentVolume = peerVolumeByUserId[participantMenu.userId] ?? 100
+                const currentVolume = normalizeRemotePlaybackVolume(peerVolumeByUserId[participantMenu.userId])
                 const targetVoice = voiceControls[participantMenu.userId] ?? {
                     muted: false,
                     deafened: false,
@@ -886,12 +881,12 @@ export default function ChannelSidebar({
                             </div>
                             <div className="member-volume-menu-section-hint">Only affects what you hear</div>
                             <div className="member-volume-menu-label">
-                                Volume: {currentVolume}%{currentVolume > 100 ? ' 🔊' : ''}
+                                Volume: {currentVolume}%
                             </div>
                             <input
                                 type="range"
                                 min={0}
-                                max={200}
+                                max={100}
                                 step={5}
                                 value={currentVolume}
                                 onChange={(e) => savePeerVolume(participantMenu.userId, Number(e.target.value))}

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -68,11 +68,39 @@ describe('screen share quality profiles', () => {
 
     expect(toScreenShareDisplayMediaOptions(video)).toEqual({
       video,
+      systemAudio: 'include',
       audio: {
         suppressLocalAudioPlayback: false,
       },
     })
     expect(SCREEN_SHARE_CAPTURE_READY_EVENT).toBe('voxpery-screen-share-capture-ready')
+  })
+
+  it('records non-identifying screen audio quality settings', () => {
+    const videoTrack = {
+      getSettings: () => ({ width: 1920, height: 1080, frameRate: 60 }),
+    } as unknown as MediaStreamTrack
+    const audioTrack = {
+      contentHint: 'music',
+      getSettings: () => ({
+        sampleRate: 48000,
+        channelCount: 2,
+        deviceId: 'private-audio-id',
+      }),
+    } as unknown as MediaStreamTrack
+
+    expect(toScreenShareCaptureDiagnostics(
+      SCREEN_SHARE_PRESET_PROFILE.video,
+      videoTrack,
+      true,
+      true,
+      audioTrack,
+    )).toMatchObject({
+      audioCaptured: true,
+      audioSampleRate: 48000,
+      audioChannelCount: 2,
+      audioContentHint: 'music',
+    })
   })
 
   it('records requested and actual capture quality without device identifiers', () => {

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -91,11 +91,16 @@ type DisplayAudioConstraints = MediaTrackConstraints & {
     suppressLocalAudioPlayback: boolean
 }
 
+type ScreenShareDisplayMediaOptions = DisplayMediaStreamOptions & {
+    systemAudio: 'include'
+}
+
 export function toScreenShareDisplayMediaOptions(
     video: DisplayMediaStreamOptions['video'],
-): DisplayMediaStreamOptions {
+): ScreenShareDisplayMediaOptions {
     return {
         video,
+        systemAudio: 'include',
         audio: {
             // Keep the active call audible while the native/macOS share picker changes focus.
             suppressLocalAudioPlayback: false,
@@ -112,8 +117,10 @@ export function toScreenShareCaptureDiagnostics(
     videoTrack: MediaStreamTrack,
     audioCaptured: boolean,
     constraintsApplied: boolean,
+    audioTrack?: MediaStreamTrack,
 ): ScreenShareCaptureDiagnostics {
     const settings = videoTrack.getSettings?.() ?? {}
+    const audioSettings = audioTrack?.getSettings?.() ?? {}
     const requested = toScreenShareConstraintsForProfile(profile)
     const requestedWidth = requested.width as { ideal?: number } | undefined
     const requestedHeight = requested.height as { ideal?: number } | undefined
@@ -128,6 +135,11 @@ export function toScreenShareCaptureDiagnostics(
         displaySurface: settings.displaySurface,
         constraintsApplied,
         audioCaptured,
+        ...(audioTrack ? {
+            audioSampleRate: finiteSetting(audioSettings.sampleRate),
+            audioChannelCount: finiteSetting(audioSettings.channelCount),
+            audioContentHint: audioTrack.contentHint === 'music' ? 'music' as const : undefined,
+        } : {}),
         videoPublished: false,
         audioPublished: false,
         simulcast: true,
@@ -277,14 +289,19 @@ export function useLocalMedia() {
         if (cached) {
             const video = cached.getVideoTracks()[0]
             if (video?.readyState === 'live') {
+                const audio = cached.getAudioTracks().find((track) => track.readyState === 'live')
+                if (audio && 'contentHint' in audio) {
+                    try { audio.contentHint = 'music' } catch { /* ignore */ }
+                }
                 const profile = resolveScreenShareProfile(video.getSettings?.().displaySurface)
                 return {
                     stream: cached,
                     diagnostics: toScreenShareCaptureDiagnostics(
                         profile,
                         video,
-                        cached.getAudioTracks().some((track) => track.readyState === 'live'),
+                        !!audio,
                         true,
+                        audio,
                     ),
                 }
             }
@@ -302,11 +319,16 @@ export function useLocalMedia() {
                 throw new Error('No screen video track was captured')
             }
             const { profile, constraintsApplied } = await applyScreenShareTrackProfile(videoTrack)
+            const audioTrack = stream.getAudioTracks().find((track) => track.readyState === 'live')
+            if (audioTrack && 'contentHint' in audioTrack) {
+                try { audioTrack.contentHint = 'music' } catch { /* ignore */ }
+            }
             const diagnostics = toScreenShareCaptureDiagnostics(
                 profile,
                 videoTrack,
-                stream.getAudioTracks().some((track) => track.readyState === 'live'),
+                !!audioTrack,
                 constraintsApplied,
+                audioTrack,
             )
             cachedScreenStreamRef.current = stream
             window.dispatchEvent(new Event(SCREEN_SHARE_CAPTURE_READY_EVENT))

--- a/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.test.ts
+++ b/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { extractScreenShareOutboundSample } from './useWebrtcDiagnostics'
+import {
+  extractScreenShareAudioOutboundSample,
+  extractScreenShareOutboundSample,
+} from './useWebrtcDiagnostics'
 
 describe('screen share outbound diagnostics', () => {
   it('aggregates simulcast layers for the active screen track only', () => {
@@ -68,5 +71,61 @@ describe('screen share outbound diagnostics', () => {
         trackIdentifier: 'camera-track',
       } as RTCStats,
     ], 'screen-track')).toBeNull()
+  })
+})
+
+describe('screen share audio outbound diagnostics', () => {
+  it('reports the active screen audio codec and transport counters', () => {
+    const reports = [
+      {
+        id: 'source-screen-audio',
+        type: 'media-source',
+        timestamp: 2_000,
+        trackIdentifier: 'screen-audio-track',
+      },
+      {
+        id: 'codec-opus',
+        type: 'codec',
+        timestamp: 2_000,
+        mimeType: 'audio/opus',
+        channels: 2,
+      },
+      {
+        id: 'screen-audio-outbound',
+        type: 'outbound-rtp',
+        timestamp: 2_000,
+        kind: 'audio',
+        mediaSourceId: 'source-screen-audio',
+        codecId: 'codec-opus',
+        bytesSent: 24_000,
+        packetsSent: 120,
+      },
+      {
+        id: 'screen-audio-remote-inbound',
+        type: 'remote-inbound-rtp',
+        timestamp: 2_000,
+        localId: 'screen-audio-outbound',
+        packetsLost: 2,
+      },
+    ] as unknown as RTCStats[]
+
+    expect(extractScreenShareAudioOutboundSample(reports, 'screen-audio-track')).toEqual({
+      packetsSent: 120,
+      packetsLost: 2,
+      codec: 'audio/opus',
+      channels: 2,
+      bytesSent: 24_000,
+      timestamp: 2_000,
+    })
+  })
+
+  it('does not confuse microphone output with screen-share audio', () => {
+    expect(extractScreenShareAudioOutboundSample([{
+      id: 'microphone',
+      type: 'outbound-rtp',
+      timestamp: 1_000,
+      kind: 'audio',
+      trackIdentifier: 'microphone-track',
+    } as RTCStats], 'screen-audio-track')).toBeNull()
   })
 })

--- a/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.ts
+++ b/apps/web/src/webrtc/hooks/useWebrtcDiagnostics.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Room, Track } from 'livekit-client'
 import {
     updateVoiceDiagnostics,
+    type ScreenShareAudioOutboundDiagnostics,
     type ScreenShareOutboundDiagnostics,
 } from '../voiceDiagnostics'
 
@@ -14,6 +15,11 @@ const WS_PING_INTERVAL_MS = 2500
 type PingSource = 'rtc' | 'ws' | null
 
 export interface ScreenShareOutboundSample extends ScreenShareOutboundDiagnostics {
+    bytesSent?: number
+    timestamp?: number
+}
+
+export interface ScreenShareAudioOutboundSample extends ScreenShareAudioOutboundDiagnostics {
     bytesSent?: number
     timestamp?: number
 }
@@ -94,6 +100,51 @@ export function extractScreenShareOutboundSample(
     }
 }
 
+export function extractScreenShareAudioOutboundSample(
+    reports: RTCStats[],
+    trackIdentifier: string,
+): ScreenShareAudioOutboundSample | null {
+    const byId = new Map(reports.map((report) => [report.id, report]))
+    for (const report of reports) {
+        if (report.type !== 'outbound-rtp') continue
+        const outbound = report as RTCOutboundRtpStreamStats & {
+            mediaType?: string
+            mediaSourceId?: string
+            trackId?: string
+            trackIdentifier?: string
+            codecId?: string
+            isRemote?: boolean
+        }
+        if ((outbound.kind ?? outbound.mediaType) !== 'audio' || outbound.isRemote) continue
+
+        const source = outbound.mediaSourceId ? byId.get(outbound.mediaSourceId) : undefined
+        const legacyTrack = outbound.trackId ? byId.get(outbound.trackId) : undefined
+        const sourceIdentifier = String(
+            outbound.trackIdentifier
+            ?? (source as (RTCStats & { trackIdentifier?: string }) | undefined)?.trackIdentifier
+            ?? (legacyTrack as (RTCStats & { trackIdentifier?: string }) | undefined)?.trackIdentifier
+            ?? '',
+        )
+        if (sourceIdentifier !== trackIdentifier) continue
+
+        const codec = outbound.codecId ? byId.get(outbound.codecId) : undefined
+        const remoteInbound = reports.find((candidate) => (
+            candidate.type === 'remote-inbound-rtp'
+            && (candidate as RTCStats & { localId?: string }).localId === outbound.id
+        )) as (RTCStats & { packetsLost?: number }) | undefined
+
+        return {
+            packetsSent: finiteNumber(outbound.packetsSent),
+            packetsLost: finiteNumber(remoteInbound?.packetsLost),
+            codec: (codec as (RTCStats & { mimeType?: string }) | undefined)?.mimeType,
+            channels: finiteNumber((codec as (RTCStats & { channels?: number }) | undefined)?.channels),
+            bytesSent: finiteNumber(outbound.bytesSent),
+            timestamp: finiteNumber(outbound.timestamp),
+        }
+    }
+    return null
+}
+
 const clamp = (value: number, min: number, max: number) =>
     Math.min(max, Math.max(min, value))
 
@@ -170,6 +221,7 @@ export function useWebrtcDiagnostics(options: {
     const selectedPingSourceRef = useRef<PingSource>(null)
     const prevInboundTotalsRef = useRef<InboundTotals | null>(null)
     const previousScreenShareOutboundRef = useRef<ScreenShareOutboundSample | null>(null)
+    const previousScreenShareAudioOutboundRef = useRef<ScreenShareAudioOutboundSample | null>(null)
 
     // WS ping/pong — kept as fallback while RTC path is unavailable.
     useEffect(() => {
@@ -310,6 +362,45 @@ export function useWebrtcDiagnostics(options: {
                         }
                     } else {
                         previousScreenShareOutboundRef.current = null
+                    }
+
+                    const screenAudioPublication = room.localParticipant.getTrackPublication(Track.Source.ScreenShareAudio)
+                    const screenAudioTrackIdentifier = screenAudioPublication?.track?.mediaStreamTrack.id
+                    if (screenAudioTrackIdentifier) {
+                        const sample = extractScreenShareAudioOutboundSample(
+                            Array.from(stats.values()),
+                            screenAudioTrackIdentifier,
+                        )
+                        if (sample) {
+                            const previous = previousScreenShareAudioOutboundRef.current
+                            let bitrateKbps: number | undefined
+                            if (
+                                previous?.bytesSent != null
+                                && previous.timestamp != null
+                                && sample.bytesSent != null
+                                && sample.timestamp != null
+                                && sample.timestamp > previous.timestamp
+                                && sample.bytesSent >= previous.bytesSent
+                            ) {
+                                bitrateKbps = Math.round(
+                                    ((sample.bytesSent - previous.bytesSent) * 8)
+                                    / (sample.timestamp - previous.timestamp),
+                                )
+                            }
+                            previousScreenShareAudioOutboundRef.current = sample
+                            updateVoiceDiagnostics({
+                                screenShareAudioOutbound: {
+                                    bitrateKbps,
+                                    packetsSent: sample.packetsSent,
+                                    packetsLost: sample.packetsLost,
+                                    codec: sample.codec,
+                                    channels: sample.channels,
+                                },
+                            })
+                        }
+                    } else {
+                        previousScreenShareAudioOutboundRef.current = null
+                        updateVoiceDiagnostics({ screenShareAudioOutbound: undefined })
                     }
 
                     // Transport-selected candidate pair (Chromium/WebKit).

--- a/apps/web/src/webrtc/remotePlaybackVolume.test.ts
+++ b/apps/web/src/webrtc/remotePlaybackVolume.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeRemotePlaybackVolume,
+  parseRemotePlaybackVolumes,
+  readRemotePlaybackVolumes,
+  REMOTE_PLAYBACK_VOLUME_STORAGE_KEY,
+  writeRemotePlaybackVolumes,
+} from './remotePlaybackVolume'
+
+describe('remote playback volume', () => {
+  it('keeps playback in the distortion-safe media element range', () => {
+    expect(normalizeRemotePlaybackVolume(-20)).toBe(0)
+    expect(normalizeRemotePlaybackVolume(65.6)).toBe(66)
+    expect(normalizeRemotePlaybackVolume(100)).toBe(100)
+    expect(normalizeRemotePlaybackVolume(200)).toBe(100)
+  })
+
+  it('sanitizes saved peer and screen-share volumes', () => {
+    expect(parseRemotePlaybackVolumes(JSON.stringify({
+      peer: 150,
+      'screen:peer': 80,
+      invalid: 'loud',
+    }))).toEqual({
+      peer: 100,
+      'screen:peer': 80,
+    })
+  })
+
+  it('migrates legacy amplified values in storage', () => {
+    const storage = window.localStorage
+    storage.clear()
+    storage.setItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY, JSON.stringify({ peer: 200 }))
+
+    expect(readRemotePlaybackVolumes(storage)).toEqual({ peer: 100 })
+    expect(storage.getItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY)).toBe('{"peer":100}')
+
+    expect(writeRemotePlaybackVolumes({ peer: 125, 'screen:peer': 40 }, storage)).toEqual({
+      peer: 100,
+      'screen:peer': 40,
+    })
+  })
+})

--- a/apps/web/src/webrtc/remotePlaybackVolume.ts
+++ b/apps/web/src/webrtc/remotePlaybackVolume.ts
@@ -1,0 +1,49 @@
+export const REMOTE_PLAYBACK_VOLUME_STORAGE_KEY = 'voxpery-voice-peer-volume'
+export const REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT = 'voxpery-voice-peer-volume-changed'
+export const DEFAULT_REMOTE_PLAYBACK_VOLUME = 100
+export const MAX_REMOTE_PLAYBACK_VOLUME = 100
+
+export function normalizeRemotePlaybackVolume(
+  value: unknown,
+  fallback = DEFAULT_REMOTE_PLAYBACK_VOLUME,
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(MAX_REMOTE_PLAYBACK_VOLUME, Math.max(0, Math.round(value)))
+}
+
+export function parseRemotePlaybackVolumes(raw: string | null): Record<string, number> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+
+    const volumes: Record<string, number> = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) continue
+      volumes[key] = normalizeRemotePlaybackVolume(value)
+    }
+    return volumes
+  } catch {
+    return {}
+  }
+}
+
+export function readRemotePlaybackVolumes(storage: Storage = localStorage): Record<string, number> {
+  const raw = storage.getItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY)
+  const volumes = parseRemotePlaybackVolumes(raw)
+  if (raw && raw !== JSON.stringify(volumes)) {
+    storage.setItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY, JSON.stringify(volumes))
+  }
+  return volumes
+}
+
+export function writeRemotePlaybackVolumes(
+  volumes: Record<string, number>,
+  storage: Storage = localStorage,
+): Record<string, number> {
+  const normalized = Object.fromEntries(
+    Object.entries(volumes).map(([key, value]) => [key, normalizeRemotePlaybackVolume(value)]),
+  )
+  storage.setItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY, JSON.stringify(normalized))
+  return normalized
+}

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -3,6 +3,7 @@ import {
   clearRemoteMediaStartCue,
   getMicrophonePublishOptions,
   getPreferredScreenShareCodec,
+  getScreenShareAudioPublishOptions,
   getScreenSharePublishOptions,
   reconcileFinalMediaDisconnect,
   remoteMediaKindForSource,
@@ -24,6 +25,18 @@ describe('microphone publish options', () => {
       dtx: true,
       red: true,
       forceStereo: false,
+    })
+  })
+})
+
+describe('screen-share audio publish options', () => {
+  it('preserves continuous system audio as high-quality stereo', () => {
+    expect(getScreenShareAudioPublishOptions()).toMatchObject({
+      source: Track.Source.ScreenShareAudio,
+      audioPreset: AudioPresets.musicHighQualityStereo,
+      dtx: false,
+      red: false,
+      forceStereo: true,
     })
   })
 })

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -59,6 +59,16 @@ export function getMicrophonePublishOptions(): TrackPublishOptions {
   }
 }
 
+export function getScreenShareAudioPublishOptions(): TrackPublishOptions {
+  return {
+    source: Track.Source.ScreenShareAudio,
+    audioPreset: AudioPresets.musicHighQualityStereo,
+    dtx: false,
+    red: false,
+    forceStereo: true,
+  }
+}
+
 type ScreenShareEncoding = {
   maxBitrate: number
   maxFramerate: number
@@ -1134,6 +1144,13 @@ export function useLiveKitVoice() {
 
     const capture: ScreenShareCaptureResult = await getScreenStream()
     const { stream, diagnostics } = capture
+    const screenShareAudioDiagnostics = diagnostics.audioCaptured ? {
+      audioPreset: 'musicHighQualityStereo' as const,
+      audioMaxBitrateKbps: 128 as const,
+      audioDtx: false as const,
+      audioRed: false as const,
+      audioForceStereo: true as const,
+    } : {}
     const tracks = stream.getTracks()
     localScreenTracksRef.current = tracks
     const publishedTracks: MediaStreamTrack[] = []
@@ -1145,14 +1162,16 @@ export function useLiveKitVoice() {
 
     try {
       for (const track of tracks) {
-        const source = track.kind === 'audio' ? Track.Source.ScreenShareAudio : Track.Source.ScreenShare
         const screenVideo = track.kind === 'video' ? getScreenShareEncoding(track) : undefined
         if (track.kind === 'video' && screenVideo && 'contentHint' in track) {
           try { track.contentHint = screenVideo.contentHint } catch { /* ignore */ }
         }
+        if (track.kind === 'audio' && 'contentHint' in track) {
+          try { track.contentHint = 'music' } catch { /* ignore */ }
+        }
         const options: TrackPublishOptions = screenVideo
           ? getScreenSharePublishOptions(screenVideo)
-          : { source }
+          : getScreenShareAudioPublishOptions()
         if (track.kind === 'video') {
           publishedCodec = options.videoCodec
           publishedScalabilityMode = options.scalabilityMode
@@ -1175,6 +1194,7 @@ export function useLiveKitVoice() {
       updateVoiceDiagnostics({
         screenShare: {
           ...diagnostics,
+          ...screenShareAudioDiagnostics,
           videoPublished: false,
           audioPublished: false,
           simulcast: publishedWithSimulcast,
@@ -1189,6 +1209,7 @@ export function useLiveKitVoice() {
     updateVoiceDiagnostics({
       screenShare: {
         ...diagnostics,
+        ...screenShareAudioDiagnostics,
         videoPublished,
         audioPublished,
         simulcast: publishedWithSimulcast,

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -76,8 +76,16 @@ export interface ScreenShareCaptureDiagnostics {
   displaySurface?: string
   constraintsApplied?: boolean
   audioCaptured?: boolean
+  audioSampleRate?: number
+  audioChannelCount?: number
+  audioContentHint?: 'music'
   videoPublished?: boolean
   audioPublished?: boolean
+  audioPreset?: 'musicHighQualityStereo'
+  audioMaxBitrateKbps?: 128
+  audioDtx?: false
+  audioRed?: false
+  audioForceStereo?: true
   simulcast?: boolean
   codec?: string
   scalabilityMode?: string
@@ -91,6 +99,14 @@ export interface ScreenShareOutboundDiagnostics {
   packetsSent?: number
   packetsLost?: number
   qualityLimitationReason?: string
+}
+
+export interface ScreenShareAudioOutboundDiagnostics {
+  bitrateKbps?: number
+  packetsSent?: number
+  packetsLost?: number
+  codec?: string
+  channels?: number
 }
 
 export interface VoiceRuntimeDiagnostics {
@@ -116,6 +132,7 @@ export interface VoiceRuntimeDiagnostics {
   livekit?: VoiceLivekitDiagnostics
   screenShare?: ScreenShareCaptureDiagnostics
   screenShareOutbound?: ScreenShareOutboundDiagnostics
+  screenShareAudioOutbound?: ScreenShareAudioOutboundDiagnostics
   updatedAt?: string
 }
 

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -55,8 +55,9 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] Resizing and fullscreening User B's remote share tile upgrades the received adaptive layer without restarting the share.
 - [ ] User A starts screen share; User B sees the screen tile.
 - [ ] Sharing a supported browser tab/system-audio source publishes both `ScreenShare` and `ScreenShareAudio`; User B hears the shared audio independently from User A's microphone.
+- [ ] Shared system, game, and music audio remains stereo and continuous without speech-style gating; diagnostics report `musicHighQualityStereo`, 128 kbps, `forceStereo: true`, and `dtx: false`.
 - [ ] Sharing a source/platform that provides no audio still publishes video and shows User A one non-fatal `Sharing without audio` notice.
-- [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio capture/publication, simulcast, outbound bitrate/FPS, packet loss, and quality limitation reason are present without device identifiers.
+- [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio sample rate/channel count/content hint/publication profile, simulcast, outbound video bitrate/FPS, actual screen-audio Opus bitrate/channels/packets, packet loss, and quality limitation reason are present without device identifiers.
 - [ ] Under constrained bandwidth, screen share remains watchable by stepping down to a lower simulcast layer instead of freezing on a single high-quality layer.
 - [ ] On a clean macOS install, starting screen share prompts for Screen & System Audio Recording access and Voxpery appears in that Privacy & Security list.
 - [ ] On macOS, opening and closing the native share picker does not lower remote microphone audio; the same level continues without clicking Voxpery again.
@@ -66,6 +67,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] While hidden by User B, the remote screen video and screen-share audio publications are unsubscribed; selecting `Show` restores them without replaying the start cue.
 - [ ] User A's normal microphone audio continues while the screen share is hidden.
 - [ ] User B mutes or lowers the screen-share volume; only screen-share audio changes and User A's normal microphone audio remains audible.
+- [ ] Per-user microphone and screen-share volume controls stay within 0-100%; repeated mute/unmute and 0/100 transitions do not cut out, clip, or change the selected output device.
 - [ ] User B shows the screen share again and audio behavior returns with the visible media.
 - [ ] Minimizing or hiding User B's Voxpery window pauses incoming camera/screen video traffic while microphone and screen-share audio continue; restoring the window resumes video without replaying start cues.
 - [ ] User A stops screen share; User B hears the screen-stop cue once.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -177,15 +177,15 @@ LiveKit RemoteTrack
     |
 MediaStream
     |
-<audio> element (volume 0.0-1.0) + GainNode (> 100%)
+<audio> element (volume 0.0-1.0)
     |
 AudioContext analyser (speaking indicator)
     |
 Speaker
 ```
 
-- **Output volume**: Global 1-100%, per-peer microphone 0-200%, and per-screen-share audio 0-200%
-- **Amplification >100%**: Routed through WebAudio GainNode (gain > 1.0)
+- **Output volume**: Global 1-100%, per-peer microphone 0-100%, and per-screen-share audio 0-100%.
+- **Distortion-safe playback**: Remote media stays on the native media-element path. Legacy values above 100% are migrated to 100% so playback is not clipped or stranded on a closed Web Audio graph.
 - **Deafen**: Sets `audio.muted = true` on all remote elements
 - **Hide screen share**: Hiding a remote screen share suppresses its tile and screen-share audio locally while keeping both the LiveKit subscription and the peer's normal microphone audio active.
 - **Pre-join media presence**: Server members can see a camera icon and `LIVE` screen-share badge beside voice participants before joining the channel. These indicators use the server-broadcast voice control state and do not subscribe the viewer to media.
@@ -215,6 +215,7 @@ Speaker
 ```typescript
 const stream = await navigator.mediaDevices.getDisplayMedia({
   video: { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 60, max: 60 } },
+  systemAudio: 'include',
   audio: { suppressLocalAudioPlayback: false }  // Shared audio without ducking the active call
 })
 await room.localParticipant.publishTrack(videoTrack, {
@@ -227,6 +228,14 @@ await room.localParticipant.publishTrack(videoTrack, {
     ? undefined
     : [screenShare360p30, screenShare720p60]
 })
+audioTrack.contentHint = 'music'
+await room.localParticipant.publishTrack(audioTrack, {
+  source: Track.Source.ScreenShareAudio,
+  audioPreset: AudioPresets.musicHighQualityStereo, // 128 kbps Opus
+  forceStereo: true,
+  dtx: false,
+  red: false,
+})
 ```
 
 Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast with 360p30 and 720p60 intermediate layers. Remote LiveKit video tracks are rendered through `RemoteVideoTrack.attach()` so adaptive stream can select a layer from the element's actual dimensions and visibility. Incompatible runtimes retain the VP8 path.
@@ -237,10 +246,11 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - **Presentation/window share**: `contentHint = 'detail'` at 1080p30 and `maintain-resolution` degradation to preserve text sharpness while limiting traffic.
 - **Browser tab/video and Auto monitor share**: `contentHint = 'motion'` at 1080p60 with an 8 Mbps cap and `maintain-framerate` degradation.
 - **Gaming share**: Explicit 1080p60 high-motion mode with a 12 Mbps cap for users who prefer quality over bandwidth.
+- **Screen-share audio**: `contentHint = 'music'`, stereo 128 kbps Opus, and continuous transmission (`dtx = false`) preserve system, game, and music audio independently from the mono speech microphone profile.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
 - A share is not published without a live video track. If the selected platform/source does not provide a system or tab audio track, video sharing continues and the sender receives a non-fatal `Sharing without audio` notice with source-picker guidance.
 - Publishing is rollback-safe: if any selected screen track fails to publish, already-published tracks from that attempt are unpublished and the local capture is stopped.
-- Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio capture/publication, codec/scalability mode, simulcast state, and outbound resolution/FPS/bitrate/packet/quality-limitation samples without device identifiers.
+- Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio sample rate/channel count/content hint/publish profile, codec/scalability mode, simulcast state, outbound video resolution/FPS/bitrate/packet/quality-limitation samples, and actual screen-audio Opus bitrate/channel/packet samples without device identifiers.
 
 ### Remote Viewing Controls
 
@@ -251,7 +261,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - Hiding a screen share locally suppresses both its video and screen-share audio playback; the participant's microphone audio continues normally.
 - The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
 - When the Voxpery window is hidden or minimized, remote video subscriptions pause while microphone and screen-share audio continue. Video subscriptions resume when the app becomes visible, without replaying media-start cues.
-- Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, WebAudio state, and remote playback without changing per-user volume settings.
+- Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, and remote playback without changing per-user volume settings.
 
 ### Voice Event Cues
 
@@ -318,7 +328,7 @@ When debugging a production voice report, capture:
 
 1. The call bar ping color and visible ping.
 2. Whether the room was connected, connecting, or reconnecting.
-3. Enable temporary diagnostics with `localStorage.setItem("voxperyVoiceDiagnostics", "1")`, reload, then inspect `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active. During screen share, `screenShare` and `screenShareOutbound` show actual capture/publish quality and network limitation signals.
+3. Enable temporary diagnostics with `localStorage.setItem("voxperyVoiceDiagnostics", "1")`, reload, then inspect `window.__VOXPERY_VOICE_DIAGNOSTICS__` from DevTools after joining voice; it should show `rnnoiseStatus: "ready"`, the active profile, suppression tuning, and whether aggressive isolation is active. During screen share, `screenShare` shows audio sample rate/channel count and the stereo music publish profile, `screenShareOutbound` shows actual video quality, and `screenShareAudioOutbound` shows actual Opus bitrate/channel/packet signals.
 4. Whether the user recently changed microphone, camera, VPN, firewall, or network.
 
 ### Voice cues


### PR DESCRIPTION
## Summary

- publish screen-share audio with a continuous high-quality stereo Opus profile
- request supported system audio and mark shared audio as music content
- remove the unstable Web Audio amplification path
- limit remote microphone and screen-share playback to 0-100%
- migrate legacy volume values above 100%
- add screen-share audio codec, bitrate, channel, and packet diagnostics
- update voice documentation and release smoke coverage

## Validation

- `npm run lint`
- `npm run test:run` — 253 passed
- `npm run build`
- `npm run test:e2e:ui-smoke` — 39 passed