### PR TITLE
feat: make screen share viewing opt-in

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -82,6 +82,7 @@ function voiceState(overrides?: Record<string, unknown>) {
     cameraStream: null,
     remoteStreams: new Map<string, MediaStream>(),
     remoteScreenTrackIds: new Set<string>(),
+    watchedRemoteScreenPeerIds: new Set<string>(),
     pingMs: 7,
     lastError: null,
     livekit: {
@@ -160,27 +161,43 @@ describe('ActiveCallBar regressions', () => {
     })
   })
 
-  it('hides and restores a remote screen share locally without changing its subscription', () => {
+  it('requires an explicit action before subscribing to an available screen share', () => {
+    useAppStore.getState().setVoiceControl('peer-1', false, false, true)
+
+    const { voice } = renderActiveCallBar()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Watch stream' }))
+
+    expect(voice.setRemoteMediaSubscribed).toHaveBeenCalledWith('peer-1', 'screen', true)
+  })
+
+  it('stops only the viewer subscription for a watched screen share', () => {
     const screenTrack = mediaTrack('video', 'screen-track')
     const remoteStream = new MediaStream([screenTrack])
 
     const { voice } = renderActiveCallBar({
       remoteStreams: new Map([['peer-1', remoteStream]]),
       remoteScreenTrackIds: new Set(['screen-track']),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
     })
 
-    fireEvent.click(screen.getByTitle('Hide screen share'))
+    fireEvent.click(screen.getByTitle('Stop watching'))
 
-    expect(voice.setRemoteMediaSubscribed).not.toHaveBeenCalled()
-    expect(screen.getByText('Screen share hidden')).not.toBeNull()
-    expect(screen.getAllByText('admin')).toHaveLength(2)
-    expect(screen.queryByTitle('Hide screen share')).toBeNull()
+    expect(voice.setRemoteMediaSubscribed).toHaveBeenCalledWith('peer-1', 'screen', false)
+    expect(voice.leaveVoice).not.toHaveBeenCalled()
+  })
 
-    fireEvent.click(screen.getByRole('button', { name: /show/i }))
+  it('uses an isolated preview stream for the local screen share', () => {
+    const localScreen = new MediaStream([mediaTrack('video', 'local-screen')])
+    const { container } = renderActiveCallBar({
+      screenStream: localScreen,
+      isScreenSharing: true,
+    })
 
-    expect(voice.setRemoteMediaSubscribed).not.toHaveBeenCalled()
-    expect(screen.getByTitle('Hide screen share')).not.toBeNull()
-    expect(screen.queryByText('Screen share hidden')).toBeNull()
+    const preview = container.querySelector('[data-fullscreen-key="screen"] video') as HTMLVideoElement
+    expect(preview.srcObject).toBeInstanceOf(MediaStream)
+    expect(preview.srcObject).not.toBe(localScreen)
+    expect((preview.srcObject as MediaStream).getVideoTracks()).toEqual(localScreen.getVideoTracks())
   })
 
   it('reasserts remote microphone playback after the macOS share picker returns', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -105,6 +105,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     startCamera,
     stopCamera,
     setVoiceControls,
+    setRemoteMediaSubscribed,
     playVoiceCue,
   } = useLiveKitVoice()
   const { user } = useAuthStore()
@@ -241,6 +242,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const cameraPreviewCleanupRef = useRef<(() => void) | null>(null)
   const cameraKeepaliveVideoRef = useRef<HTMLVideoElement | null>(null)
   const cameraKeepaliveCleanupRef = useRef<(() => void) | null>(null)
+  const screenPreviewVideoRef = useRef<HTMLVideoElement | null>(null)
+  const screenPreviewCleanupRef = useRef<(() => void) | null>(null)
   useEffect(() => {
     localStreamRef.current = state.localStream
   }, [state.localStream])
@@ -258,6 +261,13 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     if (!video || !state.cameraStream) return
     cameraKeepaliveCleanupRef.current = attachMediaStreamPreview(video, state.cameraStream)
   }, [state.cameraStream])
+  const attachScreenPreviewElement = useCallback((video: HTMLVideoElement | null) => {
+    screenPreviewCleanupRef.current?.()
+    screenPreviewCleanupRef.current = null
+    screenPreviewVideoRef.current = video
+    if (!video || !state.screenStream) return
+    screenPreviewCleanupRef.current = attachMediaStreamPreview(video, state.screenStream)
+  }, [state.screenStream])
   useEffect(() => {
     const video = cameraVideoRef.current
     const stream = state.cameraStream
@@ -281,6 +291,17 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   }, [state.cameraStream])
   useEffect(() => {
+    const video = screenPreviewVideoRef.current
+    const stream = state.screenStream
+    if (!video || !stream) return
+    screenPreviewCleanupRef.current?.()
+    screenPreviewCleanupRef.current = attachMediaStreamPreview(video, stream)
+    return () => {
+      screenPreviewCleanupRef.current?.()
+      screenPreviewCleanupRef.current = null
+    }
+  }, [state.screenStream])
+  useEffect(() => {
     deafenedRef.current = deafened || serverDeafened
   }, [deafened, serverDeafened])
 
@@ -290,7 +311,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     return member?.user_id ?? peerId
   }, [members, peerVolumeByUserId])
 
-  const hiddenScreenSharePeerIdsRef = useRef<Set<string>>(new Set())
   const remoteAudioPlaybackKey = useCallback((peerId: string, kind: RemoteAudioKind) => `${kind}:${peerId}`, [])
   const parseRemoteAudioPlaybackKey = useCallback((playbackKey: string): { peerId: string; kind: RemoteAudioKind } => {
     if (playbackKey.startsWith('screen:')) {
@@ -526,25 +546,13 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     () => Array.from(remoteMediaPlaceholders.values()),
     [remoteMediaPlaceholders],
   )
-  const hiddenScreenSharePeerIds = useMemo(() => {
-    const hidden = new Set<string>()
-    for (const placeholder of remoteMediaPlaceholders.values()) {
-      if (placeholder.kind === 'screen' && isRemoteMediaHidden(placeholder.peerId, 'screen')) {
-        hidden.add(placeholder.peerId)
-      }
-    }
-    return hidden
-  }, [isRemoteMediaHidden, remoteMediaPlaceholders])
-  useEffect(() => {
-    hiddenScreenSharePeerIdsRef.current = hiddenScreenSharePeerIds
-    applyOutputVolumeToElements(outputVolumeRef.current / 100)
-  }, [applyOutputVolumeToElements, hiddenScreenSharePeerIds])
+  const watchedRemoteScreenPeerIds = state.watchedRemoteScreenPeerIds
 
   useEffect(() => {
     for (const [peerId, stream] of state.remoteStreams.entries()) {
       const entries: Array<{ kind: RemoteAudioKind; include: boolean }> = [
         { kind: 'mic', include: true },
-        { kind: 'screen', include: !hiddenScreenSharePeerIds.has(peerId) },
+        { kind: 'screen', include: watchedRemoteScreenPeerIds.has(peerId) },
       ]
       for (const { kind, include } of entries) {
         const playbackKey = remoteAudioPlaybackKey(peerId, kind)
@@ -564,7 +572,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         }
       }
     }
-  }, [hiddenScreenSharePeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+  }, [watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -581,6 +589,21 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     if (!currentVoiceChannelId) return []
     return members.filter((m) => voiceStates[m.user_id] === currentVoiceChannelId)
   }, [currentVoiceChannelId, members, voiceStates])
+  const availableRemoteScreenPeerIds = useMemo(() => (
+    channelParticipants
+      .filter((participant) => participant.user_id !== user?.id && voiceControls[participant.user_id]?.screenSharing)
+      .map((participant) => participant.user_id)
+  ), [channelParticipants, user?.id, voiceControls])
+  const activeRemoteScreenPeerIds = useMemo(() => new Set(
+    remoteVideoTrackEntries
+      .filter((entry) => entry.kind === 'screen')
+      .map((entry) => entry.peerId),
+  ), [remoteVideoTrackEntries])
+  const remoteScreenSharePlaceholders = useMemo(() => (
+    availableRemoteScreenPeerIds.filter((peerId) => (
+      !watchedRemoteScreenPeerIds.has(peerId) || !activeRemoteScreenPeerIds.has(peerId)
+    ))
+  ), [activeRemoteScreenPeerIds, availableRemoteScreenPeerIds, watchedRemoteScreenPeerIds])
   useEffect(() => {
     if (remoteMediaPlaceholders.size === 0) return
     const participantIds = new Set(channelParticipants.map((participant) => participant.user_id))
@@ -617,7 +640,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const showVoiceStage =
     isViewingVoiceChannel &&
     isInThisChannel &&
-    (channelParticipants.length > 0 || state.isScreenSharing || !!state.cameraStream || remoteVideoTrackEntries.length > 0)
+    (channelParticipants.length > 0 || state.isScreenSharing || !!state.cameraStream || remoteVideoTrackEntries.length > 0 || availableRemoteScreenPeerIds.length > 0)
 
   const getStageColumns = (tileCount: number) => {
     if (isMobileViewport) {
@@ -991,13 +1014,18 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const localInitial = (user?.username?.charAt(0) || 'Y').toUpperCase()
   const remoteShareOwner = (peerId: string) => members.find((m) => m.user_id === peerId)?.username ?? 'User'
   const localFallbackTileCount = currentVoiceChannelId && !channelParticipants.some((p) => p.user_id === user?.id) ? 1 : 0
-  const visibleRemoteMediaTileCount = remoteVideoTrackEntries.filter((entry) => !isRemoteMediaHidden(entry.peerId, entry.kind)).length
+  const visibleRemoteMediaTileCount = remoteVideoTrackEntries.filter((entry) => (
+    entry.kind === 'screen'
+      ? watchedRemoteScreenPeerIds.has(entry.peerId)
+      : !isRemoteMediaHidden(entry.peerId, entry.kind)
+  )).length
   const totalStageTiles = channelParticipants.length
     + localFallbackTileCount
     + (state.isScreenSharing && state.screenStream ? 1 : 0)
     + (state.cameraStream ? 1 : 0)
     + visibleRemoteMediaTileCount
     + remoteMediaPlaceholdersToRender.length
+    + remoteScreenSharePlaceholders.length
   const stageColumns = getStageColumns(totalStageTiles)
   const roomState = state.livekit.roomState
   const roomConnected = roomState === 'connected'
@@ -1148,7 +1176,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               )}
               {state.isScreenSharing && state.screenStream && (
                 <div className="screen-share-preview voice-stage-share-tile" data-fullscreen-key="screen" onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
-                  <video autoPlay muted playsInline ref={(el) => { if (!el) return; if (el.srcObject !== state.screenStream) el.srcObject = state.screenStream; void el.play().catch(() => { }) }} />
+                  <video autoPlay muted playsInline ref={attachScreenPreviewElement} />
                   <div className="screen-share-info-overlay"><span className="screen-share-info-text">Screen share · You</span></div>
                   <div className="screen-share-controls-bar">
                     <div className="screen-share-controls-left" />
@@ -1165,6 +1193,30 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   </div>
                 </div>
               )}
+              {remoteScreenSharePlaceholders.map((peerId) => {
+                const isConnecting = watchedRemoteScreenPeerIds.has(peerId)
+                return (
+                  <div key={`screen-available-${peerId}`} className="voice-stage-hidden-media-tile">
+                    <div className="voice-stage-hidden-media-icon">
+                      <Monitor size={18} />
+                    </div>
+                    <div className="voice-stage-hidden-media-title">
+                      {isConnecting ? 'Connecting to stream' : 'Stream available'}
+                    </div>
+                    <div className="voice-stage-hidden-media-sub">{remoteShareOwner(peerId)}</div>
+                    {!isConnecting && (
+                      <button
+                        type="button"
+                        className="voice-stage-hidden-media-show"
+                        onClick={() => setRemoteMediaSubscribed(peerId, 'screen', true)}
+                      >
+                        <Eye size={14} />
+                        Watch stream
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
               {remoteMediaPlaceholdersToRender.map((placeholder) => (
                 <div key={`hidden-${placeholder.key}`} className="voice-stage-hidden-media-tile">
                   <div className="voice-stage-hidden-media-icon">
@@ -1193,7 +1245,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                 const tileKey = `${peerId}-${track.id}`
                 const owner = remoteShareOwner(peerId)
                 const isHidden = isRemoteMediaHidden(peerId, kind)
-                if (isHidden) return null
+                if (kind === 'screen' && !watchedRemoteScreenPeerIds.has(peerId)) return null
+                if (kind === 'camera' && isHidden) return null
                 return (
                   <div key={tileKey} className="screen-share-preview remote-screen-preview voice-stage-share-tile" data-fullscreen-key={tileKey} onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
                     <RemoteVideoTrack track={track} />
@@ -1235,7 +1288,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                         )}
                       </div>
                       <div className="screen-share-controls-right">
-                        <button type="button" className="screen-share-controls-btn" title={kind === 'screen' ? 'Hide screen share' : 'Hide camera'} onClick={() => setRemoteMediaHidden(peerId, kind, true, label)}>
+                        <button
+                          type="button"
+                          className="screen-share-controls-btn"
+                          title={kind === 'screen' ? 'Stop watching' : 'Hide camera'}
+                          onClick={() => {
+                            if (kind === 'screen') setRemoteMediaSubscribed(peerId, 'screen', false)
+                            else setRemoteMediaHidden(peerId, kind, true, label)
+                          }}
+                        >
                           <EyeOff size={16} />
                         </button>
                         <button type="button" className="screen-share-controls-btn" title="Toggle fullscreen" onClick={(e) => {
@@ -1266,7 +1327,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                         if (el) {
                           const audioEl = el as VoxperyAudioElement
                           remoteAudioRefsRef.current.set(playbackKey, audioEl)
-                          const include = kind === 'mic' || !hiddenScreenSharePeerIds.has(peerId)
+                          const include = kind === 'mic' || watchedRemoteScreenPeerIds.has(peerId)
                           const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
                           const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
                           if (audioEl.__voxpery_trackIds !== currentTrackIds) {

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -10,6 +10,7 @@ import {
   remoteMediaStartCueKey,
   remoteMediaVoiceCue,
   resyncVoiceStateAfterReconnect,
+  shouldSubscribeRemotePublication,
   shouldSubscribeRemoteTrack,
   shouldPlayRemoteMediaStartCue,
   shouldPlayRemoteMediaStopCue,
@@ -109,6 +110,15 @@ describe('remote media subscriptions', () => {
   it('keeps user-hidden media unsubscribed even while the app is visible', () => {
     expect(shouldSubscribeRemoteTrack(Track.Kind.Video, true, true)).toBe(false)
     expect(shouldSubscribeRemoteTrack(Track.Kind.Audio, true, true)).toBe(false)
+  })
+
+  it('requires an explicit watch action for screen video and audio', () => {
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShare, Track.Kind.Video, true, false, false)).toBe(false)
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, true, false, false)).toBe(false)
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShare, Track.Kind.Video, true, false, true)).toBe(true)
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, true, false, true)).toBe(true)
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, false, false, true)).toBe(false)
+    expect(shouldSubscribeRemotePublication(Track.Source.Microphone, Track.Kind.Audio, false)).toBe(true)
   })
 
   it('maps camera and screen publications to viewer controls', () => {

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -133,6 +133,18 @@ export function shouldSubscribeRemoteTrack(
   return kind === Track.Kind.Audio || appVisible
 }
 
+export function shouldSubscribeRemotePublication(
+  source: Track.Source,
+  kind: Track.Kind,
+  appVisible: boolean,
+  userHidden = false,
+  screenShareWatched = false,
+): boolean {
+  const isScreenShare = source === Track.Source.ScreenShare || source === Track.Source.ScreenShareAudio
+  if (isScreenShare) return !userHidden && appVisible && screenShareWatched
+  return shouldSubscribeRemoteTrack(kind, appVisible, userHidden)
+}
+
 export function remoteMediaKindForSource(source: Track.Source): RemoteMediaKind | null {
   if (source === Track.Source.Camera) return 'camera'
   if (source === Track.Source.ScreenShare || source === Track.Source.ScreenShareAudio) return 'screen'
@@ -243,6 +255,7 @@ export interface UseLiveKitVoiceState {
   cameraStream: MediaStream | null
   remoteStreams: Map<PeerId, MediaStream>
   remoteScreenTrackIds: Set<string>
+  watchedRemoteScreenPeerIds: Set<PeerId>
   pingMs: number | null
   lastError: string | null
   livekit: {
@@ -282,9 +295,8 @@ export function useLiveKitVoice() {
   const remoteMediaStartCueKeysRef = useRef<Set<string>>(new Set())
   const remoteMediaStartCueReadyRef = useRef(false)
   const remoteScreenStopCueTimersRef = useRef<Map<PeerId, ReturnType<typeof setTimeout>>>(new Map())
-  const visibilitySuppressedTrackSidsRef = useRef<Set<string>>(new Set())
   const userHiddenRemoteMediaKeysRef = useRef<Set<string>>(new Set())
-  const resumedTrackSidsRef = useRef<Set<string>>(new Set())
+  const watchedRemoteScreenPeerIdsRef = useRef<Set<PeerId>>(new Set())
   const joinedChannelIdRef = useRef<string | null>(null)
   const finalMediaDisconnectReconciledRef = useRef(false)
   const finalMediaDisconnectHandlerRef = useRef<(isCurrentRoom: boolean) => void>(() => undefined)
@@ -305,6 +317,7 @@ export function useLiveKitVoice() {
 
   const [remoteStreamsVersion, setRemoteStreamsVersion] = useState(0)
   const [remoteScreenTrackIds, setRemoteScreenTrackIds] = useState<Set<string>>(new Set())
+  const [watchedRemoteScreenPeerIds, setWatchedRemoteScreenPeerIds] = useState<Set<PeerId>>(() => new Set())
   const bumpRemote = () => {
     setRemoteStreamsVersion((v) => v + 1)
     setRemoteScreenTrackIds(new Set(remoteScreenTrackIdsRef.current))
@@ -324,13 +337,15 @@ export function useLiveKitVoice() {
     const userHidden = mediaKind
       ? userHiddenRemoteMediaKeysRef.current.has(remoteMediaSubscriptionKey(peerId, mediaKind))
       : false
-    const shouldSubscribe = shouldSubscribeRemoteTrack(publication.kind, appVisible, userHidden)
+    const explicitlyWatched = watchedRemoteScreenPeerIdsRef.current.has(peerId)
+    const shouldSubscribe = shouldSubscribeRemotePublication(
+      publication.source,
+      publication.kind,
+      appVisible,
+      userHidden,
+      explicitlyWatched,
+    )
 
-    if (!shouldSubscribe && !userHidden && publication.kind === Track.Kind.Video) {
-      visibilitySuppressedTrackSidsRef.current.add(publication.trackSid)
-    } else if (shouldSubscribe && visibilitySuppressedTrackSidsRef.current.delete(publication.trackSid)) {
-      resumedTrackSidsRef.current.add(publication.trackSid)
-    }
     if (publication.isSubscribed !== shouldSubscribe) {
       publication.setSubscribed(shouldSubscribe)
     }
@@ -350,23 +365,35 @@ export function useLiveKitVoice() {
     subscribed: boolean,
   ) => {
     const key = remoteMediaSubscriptionKey(peerId, kind)
-    if (subscribed) userHiddenRemoteMediaKeysRef.current.delete(key)
-    else userHiddenRemoteMediaKeysRef.current.add(key)
+    if (kind === 'screen') {
+      if (subscribed) watchedRemoteScreenPeerIdsRef.current.add(peerId)
+      else watchedRemoteScreenPeerIdsRef.current.delete(peerId)
+      setWatchedRemoteScreenPeerIds(new Set(watchedRemoteScreenPeerIdsRef.current))
+      userHiddenRemoteMediaKeysRef.current.delete(key)
+    } else if (subscribed) {
+      userHiddenRemoteMediaKeysRef.current.delete(key)
+    } else {
+      userHiddenRemoteMediaKeysRef.current.add(key)
+    }
 
     const participant = roomRef.current?.remoteParticipants.get(peerId)
     participant?.trackPublications.forEach((publication) => {
       if (remoteMediaKindForSource(publication.source) !== kind) return
 
       if (!subscribed) {
-        visibilitySuppressedTrackSidsRef.current.delete(publication.trackSid)
         if (publication.isSubscribed) publication.setSubscribed(false)
         return
       }
 
       const appVisible = typeof document === 'undefined' || document.visibilityState !== 'hidden'
-      const shouldSubscribe = shouldSubscribeRemoteTrack(publication.kind, appVisible)
+      const shouldSubscribe = shouldSubscribeRemotePublication(
+        publication.source,
+        publication.kind,
+        appVisible,
+        false,
+        kind !== 'screen' || watchedRemoteScreenPeerIdsRef.current.has(peerId),
+      )
       if (shouldSubscribe && !publication.isSubscribed) {
-        resumedTrackSidsRef.current.add(publication.trackSid)
         publication.setSubscribed(true)
       }
     })
@@ -686,10 +713,7 @@ export function useLiveKitVoice() {
     let hasScreenShare = false
 
     participant.trackPublications.forEach((pub) => {
-      if (!pub.track || !pub.isSubscribed || pub.track.kind !== Track.Kind.Video) return
       if (pub.isMuted) return
-      const mediaTrack = pub.track.mediaStreamTrack
-      if (!mediaTrack || mediaTrack.readyState !== 'live' || mediaTrack.muted) return
       if (pub.source === Track.Source.Camera) hasCamera = true
       if (pub.source === Track.Source.ScreenShare) hasScreenShare = true
     })
@@ -855,14 +879,16 @@ export function useLiveKitVoice() {
       }
 
       room.on(RoomEvent.TrackPublished, (publication, participant) => {
+        if (publication.source === Track.Source.ScreenShare) {
+          playRemoteMediaStartCue(participant, 'screen')
+        }
         syncRemotePublicationSubscription(publication, participant.identity)
+        syncParticipantMediaState(participant)
       })
 
       room
         .on(RoomEvent.TrackSubscribed, (track, pub, participant) => {
           const peerId = participant.identity
-          visibilitySuppressedTrackSidsRef.current.delete(pub.trackSid)
-          const resumedAfterPause = resumedTrackSidsRef.current.delete(pub.trackSid)
 
           const combined = remoteStreamsRef.current.get(peerId) ?? new MediaStream()
           const mediaTrack = track.mediaStreamTrack
@@ -874,7 +900,6 @@ export function useLiveKitVoice() {
           if (pub.source === Track.Source.ScreenShare) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShare', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.add(mediaTrack.id)
-            if (!resumedAfterPause) playRemoteMediaStartCue(participant, 'screen')
           } else if (pub.source === Track.Source.ScreenShareAudio) {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShareAudio', { value: true, writable: true, configurable: true })
           } else if (pub.source === Track.Source.Camera) {
@@ -911,6 +936,8 @@ export function useLiveKitVoice() {
         .on(RoomEvent.TrackUnpublished, (publication, participant) => {
           if (publication.source === Track.Source.ScreenShare) {
             scheduleRemoteMediaStopCue(participant, 'screen')
+            watchedRemoteScreenPeerIdsRef.current.delete(participant.identity)
+            setWatchedRemoteScreenPeerIds(new Set(watchedRemoteScreenPeerIdsRef.current))
           }
           syncParticipantMediaState(participant)
           updateRoomStats()
@@ -932,12 +959,10 @@ export function useLiveKitVoice() {
           updateRoomStats()
         })
         .on(RoomEvent.ParticipantDisconnected, (participant) => {
-          participant.trackPublications.forEach((publication) => {
-            visibilitySuppressedTrackSidsRef.current.delete(publication.trackSid)
-            resumedTrackSidsRef.current.delete(publication.trackSid)
-          })
           userHiddenRemoteMediaKeysRef.current.delete(remoteMediaSubscriptionKey(participant.identity, 'camera'))
           userHiddenRemoteMediaKeysRef.current.delete(remoteMediaSubscriptionKey(participant.identity, 'screen'))
+          watchedRemoteScreenPeerIdsRef.current.delete(participant.identity)
+          setWatchedRemoteScreenPeerIds(new Set(watchedRemoteScreenPeerIdsRef.current))
           closePeer(participant.identity)
           updateRoomStats()
           playVoiceCue('leave')
@@ -1069,9 +1094,9 @@ export function useLiveKitVoice() {
     remoteMediaStartCueKeysRef.current.clear()
     remoteScreenStopCueTimersRef.current.forEach(clearTimeout)
     remoteScreenStopCueTimersRef.current.clear()
-    visibilitySuppressedTrackSidsRef.current.clear()
     userHiddenRemoteMediaKeysRef.current.clear()
-    resumedTrackSidsRef.current.clear()
+    watchedRemoteScreenPeerIdsRef.current.clear()
+    setWatchedRemoteScreenPeerIds(new Set())
     setJoinedChannelId(null)
     useAppStore.getState().setJoinedVoiceChannelId(null)
     if (userId) useAppStore.getState().setVoiceCamera(userId, false)
@@ -1444,6 +1469,7 @@ export function useLiveKitVoice() {
     cameraStream,
     remoteStreams,
     remoteScreenTrackIds,
+    watchedRemoteScreenPeerIds,
     pingMs,
     lastError,
     livekit: {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Made normal browser reloads revalidate the web app shell, service worker, and stable RNNoise worklet URL so newly deployed releases no longer require a hard refresh, while retaining long-lived caching for fingerprinted assets.
 - Made background DM notifications preserve unread state until the refreshed target message is visibly anchored, with a latest-message fallback when the original target is unavailable.
+- Made remote screen sharing opt-in per viewer so unwatched video and shared audio consume no media bandwidth, while preserving microphone audio and reconnect behavior.
+- Isolated the local screen-share preview from the published capture stream so fullscreen transitions do not rebind or restart the capture track.
 
 ## [0.2.6] - 2026-08-09
 

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -53,8 +53,8 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] Monitor/game and browser/video shares stay motion-first under load: frame pacing remains smooth before sharpness is preserved.
 - [ ] A VP9-capable Chromium/WebView2 publisher reports `codec: vp9` and `scalabilityMode: L3T3_KEY`; a fallback runtime reports `codec: vp8`.
 - [ ] Resizing and fullscreening User B's remote share tile upgrades the received adaptive layer without restarting the share.
-- [ ] User A starts screen share; User B sees the screen tile.
-- [ ] Sharing a supported browser tab/system-audio source publishes both `ScreenShare` and `ScreenShareAudio`; User B hears the shared audio independently from User A's microphone.
+- [ ] User A starts screen share; User B sees `Stream available` but receives no screen video or shared-audio traffic before choosing `Watch stream`.
+- [ ] User B chooses `Watch stream`; both `ScreenShare` and `ScreenShareAudio` subscribe, while User A's microphone remains continuously audible.
 - [ ] Shared system, game, and music audio remains stereo and continuous without speech-style gating; diagnostics report `musicHighQualityStereo`, 128 kbps, `forceStereo: true`, and `dtx: false`.
 - [ ] Sharing a source/platform that provides no audio still publishes video and shows User A one non-fatal `Sharing without audio` notice.
 - [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio sample rate/channel count/content hint/publication profile, simulcast, outbound video bitrate/FPS, actual screen-audio Opus bitrate/channels/packets, packet loss, and quality limitation reason are present without device identifiers.
@@ -63,13 +63,13 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] On macOS, opening and closing the native share picker does not lower remote microphone audio; the same level continues without clicking Voxpery again.
 - [ ] User B hears the screen-start cue only once for the screen video track.
 - [ ] Sharing screen audio does not play a duplicate start cue.
-- [ ] User B hides the screen share; the screen tile collapses and its screen video/audio publications stop for that viewer.
-- [ ] While hidden by User B, the remote screen video and screen-share audio publications are unsubscribed; selecting `Show` restores them without replaying the start cue.
-- [ ] User A's normal microphone audio continues while the screen share is hidden.
+- [ ] User B chooses `Stop watching`; the screen tile returns to `Stream available` and its screen video/audio publications unsubscribe for that viewer.
+- [ ] User A's normal microphone audio continues while User B is not watching the stream.
 - [ ] User B mutes or lowers the screen-share volume; only screen-share audio changes and User A's normal microphone audio remains audible.
 - [ ] Per-user microphone and screen-share volume controls stay within 0-100%; repeated mute/unmute and 0/100 transitions do not cut out, clip, or change the selected output device.
-- [ ] User B shows the screen share again and audio behavior returns with the visible media.
-- [ ] Minimizing or hiding User B's Voxpery window pauses incoming camera/screen video traffic while microphone and screen-share audio continue; restoring the window resumes video without replaying start cues.
+- [ ] User B chooses `Watch stream` again and screen video/audio return without replaying the publisher start cue.
+- [ ] Minimizing or hiding User B's Voxpery window pauses incoming camera and watched screen video/audio traffic while microphone audio continues; restoring the window resumes only explicitly watched media without replaying start cues.
+- [ ] User A repeatedly enters and leaves fullscreen on the local screen preview; capture stays live, no green/frozen frame appears, and User B's remote stream does not restart.
 - [ ] User A stops screen share; User B hears the screen-stop cue once.
 - [ ] User A leaves while sharing; User B hears the leave cue without an additional screen-stop cue.
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -187,7 +187,7 @@ Speaker
 - **Output volume**: Global 1-100%, per-peer microphone 0-100%, and per-screen-share audio 0-100%.
 - **Distortion-safe playback**: Remote media stays on the native media-element path. Legacy values above 100% are migrated to 100% so playback is not clipped or stranded on a closed Web Audio graph.
 - **Deafen**: Sets `audio.muted = true` on all remote elements
-- **Hide screen share**: Hiding a remote screen share suppresses its tile and screen-share audio locally while keeping both the LiveKit subscription and the peer's normal microphone audio active.
+- **Watch screen share**: Screen-share video and shared audio remain unsubscribed until the viewer chooses `Watch stream`; `Stop watching` removes only those viewer subscriptions while the peer's normal microphone audio remains active.
 - **Pre-join media presence**: Server members can see a camera icon and `LIVE` screen-share badge beside voice participants before joining the channel. These indicators use the server-broadcast voice control state and do not subscribe the viewer to media.
 
 ### Input and Output Device Selection
@@ -238,7 +238,7 @@ await room.localParticipant.publishTrack(audioTrack, {
 })
 ```
 
-Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast with 360p30 and 720p60 intermediate layers. Remote LiveKit video tracks are rendered through `RemoteVideoTrack.attach()` so adaptive stream can select a layer from the element's actual dimensions and visibility. Incompatible runtimes retain the VP8 path.
+Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast with 360p30 and 720p60 intermediate layers. Remote LiveKit video tracks are rendered through `RemoteVideoTrack.attach()` so adaptive stream can select a layer from the element's actual dimensions and visibility. Incompatible runtimes retain the VP8 path. The local preview uses a separate `MediaStream` wrapper around the capture tracks, so entering or leaving fullscreen never rebinds or restarts the published capture.
 
 ### Content Hints
 
@@ -254,13 +254,12 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 
 ### Remote Viewing Controls
 
-- Remote camera and screen-share tiles can be hidden per viewer without leaving the voice channel.
-- Hidden media stays subscribed and is replaced by a compact placeholder with a `Show` action, so the viewer can resume it immediately without waiting for LiveKit to resubscribe.
-- The placeholder is owned by viewer state and the publisher's `LIVE` or camera presence remains unchanged for every other participant.
-- Hidden preferences are local to the current voice session and reset after leaving, refreshing, or switching voice channels.
-- Hiding a screen share locally suppresses both its video and screen-share audio playback; the participant's microphone audio continues normally.
+- Remote camera tiles can be hidden per viewer without leaving the voice channel.
+- A remote screen share appears first as a compact `Stream available` tile. `Watch stream` subscribes that viewer to both `ScreenShare` and `ScreenShareAudio`; `Stop watching` unsubscribes both while leaving microphone audio untouched.
+- Viewer subscription state is local to the current voice session, survives visibility changes and LiveKit reconnects, and resets when the share ends, the participant disconnects, or the viewer leaves voice.
+- Unwatched shares and shares in a hidden Voxpery window produce no incoming screen video or shared-audio traffic. Returning to a visible window restores only streams the user explicitly chose to watch.
 - The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
-- When the Voxpery window is hidden or minimized, remote video subscriptions pause while microphone and screen-share audio continue. Video subscriptions resume when the app becomes visible, without replaying media-start cues.
+- When the Voxpery window is hidden or minimized, camera and watched screen-share subscriptions pause while microphone audio continues. Explicitly watched shares resume when the app becomes visible, without replaying media-start cues.
 - Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, and remote playback without changing per-user volume settings.
 
 ### Voice Event Cues
@@ -269,7 +268,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - Camera start and stop confirmations are local to the member changing their camera. Remote participants see camera state without receiving a channel-wide camera cue.
 - Screen-share start and stop cues are heard by members already in the voice channel. Existing shares remain silent during initial room hydration, subscription resume, and local hide/show actions.
 - Screen-share stop is suppressed when the publisher disconnects so the normal leave cue remains the single channel departure sound.
-- Voxpery auto-subscribes voice members to visible shares, so it does not emit viewer join/leave sounds without an explicit watch session.
+- Viewer watch and stop-watching actions are silent; channel-wide screen-share cues describe only publisher start and stop events.
 - Camera confirmations use short high-frequency shutter-like clicks; screen-share confirmations use sustained digital chords so neither resembles voice join or leave cues, and all cues respect the existing notification-sounds preference.
 
 ## Camera


### PR DESCRIPTION
## Summary
- require viewers to explicitly join remote screen shares
- unsubscribe screen video and shared audio when not watched
- preserve microphone audio across watch and stop-watching actions
- restore explicitly watched streams after visibility changes and reconnects
- isolate the local screen preview from the published capture stream
- update voice documentation and release smoke coverage

## Validation
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:ui-smoke