### PR TITLE
fix: anchor DM notification navigation

### DIFF
--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -467,6 +467,30 @@ describe('ChatArea regressions', () => {
     expect(screen.getByRole('button', { name: 'Jump to latest messages' })).toBeInTheDocument()
   })
 
+  it('handles a notification jump only after the target row is visible', async () => {
+    const handled = vi.fn()
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      if (this.classList.contains('chat-messages')) {
+        return { top: 0, bottom: 360, left: 0, right: 800, width: 800, height: 360, x: 0, y: 0, toJSON: () => ({}) }
+      }
+      if (this.dataset.messageId === 'message-2') {
+        return { top: 40, bottom: 100, left: 0, right: 800, width: 800, height: 60, x: 0, y: 40, toJSON: () => ({}) }
+      }
+      return { top: 400, bottom: 460, left: 0, right: 800, width: 800, height: 60, x: 0, y: 400, toJSON: () => ({}) }
+    })
+
+    renderChatArea({
+      jumpToMessageId: 'message-2',
+      onJumpToMessageHandled: handled,
+    })
+
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith(1, { align: 'start', behavior: 'auto' })
+      expect(handled).toHaveBeenCalledTimes(1)
+    })
+    rectSpy.mockRestore()
+  })
+
   it('keeps the unread divider anchored to the original remote message', async () => {
     const localMessage = {
       ...message('message-local', 'my new message', 2),

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -1346,10 +1346,10 @@ export default function ChatArea({
         return isMessageGroupedAt(messages, index, firstUnreadIndex)
     }
 
-    const scrollToMessageId = useCallback((messageId: string) => {
+    const scrollToMessageId = useCallback((messageId: string, behavior: ScrollBehavior = 'smooth') => {
         const index = messages.findIndex((m) => m.id === messageId)
         if (index >= 0) {
-            rowVirtualizer.scrollToIndex(index, { align: 'start', behavior: 'smooth' })
+            rowVirtualizer.scrollToIndex(index, { align: 'start', behavior })
             if (highlightTimeoutRef.current) clearTimeout(highlightTimeoutRef.current)
             setHighlightedMessageId(messageId)
             highlightTimeoutRef.current = setTimeout(() => {
@@ -1364,16 +1364,39 @@ export default function ChatArea({
         if (highlightTimeoutRef.current) clearTimeout(highlightTimeoutRef.current)
     }, [])
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (!jumpToMessageId || messages.length === 0) return
         const exists = messages.some((message) => message.id === jumpToMessageId)
         if (!exists) return
         shouldAutoScrollRef.current = false
-        scrollToMessageId(jumpToMessageId)
-        requestAnimationFrame(() => {
-            syncAutoScrollState()
-        })
-        onJumpToMessageHandled?.()
+        scrollToMessageId(jumpToMessageId, 'auto')
+        let cancelled = false
+        let attempts = 0
+        const confirmVisible = () => {
+            if (cancelled) return
+            const scroller = messagesScrollRef.current
+            const row = scroller
+                ? Array.from(scroller.querySelectorAll<HTMLElement>('[data-message-id]'))
+                    .find((candidate) => candidate.dataset.messageId === jumpToMessageId)
+                : null
+            if (scroller && row) {
+                const scrollerRect = scroller.getBoundingClientRect()
+                const rowRect = row.getBoundingClientRect()
+                if (rowRect.bottom > scrollerRect.top && rowRect.top < scrollerRect.bottom) {
+                    syncAutoScrollState()
+                    onJumpToMessageHandled?.()
+                    return
+                }
+            }
+            attempts += 1
+            if (attempts >= 12) return
+            scrollToMessageId(jumpToMessageId, 'auto')
+            requestAnimationFrame(confirmVisible)
+        }
+        requestAnimationFrame(confirmVisible)
+        return () => {
+            cancelled = true
+        }
     }, [jumpToMessageId, messages, onJumpToMessageHandled, scrollToMessageId, syncAutoScrollState])
 
     const closeMentionMenu = () => {

--- a/apps/web/src/dmNotificationNavigation.ts
+++ b/apps/web/src/dmNotificationNavigation.ts
@@ -1,0 +1,19 @@
+export type DmNotificationAnchor = {
+  channelId: string
+  messageId: string | null
+  notificationId: string
+}
+
+export type DmNotificationLocationState = {
+  dmNotificationAnchor?: DmNotificationAnchor
+}
+
+export function readDmNotificationAnchor(state: unknown): DmNotificationAnchor | null {
+  if (!state || typeof state !== 'object') return null
+  const candidate = (state as DmNotificationLocationState).dmNotificationAnchor
+  if (!candidate || typeof candidate !== 'object') return null
+  if (typeof candidate.channelId !== 'string' || !candidate.channelId) return null
+  if (candidate.messageId !== null && typeof candidate.messageId !== 'string') return null
+  if (typeof candidate.notificationId !== 'string' || !candidate.notificationId) return null
+  return candidate
+}

--- a/apps/web/src/pages/AppShell.test.tsx
+++ b/apps/web/src/pages/AppShell.test.tsx
@@ -1,5 +1,5 @@
-import { act, render, waitFor } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DmChannel, Friend, User } from '../api'
 import { useAppStore } from '../stores/app'
@@ -11,6 +11,12 @@ const apiMocks = vi.hoisted(() => ({
   createWebSocket: vi.fn(),
   listDmChannels: vi.fn(),
   listFriends: vi.fn(),
+}))
+
+const pushMocks = vi.hoisted(() => ({
+  isAppBackgrounded: vi.fn(() => false),
+  shouldShowPushNotification: vi.fn(() => false),
+  showPushNotification: vi.fn(),
 }))
 
 vi.mock('../api', () => ({
@@ -46,8 +52,9 @@ vi.mock('../notificationSound', () => ({
 }))
 
 vi.mock('../pushNotifications', () => ({
-  shouldShowPushNotification: vi.fn(() => false),
-  showPushNotification: vi.fn(),
+  isAppBackgrounded: pushMocks.isAppBackgrounded,
+  shouldShowPushNotification: pushMocks.shouldShowPushNotification,
+  showPushNotification: pushMocks.showPushNotification,
 }))
 
 vi.mock('../secureStorage', () => ({
@@ -92,12 +99,18 @@ function friend(id: string, username: string): Friend {
   }
 }
 
-function renderAppShell() {
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="shell-child" data-location-state={JSON.stringify(location.state)} />
+}
+
+function renderAppShell(initialEntry = '/channels/@me') {
   return render(
-    <MemoryRouter initialEntries={['/channels/@me']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route element={<AppShell />}>
-          <Route path="/channels/@me" element={<div data-testid="shell-child" />} />
+          <Route path="/channels/@me" element={<LocationProbe />} />
+          <Route path="/social/dm" element={<LocationProbe />} />
         </Route>
       </Routes>
     </MemoryRouter>,
@@ -120,6 +133,8 @@ describe('AppShell social refresh', () => {
     })
     apiMocks.listDmChannels.mockResolvedValue([dmChannel('dm-1')])
     apiMocks.listFriends.mockResolvedValue([friend('friend-1', 'friend')])
+    pushMocks.isAppBackgrounded.mockReturnValue(false)
+    pushMocks.shouldShowPushNotification.mockReturnValue(false)
 
     useAuthStore.setState({
       token: 'token',
@@ -185,5 +200,65 @@ describe('AppShell social refresh', () => {
       expect(apiMocks.listDmChannels).toHaveBeenCalledTimes(3)
       expect(apiMocks.listFriends).toHaveBeenCalledTimes(3)
     })
+  })
+
+  it('keeps a background DM unread until its notification target is opened', async () => {
+    const channel = dmChannel('dm-1')
+    sessionStorage.setItem('voxpery-social-view', 'dm')
+    useAppStore.setState({
+      activeDmChannelId: channel.id,
+      dmChannels: [channel],
+      dmChannelIds: [channel.id],
+      dmUnread: { [channel.id]: 0 },
+      socialDataReady: true,
+    })
+    pushMocks.isAppBackgrounded.mockReturnValue(true)
+    pushMocks.shouldShowPushNotification.mockReturnValue(true)
+
+    renderAppShell('/social/dm')
+
+    await waitFor(() => {
+      expect(apiMocks.listDmChannels).toHaveBeenCalled()
+      expect(useAppStore.getState().socialDataReady).toBe(true)
+    })
+
+    act(() => {
+      useSocketStore.getState().listeners.forEach((listener) => {
+        listener({
+          type: 'NewMessage',
+          data: {
+            channel_id: channel.id,
+            channel_type: 'dm',
+            message: {
+              id: 'message-notification',
+              created_at: '2026-08-14T12:00:00.000Z',
+              author: { user_id: 'friend-1', username: 'friend' },
+            },
+          },
+        })
+      })
+    })
+
+    await waitFor(() => {
+      expect(pushMocks.showPushNotification).toHaveBeenCalledTimes(1)
+      expect(useAppStore.getState().dmUnread[channel.id]).toBe(1)
+    })
+
+    const notification = pushMocks.showPushNotification.mock.calls[0]?.[0] as { onClick?: () => void }
+    act(() => notification.onClick?.())
+
+    await waitFor(() => {
+      expect(screen.getByTestId('shell-child')).toHaveAttribute(
+        'data-location-state',
+        JSON.stringify({
+          dmNotificationAnchor: {
+            channelId: channel.id,
+            messageId: 'message-notification',
+            notificationId: 'message-notification',
+          },
+        }),
+      )
+    })
+    expect(useAppStore.getState().dmUnread[channel.id]).toBe(1)
   })
 })

--- a/apps/web/src/pages/AppShell.tsx
+++ b/apps/web/src/pages/AppShell.tsx
@@ -16,9 +16,11 @@ import { dmApi, friendApi, type DmChannel, type Friend, type User } from '../api
 import { touchDmChannelActivity, upsertDmChannel } from '../friendsList'
 import { playMessageNotificationSound, shouldPlayNotificationSound } from '../notificationSound'
 import {
+  isAppBackgrounded,
   shouldShowPushNotification,
   showPushNotification,
 } from '../pushNotifications'
+import type { DmNotificationLocationState } from '../dmNotificationNavigation'
 import { isSocialDmViewVisible } from '../socialView'
 import { isTauri } from '../secureStorage'
 import {
@@ -435,7 +437,7 @@ export default function AppShell() {
           }
         }
         if (e?.type === 'NewMessage') {
-          const payload = e?.data as { channel_id?: string; channel_type?: string; message?: { created_at?: string; author?: { user_id?: string; username?: string } } }
+          const payload = e?.data as { channel_id?: string; channel_type?: string; message?: { id?: string; created_at?: string; author?: { user_id?: string; username?: string } } }
           const channelId = payload?.channel_id
           const channelType = payload?.channel_type
           const incomingMessage = payload?.message
@@ -497,6 +499,7 @@ export default function AppShell() {
             const canAutoReadActiveDm =
               isSocialWithVisibleDm
               && activeDmChannelId === channel.id
+              && !isAppBackgrounded()
 
             if (canAutoReadActiveDm) {
               clearDmUnread(channel.id)
@@ -517,10 +520,17 @@ export default function AppShell() {
                   body: 'sent you a direct message',
                   tag: `dm:${channel.id}`,
                   onClick: () => {
+                    const messageId = incomingMessage?.id ?? null
+                    const state: DmNotificationLocationState = {
+                      dmNotificationAnchor: {
+                        channelId: channel.id,
+                        messageId,
+                        notificationId: messageId ?? `${channel.id}:${Date.now()}`,
+                      },
+                    }
                     setPersistedSocialView('dm')
                     setActiveDmChannelId(channel.id)
-                    clearDmUnread(channel.id)
-                    navigate(ROUTES.dm)
+                    navigate(ROUTES.dm, { state })
                   },
                 })
               }

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { MemoryRouter, Route, Routes, type InitialEntry } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DmChannel, Friend } from '../api'
 import { ROUTES } from '../routes'
@@ -7,7 +7,7 @@ import { useAppStore } from '../stores/app'
 import { useAuthStore } from '../stores/auth'
 import { useSocketStore } from '../stores/socket'
 import { useToastStore } from '../stores/toast'
-import { clearDmMessageCacheForTests } from '../dmMessageCache'
+import { clearDmMessageCacheForTests, setCachedDmMessages } from '../dmMessageCache'
 import {
   flushMessageDrafts,
   resetMessageDraftCacheForTests,
@@ -75,16 +75,40 @@ vi.mock('../api', () => ({
 }))
 
 vi.mock('../components/ChatArea', () => ({
-  default: ({ loading, messages, messageInput }: { loading?: boolean; messages: unknown[]; messageInput: string }) => (
+  default: ({
+    loading,
+    messages,
+    messageInput,
+    jumpToMessageId,
+    onJumpToMessageHandled,
+  }: {
+    loading?: boolean
+    messages: unknown[]
+    messageInput: string
+    jumpToMessageId?: string | null
+    onJumpToMessageHandled?: () => void
+  }) => (
     <div
       data-testid="dm-chat"
       data-loading={String(!!loading)}
       data-message-count={String(messages.length)}
       data-message-input={messageInput}
+      data-jump-message-id={jumpToMessageId ?? ''}
     >
       DM chat
+      {jumpToMessageId ? (
+        <button type="button" onClick={onJumpToMessageHandled}>Complete notification jump</button>
+      ) : null}
     </div>
   ),
+}))
+
+const backgroundMocks = vi.hoisted(() => ({
+  isAppBackgrounded: vi.fn(() => false),
+}))
+
+vi.mock('../pushNotifications', () => ({
+  isAppBackgrounded: backgroundMocks.isAppBackgrounded,
 }))
 
 function friend(id: string, username: string, status: string): Friend {
@@ -123,9 +147,9 @@ function dmMessage(id: string, channelId: string) {
   }
 }
 
-function renderHomePage() {
+function renderHomePage(initialEntry: InitialEntry = ROUTES.home) {
   return render(
-    <MemoryRouter initialEntries={[ROUTES.home]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path={ROUTES.home} element={<HomePage />} />
         <Route path={ROUTES.dm} element={<HomePage />} />
@@ -173,6 +197,7 @@ describe('HomePage friends list', () => {
     apiMocks.listDmPins.mockResolvedValue([])
     apiMocks.hideDmChannel.mockResolvedValue(undefined)
     apiMocks.updateDmChannelPreferences.mockResolvedValue({ pinned: true })
+    backgroundMocks.isAppBackgrounded.mockReturnValue(false)
   })
 
   it('opens a DM when a friend row is selected', async () => {
@@ -353,6 +378,124 @@ describe('HomePage friends list', () => {
       expect(chat).toHaveAttribute('data-loading', 'false')
       expect(chat).toHaveAttribute('data-message-count', '1')
     })
+  })
+
+  it('waits for refreshed notification history and visible anchor before clearing unread', async () => {
+    const channel = dmChannel('dm-cilo')
+    const cached = dmMessage('message-cached', channel.id)
+    const target = dmMessage('message-notification', channel.id)
+    let resolveMessages!: (messages: ReturnType<typeof dmMessage>[]) => void
+    const pendingMessages = new Promise<ReturnType<typeof dmMessage>[]>((resolve) => {
+      resolveMessages = resolve
+    })
+    setCachedDmMessages('user-1', channel.id, [cached])
+    useAppStore.setState({
+      activeDmChannelId: channel.id,
+      dmChannels: [channel],
+      dmChannelIds: [channel.id],
+      dmUnread: { [channel.id]: 2 },
+      socialDataReady: true,
+    })
+    apiMocks.listDmChannels.mockResolvedValue([channel])
+    apiMocks.listDmMessages.mockReturnValue(pendingMessages)
+
+    renderHomePage({
+      pathname: ROUTES.dm,
+      state: {
+        dmNotificationAnchor: {
+          channelId: channel.id,
+          messageId: target.id,
+          notificationId: target.id,
+        },
+      },
+    })
+
+    const chat = await screen.findByTestId('dm-chat')
+    expect(chat).toHaveAttribute('data-message-count', '1')
+    expect(chat).toHaveAttribute('data-loading', 'true')
+    expect(chat).toHaveAttribute('data-jump-message-id', '')
+    expect(useAppStore.getState().dmUnread[channel.id]).toBe(2)
+    expect(apiMocks.markDmRead).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveMessages([cached, target])
+      await pendingMessages
+    })
+
+    await waitFor(() => {
+      expect(chat).toHaveAttribute('data-jump-message-id', target.id)
+    })
+    expect(useAppStore.getState().dmUnread[channel.id]).toBe(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete notification jump' }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().dmUnread[channel.id]).toBe(0)
+      expect(apiMocks.markDmRead).toHaveBeenCalledWith(channel.id, null)
+    })
+  })
+
+  it('falls back to the refreshed latest message when a notification target is unavailable', async () => {
+    const channel = dmChannel('dm-cilo')
+    const latest = dmMessage('message-latest', channel.id)
+    useAppStore.setState({
+      activeDmChannelId: channel.id,
+      dmChannels: [channel],
+      dmChannelIds: [channel.id],
+      dmUnread: { [channel.id]: 1 },
+      socialDataReady: true,
+    })
+    apiMocks.listDmChannels.mockResolvedValue([channel])
+    apiMocks.listDmMessages.mockResolvedValue([latest])
+
+    renderHomePage({
+      pathname: ROUTES.dm,
+      state: {
+        dmNotificationAnchor: {
+          channelId: channel.id,
+          messageId: 'message-missing',
+          notificationId: 'message-missing',
+        },
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dm-chat')).toHaveAttribute('data-jump-message-id', latest.id)
+    })
+    expect(useAppStore.getState().dmUnread[channel.id]).toBe(1)
+  })
+
+  it('does not mark the active DM read while the app is backgrounded', async () => {
+    const channel = dmChannel('dm-cilo')
+    sessionStorage.setItem('voxpery-social-view', 'dm')
+    useAppStore.setState({
+      activeDmChannelId: channel.id,
+      dmChannels: [channel],
+      dmChannelIds: [channel.id],
+      socialDataReady: true,
+    })
+    apiMocks.listDmChannels.mockResolvedValue([channel])
+    apiMocks.listDmMessages.mockResolvedValue([])
+    backgroundMocks.isAppBackgrounded.mockReturnValue(true)
+
+    renderHomePage(ROUTES.dm)
+    await waitFor(() => expect(apiMocks.listDmMessages).toHaveBeenCalledWith(channel.id, null))
+    useAppStore.setState({ dmUnread: { [channel.id]: 1 } })
+
+    act(() => {
+      useSocketStore.getState().listeners.forEach((listener) => {
+        listener({
+          type: 'NewMessage',
+          data: {
+            channel_id: channel.id,
+            message: dmMessage('message-background', channel.id),
+          },
+        })
+      })
+    })
+
+    expect(useAppStore.getState().dmUnread[channel.id]).toBe(1)
+    expect(apiMocks.markDmRead).not.toHaveBeenCalled()
   })
 
   it('prefetches DM history on hover and reuses the in-flight request on open', async () => {

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -53,6 +53,11 @@ import {
   setCachedDmMessages,
   type CachedDmMessage,
 } from '../dmMessageCache'
+import { isAppBackgrounded } from '../pushNotifications'
+import {
+  readDmNotificationAnchor,
+  type DmNotificationAnchor,
+} from '../dmNotificationNavigation'
 
 function isDmAccessForbidden(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
@@ -151,6 +156,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   )
   const navigate = useNavigate()
   const location = useLocation()
+  const routeDmNotificationAnchor = readDmNotificationAnchor(location.state)
   const isUuid = (s: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s)
 
   const [view, setView] = useState<SocialView>('friends')
@@ -166,6 +172,8 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [openingDmPeerId, setOpeningDmPeerId] = useState<string | null>(null)
   const [updatingDmPreferenceId, setUpdatingDmPreferenceId] = useState<string | null>(null)
   const [dmContextMenu, setDmContextMenu] = useState<{ channelId: string; x: number; y: number } | null>(null)
+  const [pendingDmNotificationAnchor, setPendingDmNotificationAnchor] = useState<DmNotificationAnchor | null>(null)
+  const pendingDmNotificationAnchorRef = useRef<DmNotificationAnchor | null>(null)
   const isMobileSocialSidebarOpen = mobileSidebarPanel === 'social'
   const friends = storeFriends
   const dmChannels = storeDmChannels
@@ -175,6 +183,19 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   useEffect(() => {
     const isSocialRoute = location.pathname === ROUTES.home || location.pathname === ROUTES.dm
     if (!isSocialRoute) return
+    const notificationAnchor = routeDmNotificationAnchor
+    if (notificationAnchor) {
+      const channel = dmChannels.find((candidate) => candidate.id === notificationAnchor.channelId)
+      if (!channel) return
+      pendingDmNotificationAnchorRef.current = notificationAnchor
+      setPendingDmNotificationAnchor(notificationAnchor)
+      setDmSearch('')
+      setActiveDmChannelId(channel.id)
+      setView('dm')
+      setPersistedSocialView('dm')
+      navigate(ROUTES.dm, { replace: true, state: {} })
+      return
+    }
     const openDmUserId = (location.state as { openDmUserId?: string } | null)?.openDmUserId
     if (openDmUserId && dmChannels.length > 0) {
       const channel = isUuid(openDmUserId)
@@ -201,7 +222,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       navigate(ROUTES.home, { replace: true })
     }
     setView('friends')
-  }, [location.pathname, location.state, activeDmChannelId, dmChannels, setActiveDmChannelId, clearDmUnread, navigate])
+  }, [location.pathname, location.state, routeDmNotificationAnchor, activeDmChannelId, dmChannels, setActiveDmChannelId, clearDmUnread, navigate])
 
   const voxperyServer = useMemo(
     () => storeServers.find((s) => s.invite_code === 'voxpery' || s.name === 'Voxpery') ?? null,
@@ -210,6 +231,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const [dmMessages, setDmMessages] = useState<UiDmMessage[]>([])
   const [dmUnreadDividerCount, setDmUnreadDividerCount] = useState(0)
   const [dmConversationReady, setDmConversationReady] = useState(false)
+  const [dmConversationRefreshedChannelId, setDmConversationRefreshedChannelId] = useState<string | null>(null)
   const [dmInput, setDmInput] = useState('')
   const [dmSearch, setDmSearch] = useState('')
   const [dmSearchResults, setDmSearchResults] = useState<MessageWithAuthor[] | null>(null)
@@ -237,6 +259,12 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const pushToast = useToastStore((s) => s.pushToast)
   useEffect(() => { activeDmChannelIdRef.current = activeDmChannelId }, [activeDmChannelId])
   useEffect(() => { isDmConversationVisibleRef.current = isDmConversationVisible }, [isDmConversationVisible])
+  useEffect(() => {
+    const anchor = pendingDmNotificationAnchorRef.current
+    if (!anchor || !activeDmChannelId || anchor.channelId === activeDmChannelId) return
+    pendingDmNotificationAnchorRef.current = null
+    setPendingDmNotificationAnchor(null)
+  }, [activeDmChannelId])
 
   useEffect(() => {
     if (!dmContextMenu) return
@@ -306,7 +334,11 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       setIncomingRequestCount(req.incoming.length)
       setOutgoingRequests(req.outgoing)
       setStoreDmChannels(dms)
-      setDmUnreadFromChannels(dms)
+      const pendingChannelId = pendingDmNotificationAnchorRef.current?.channelId
+      setDmUnreadFromChannels(
+        dms,
+        pendingChannelId ? new Set([pendingChannelId]) : undefined,
+      )
       setDmChannelIds(dms.map((d) => d.id))
       setSocialDataReady(true)
     } finally {
@@ -358,7 +390,9 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     if (!user || !userId) return
     const requestId = ++dmMessagesRequestRef.current
     const cached = cachedDmMessages(channelId)
-    setDmConversationReady(!!cached)
+    const waitsForNotificationAnchor = pendingDmNotificationAnchorRef.current?.channelId === channelId
+    setDmConversationRefreshedChannelId((current) => current === channelId ? null : current)
+    setDmConversationReady(!!cached && !waitsForNotificationAnchor)
     setDmMessages(cached ?? [])
     try {
       const ui = await loadDmMessagesOnce(userId, channelId, () => dmApi.listMessages(channelId, token))
@@ -367,10 +401,12 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       if (requestId === dmMessagesRequestRef.current && activeDmChannelIdRef.current === channelId) {
         setDmMessages(merged)
         setDmConversationReady(true)
+        setDmConversationRefreshedChannelId(channelId)
       }
     } catch (err) {
       if (requestId === dmMessagesRequestRef.current && activeDmChannelIdRef.current === channelId) {
         setDmConversationReady(true)
+        setDmConversationRefreshedChannelId(channelId)
       }
       if (isDmAccessForbidden(err)) {
         if (activeDmChannelIdRef.current === channelId) {
@@ -396,7 +432,10 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
 
     const unreadCount = useAppStore.getState().dmUnread[activeDmChannelId] ?? 0
     setDmUnreadDividerCount(unreadCount > 0 ? unreadCount : 0)
-    clearDmUnread(activeDmChannelId)
+    const notificationAnchor = pendingDmNotificationAnchorRef.current
+    if (notificationAnchor?.channelId !== activeDmChannelId) {
+      clearDmUnread(activeDmChannelId)
+    }
     void refreshActiveDmConversation(activeDmChannelId)
   }, [activeDmChannelId, clearDmUnread, isDmConversationVisible, refreshActiveDmConversation, user])
 
@@ -558,7 +597,9 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         rememberDmMessages(channelId, next)
         return next
       })
-      if (isDmConversationVisibleRef.current) {
+      const notificationAnchor = pendingDmNotificationAnchorRef.current
+      const isWaitingForNotificationAnchor = notificationAnchor?.channelId === channelId
+      if (isDmConversationVisibleRef.current && !isAppBackgrounded() && !isWaitingForNotificationAnchor) {
         clearDmUnread(channelId)
         void dmApi.markRead(channelId, token).catch(() => {
           // Best-effort read sync; the next conversation refresh will reconcile.
@@ -974,6 +1015,31 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   )
 
   const displayedDmMessages = dmSearch.trim() ? (dmSearchResults ?? []) : dmMessages
+
+  const notificationJumpMessageId = useMemo(() => {
+    const anchor = pendingDmNotificationAnchor ?? routeDmNotificationAnchor
+    if (!anchor || anchor.channelId !== activeDmChannelId) return null
+    if (dmConversationRefreshedChannelId !== anchor.channelId || dmSearch.trim()) return null
+    if (anchor.messageId && dmMessages.some((message) => message.id === anchor.messageId)) {
+      return anchor.messageId
+    }
+    return dmMessages.at(-1)?.id ?? null
+  }, [activeDmChannelId, dmConversationRefreshedChannelId, dmMessages, dmSearch, pendingDmNotificationAnchor, routeDmNotificationAnchor])
+
+  const isNotificationHistoryPending =
+    pendingDmNotificationAnchor?.channelId === activeDmChannelId
+    && dmConversationRefreshedChannelId !== activeDmChannelId
+
+  const handleDmNotificationAnchorVisible = useCallback(() => {
+    const anchor = pendingDmNotificationAnchorRef.current
+    if (!anchor || anchor.channelId !== activeDmChannelIdRef.current) return
+    pendingDmNotificationAnchorRef.current = null
+    setPendingDmNotificationAnchor(null)
+    clearDmUnread(anchor.channelId)
+    void dmApi.markRead(anchor.channelId, token).catch(() => {
+      // Best-effort read sync; the next conversation refresh will reconcile.
+    })
+  }, [clearDmUnread, token])
 
   const saveDmEdit = useCallback(async () => {
     if (!user || !editingDmMessageId || !editingDmContent.trim()) return
@@ -1426,7 +1492,11 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
               <ChatArea
                 activeChannel={syntheticChannel}
                 messages={displayedDmMessages}
-                loading={!dmConversationReady && !dmSearch.trim() && displayedDmMessages.length === 0}
+                loading={
+                  !dmSearch.trim()
+                  && (!dmConversationReady || isNotificationHistoryPending)
+                  && (displayedDmMessages.length === 0 || isNotificationHistoryPending)
+                }
                 unreadDividerCount={dmUnreadDividerCount}
                 draftAttachments={dmDraftAttachments}
                 messageInput={dmInput}
@@ -1467,6 +1537,8 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
                 onToggleReaction={handleToggleDmReaction}
                 emptyStateTitle={`Start your conversation with ${dmChannel.peer_username}`}
                 emptyStateDescription="This is the beginning of your direct message history."
+                jumpToMessageId={notificationJumpMessageId}
+                onJumpToMessageHandled={handleDmNotificationAnchorVisible}
               />
             )
           })()}

--- a/apps/web/src/stores/app.test.ts
+++ b/apps/web/src/stores/app.test.ts
@@ -40,4 +40,15 @@ describe('app store DM unread sync', () => {
 
         expect(useAppStore.getState().dmUnread).toEqual({ 'dm-b': 1 })
     })
+
+    it('preserves a notification channel until its visible message anchor is handled', () => {
+        useAppStore.setState({ dmUnread: { 'dm-a': 2 } })
+
+        useAppStore.getState().setDmUnreadFromChannels(
+            [dmChannel('dm-a', 0)],
+            new Set(['dm-a']),
+        )
+
+        expect(useAppStore.getState().dmUnread).toEqual({ 'dm-a': 2 })
+    })
 })

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -48,7 +48,7 @@ interface AppState {
     setDmChannels: (channels: DmChannel[]) => void
     setSocialDataReady: (ready: boolean) => void
     dmUnread: Record<string, number>
-    setDmUnreadFromChannels: (channels: DmChannel[]) => void
+    setDmUnreadFromChannels: (channels: DmChannel[], preserveChannelIds?: ReadonlySet<string>) => void
     incrementDmUnread: (channelId: string) => void
     clearDmUnread: (channelId: string) => void
     serverUnreadByChannel: Record<string, number>
@@ -223,12 +223,13 @@ export const useAppStore = create<AppState>()(
             setDmChannels: (channels) => set((s) => JSON.stringify(s.dmChannels) === JSON.stringify(channels) ? s : { dmChannels: channels }),
             setSocialDataReady: (ready) => set({ socialDataReady: ready }),
             dmUnread: {},
-            setDmUnreadFromChannels: (channels) =>
+            setDmUnreadFromChannels: (channels, preserveChannelIds) =>
                 set((s) => {
                     const next = { ...s.dmUnread }
                     let changed = false
 
                     channels.forEach((channel) => {
+                        if (preserveChannelIds?.has(channel.id)) return
                         const unreadCount = Number.isFinite(channel.unread_count)
                             ? Math.max(0, Math.trunc(channel.unread_count))
                             : 0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Made normal browser reloads revalidate the web app shell, service worker, and stable RNNoise worklet URL so newly deployed releases no longer require a hard refresh, while retaining long-lived caching for fingerprinted assets.
+- Made background DM notifications preserve unread state until the refreshed target message is visibly anchored, with a latest-message fallback when the original target is unavailable.
 
 ## [0.2.6] - 2026-08-09
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -70,7 +70,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] AutoMod rule create/edit/enable/disable/delete works and blocked messages do not persist or broadcast, including blocked keywords split with invisible zero-width/bidi characters.
 - [ ] Raid protection records message bursts, invite spikes, and join burst signals in audit/moderation activity without exposing private secrets.
 - [ ] Category overrides work for `View Channel`, `Send Messages`, `Connect to Voice`.
-- [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop.
+- [ ] Unread badges, per-channel mute, server mention notifications, DM notifications, and friend request notifications behave correctly across refresh, PWA, and desktop; clicking a background DM notification opens and visibly anchors its target (or the refreshed latest message) before clearing unread state.
 - [ ] DM pins persist across refresh/login, pinned conversations stay above activity-sorted unpinned DMs, and a hidden DM returns only after explicit reopen or new message activity.
 - [ ] Channel managers can create channels from the compact header menu, a category `+`, and the category context menu; non-managers see none of these controls.
 - [ ] Appearance offers Default, Dark, Light, and Custom choices; Custom generates a readable palette from one valid hex color, persists after reload, and `Reset defaults` restores the original Voxpery palette without horizontal overflow on desktop or mobile.


### PR DESCRIPTION
## Summary

- preserve DM unread state while the app is backgrounded
- carry the notification channel and message target into DM navigation
- wait for refreshed history instead of anchoring against stale cache
- anchor the target message before paint, with a latest-message fallback
- clear unread state only after the target row is confirmed visible
- prevent one-time notification anchors from affecting later manual scrolling
- add regression coverage and update release documentation

## Validation

- `npm run lint`
- `npm run test:run` — 259 passed
- `npm run build`
- `npm run test:e2e:ui-smoke` — 39 passed