### PR TITLE
fix: stabilize live voice and onboarding state

### DIFF
--- a/apps/web/src/components/ServerWelcomeGuide.test.tsx
+++ b/apps/web/src/components/ServerWelcomeGuide.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import ServerWelcomeGuide from './ServerWelcomeGuide'
+import { shouldShowServerWelcomeGuide } from '../serverWelcomeGuideVisibility'
 import type { Channel, ServerOnboardingGuide } from '../api'
 
 const channels: Channel[] = [
@@ -37,6 +38,33 @@ const guide: ServerOnboardingGuide = {
 }
 
 describe('ServerWelcomeGuide', () => {
+  it('only allows the guide that belongs to the active text-channel server', () => {
+    expect(shouldShowServerWelcomeGuide({
+      activeServerId: 'server-1',
+      activeChannelType: 'text',
+      guide,
+      dismissed: false,
+    })).toBe(true)
+    expect(shouldShowServerWelcomeGuide({
+      activeServerId: 'server-2',
+      activeChannelType: 'text',
+      guide,
+      dismissed: false,
+    })).toBe(false)
+    expect(shouldShowServerWelcomeGuide({
+      activeServerId: 'server-1',
+      activeChannelType: 'voice',
+      guide,
+      dismissed: false,
+    })).toBe(false)
+    expect(shouldShowServerWelcomeGuide({
+      activeServerId: 'server-1',
+      activeChannelType: 'text',
+      guide,
+      dismissed: true,
+    })).toBe(false)
+  })
+
   it('renders official community starter tasks and text/voice channel CTAs', () => {
     const onSelectChannel = vi.fn()
 

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -15,6 +15,7 @@ import ServerSettingsAuditLog from '../components/ServerSettingsAuditLog'
 import ServerSettingsCommunity from '../components/ServerSettingsCommunity'
 import ServerSettingsSafety, { type SafetySettingsTab } from '../components/ServerSettingsSafety'
 import ServerWelcomeGuide from '../components/ServerWelcomeGuide'
+import { shouldShowServerWelcomeGuide } from '../serverWelcomeGuideVisibility'
 import ServerRolesSidebar from '../components/ServerRolesSidebar'
 import ServerRoleEditor from '../components/ServerRoleEditor'
 import { useToastStore } from '../stores/toast'
@@ -709,6 +710,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
 
         const serverId = activeServerId
         let cancelled = false
+        setActiveOnboardingGuide(null)
         setWelcomeGuideDismissed(isWelcomeGuideDismissed(serverId))
         serverApi.getOnboardingGuide(serverId, token)
             .then((guide) => {
@@ -2555,7 +2557,12 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             ).sort((a, b) => a.localeCompare(b)),
         [channels, channelCategories],
     )
-    const welcomeGuideNode = activeServer && activeChannel?.channel_type === 'text' && activeOnboardingGuide?.enabled && !welcomeGuideDismissed ? (
+    const welcomeGuideNode = activeServer && activeOnboardingGuide && shouldShowServerWelcomeGuide({
+        activeServerId: activeServer.id,
+        activeChannelType: activeChannel?.channel_type,
+        guide: activeOnboardingGuide,
+        dismissed: welcomeGuideDismissed,
+    }) ? (
         <ServerWelcomeGuide
             guide={activeOnboardingGuide}
             channels={channels}

--- a/apps/web/src/serverWelcomeGuideVisibility.ts
+++ b/apps/web/src/serverWelcomeGuideVisibility.ts
@@ -1,0 +1,21 @@
+import type { Channel, ServerOnboardingGuide } from './api'
+
+interface ServerWelcomeGuideVisibilityOptions {
+  activeServerId: string | null
+  activeChannelType: Channel['channel_type'] | null | undefined
+  guide: ServerOnboardingGuide | null
+  dismissed: boolean
+}
+
+export function shouldShowServerWelcomeGuide({
+  activeServerId,
+  activeChannelType,
+  guide,
+  dismissed,
+}: ServerWelcomeGuideVisibilityOptions): boolean {
+  return !!activeServerId
+    && activeChannelType === 'text'
+    && guide?.server_id === activeServerId
+    && guide.enabled
+    && !dismissed
+}

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearRemoteMediaStartCue,
+  getLiveKitParticipantCount,
   getMicrophonePublishOptions,
   getPreferredScreenShareCodec,
   getScreenShareAudioPublishOptions,
   getScreenSharePublishOptions,
+  reconcileLiveKitVoicePresence,
   reconcileFinalMediaDisconnect,
   remoteMediaKindForSource,
   remoteMediaStartCueKey,
@@ -17,6 +19,7 @@ import {
   shouldRecoverMicrophoneTrack,
 } from './useLiveKitVoice'
 import { AudioPresets, Track } from 'livekit-client'
+import { useAppStore } from '../stores/app'
 
 describe('microphone publish options', () => {
   it('uses a high-quality mono Opus profile with resilience enabled', () => {
@@ -36,7 +39,7 @@ describe('screen-share audio publish options', () => {
       source: Track.Source.ScreenShareAudio,
       audioPreset: AudioPresets.musicHighQualityStereo,
       dtx: false,
-      red: false,
+      red: true,
       forceStereo: true,
     })
   })
@@ -117,7 +120,8 @@ describe('remote media subscriptions', () => {
     expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, true, false, false)).toBe(false)
     expect(shouldSubscribeRemotePublication(Track.Source.ScreenShare, Track.Kind.Video, true, false, true)).toBe(true)
     expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, true, false, true)).toBe(true)
-    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, false, false, true)).toBe(false)
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShareAudio, Track.Kind.Audio, false, false, true)).toBe(true)
+    expect(shouldSubscribeRemotePublication(Track.Source.ScreenShare, Track.Kind.Video, false, false, true)).toBe(false)
     expect(shouldSubscribeRemotePublication(Track.Source.Microphone, Track.Kind.Audio, false)).toBe(true)
   })
 
@@ -126,6 +130,55 @@ describe('remote media subscriptions', () => {
     expect(remoteMediaKindForSource(Track.Source.ScreenShare)).toBe('screen')
     expect(remoteMediaKindForSource(Track.Source.ScreenShareAudio)).toBe('screen')
     expect(remoteMediaKindForSource(Track.Source.Microphone)).toBeNull()
+  })
+})
+
+describe('LiveKit voice presence reconciliation', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      channels: [{
+        id: 'voice-channel-1',
+        server_id: 'server-1',
+        name: 'General',
+        channel_type: 'voice',
+        category: 'General',
+        position: 0,
+      }],
+      channelsByServerId: {},
+      voiceStates: {},
+      voiceStateServerIds: {},
+      voiceChannelActiveSince: {},
+    })
+  })
+
+  it('counts the connected local participant together with current remotes', () => {
+    expect(getLiveKitParticipantCount('connected', 2)).toBe(3)
+    expect(getLiveKitParticipantCount('reconnecting', 2)).toBe(3)
+    expect(getLiveKitParticipantCount('disconnected', 2)).toBe(0)
+  })
+
+  it('updates sidebar presence immediately from LiveKit participant events', () => {
+    reconcileLiveKitVoicePresence('user-1', 'voice-channel-1', true)
+
+    expect(useAppStore.getState().voiceStates['user-1']).toBe('voice-channel-1')
+    expect(useAppStore.getState().voiceStateServerIds['user-1']).toBe('server-1')
+
+    reconcileLiveKitVoicePresence('user-1', 'voice-channel-1', false)
+
+    expect(useAppStore.getState().voiceStates['user-1']).toBeNull()
+    expect(useAppStore.getState().voiceStateServerIds['user-1']).toBeNull()
+  })
+
+  it('does not let a stale disconnect clear presence after a channel move', () => {
+    useAppStore.setState({
+      voiceStates: { 'user-1': 'voice-channel-2' },
+      voiceStateServerIds: { 'user-1': 'server-2' },
+    })
+
+    reconcileLiveKitVoicePresence('user-1', 'voice-channel-1', false)
+
+    expect(useAppStore.getState().voiceStates['user-1']).toBe('voice-channel-2')
+    expect(useAppStore.getState().voiceStateServerIds['user-1']).toBe('server-2')
   })
 })
 

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -64,9 +64,46 @@ export function getScreenShareAudioPublishOptions(): TrackPublishOptions {
     source: Track.Source.ScreenShareAudio,
     audioPreset: AudioPresets.musicHighQualityStereo,
     dtx: false,
-    red: false,
+    red: true,
     forceStereo: true,
   }
+}
+
+export function getLiveKitParticipantCount(roomState: string, remoteParticipantCount: number): number {
+  const hasLocalParticipant = roomState === 'connected'
+    || roomState === 'reconnecting'
+    || roomState === 'signalReconnecting'
+  return hasLocalParticipant ? remoteParticipantCount + 1 : 0
+}
+
+function getVoiceChannelServerId(channelId: string): string | null {
+  const store = useAppStore.getState()
+  const currentChannel = store.channels.find((channel) => channel.id === channelId)
+  if (currentChannel) return currentChannel.server_id
+
+  for (const [serverId, channels] of Object.entries(store.channelsByServerId)) {
+    if (channels.some((channel) => channel.id === channelId)) return serverId
+  }
+  return null
+}
+
+export function reconcileLiveKitVoicePresence(
+  participantId: string,
+  channelId: string,
+  connected: boolean,
+): void {
+  if (!participantId || !channelId) return
+
+  const store = useAppStore.getState()
+  if (connected) {
+    store.setVoiceState(participantId, channelId)
+    store.setVoiceStateServerId(participantId, getVoiceChannelServerId(channelId))
+    return
+  }
+
+  if (store.voiceStates[participantId] !== channelId) return
+  store.setVoiceState(participantId, null)
+  store.setVoiceStateServerId(participantId, null)
 }
 
 type ScreenShareEncoding = {
@@ -140,8 +177,8 @@ export function shouldSubscribeRemotePublication(
   userHidden = false,
   screenShareWatched = false,
 ): boolean {
-  const isScreenShare = source === Track.Source.ScreenShare || source === Track.Source.ScreenShareAudio
-  if (isScreenShare) return !userHidden && appVisible && screenShareWatched
+  if (source === Track.Source.ScreenShareAudio) return !userHidden && screenShareWatched
+  if (source === Track.Source.ScreenShare) return !userHidden && appVisible && screenShareWatched
   return shouldSubscribeRemoteTrack(kind, appVisible, userHidden)
 }
 
@@ -439,7 +476,7 @@ export function useLiveKitVoice() {
       return
     }
     const nextRoomState = String(room.state)
-    const nextParticipantCount = room.numParticipants ?? 0
+    const nextParticipantCount = getLiveKitParticipantCount(nextRoomState, room.remoteParticipants.size)
     setRoomState(nextRoomState)
     setParticipantCount(nextParticipantCount)
     updateVoiceDiagnostics({
@@ -959,6 +996,7 @@ export function useLiveKitVoice() {
           updateRoomStats()
         })
         .on(RoomEvent.ParticipantDisconnected, (participant) => {
+          reconcileLiveKitVoicePresence(participant.identity, channelId, false)
           userHiddenRemoteMediaKeysRef.current.delete(remoteMediaSubscriptionKey(participant.identity, 'camera'))
           userHiddenRemoteMediaKeysRef.current.delete(remoteMediaSubscriptionKey(participant.identity, 'screen'))
           watchedRemoteScreenPeerIdsRef.current.delete(participant.identity)
@@ -968,6 +1006,7 @@ export function useLiveKitVoice() {
           playVoiceCue('leave')
         })
         .on(RoomEvent.ParticipantConnected, (participant) => {
+          reconcileLiveKitVoicePresence(participant.identity, channelId, true)
           participant.trackPublications.forEach((publication) => {
             syncRemotePublicationSubscription(publication, participant.identity)
           })
@@ -988,7 +1027,10 @@ export function useLiveKitVoice() {
           const currentRoom = roomRef.current
           if (currentRoom) {
             syncRemoteSubscriptions(currentRoom)
-            currentRoom.remoteParticipants.forEach(syncParticipantMediaState)
+            currentRoom.remoteParticipants.forEach((participant) => {
+              reconcileLiveKitVoicePresence(participant.identity, channelId, true)
+              syncParticipantMediaState(participant)
+            })
           }
         })
         .on(RoomEvent.Disconnected, (reason) => {
@@ -1013,6 +1055,7 @@ export function useLiveKitVoice() {
       await Promise.race([connectPromise, timeoutPromise])
 
       room.remoteParticipants.forEach((participant) => {
+        reconcileLiveKitVoicePresence(participant.identity, channelId, true)
         rememberExistingRemoteMedia(participant)
         participant.trackPublications.forEach((publication) => {
           syncRemotePublicationSubscription(publication, participant.identity)
@@ -1027,7 +1070,7 @@ export function useLiveKitVoice() {
       updateVoiceDiagnostics({
         livekit: {
           roomState: String(room.state),
-          participants: room.numParticipants ?? 0,
+          participants: getLiveKitParticipantCount(String(room.state), room.remoteParticipants.size),
           remoteStreams: remoteStreamsRef.current.size,
           adaptiveStream: true,
           dynacast: true,
@@ -1059,6 +1102,7 @@ export function useLiveKitVoice() {
       }
 
       joinedChannelIdRef.current = channelId
+      reconcileLiveKitVoicePresence(userId, channelId, true)
       send('JoinVoice', {
         channel_id: channelId,
         participant_sid: room.localParticipant.sid,
@@ -1086,7 +1130,8 @@ export function useLiveKitVoice() {
 
     const leaveVoice = useCallback((options?: { skipLeaveSound?: boolean; skipRoomDisconnect?: boolean }) => {
     isJoiningRef.current = false
-    if (joinedChannelIdRef.current && !options?.skipLeaveSound) playVoiceCue('leave')
+    const departingChannelId = joinedChannelIdRef.current
+    if (departingChannelId && !options?.skipLeaveSound) playVoiceCue('leave')
     setLastError(null)
     send('LeaveVoice', null)
     joinedChannelIdRef.current = null
@@ -1099,7 +1144,10 @@ export function useLiveKitVoice() {
     setWatchedRemoteScreenPeerIds(new Set())
     setJoinedChannelId(null)
     useAppStore.getState().setJoinedVoiceChannelId(null)
-    if (userId) useAppStore.getState().setVoiceCamera(userId, false)
+    if (userId) {
+      if (departingChannelId) reconcileLiveKitVoicePresence(userId, departingChannelId, false)
+      useAppStore.getState().setVoiceCamera(userId, false)
+    }
     remoteMonitorCleanupsRef.current.forEach((c) => c())
     remoteMonitorCleanupsRef.current.clear()
 
@@ -1173,7 +1221,7 @@ export function useLiveKitVoice() {
       audioPreset: 'musicHighQualityStereo' as const,
       audioMaxBitrateKbps: 128 as const,
       audioDtx: false as const,
-      audioRed: false as const,
+      audioRed: true as const,
       audioForceStereo: true as const,
     } : {}
     const tracks = stream.getTracks()

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -84,7 +84,7 @@ export interface ScreenShareCaptureDiagnostics {
   audioPreset?: 'musicHighQualityStereo'
   audioMaxBitrateKbps?: 128
   audioDtx?: false
-  audioRed?: false
+  audioRed?: true
   audioForceStereo?: true
   simulcast?: boolean
   codec?: string

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -55,7 +55,8 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] Resizing and fullscreening User B's remote share tile upgrades the received adaptive layer without restarting the share.
 - [ ] User A starts screen share; User B sees `Stream available` but receives no screen video or shared-audio traffic before choosing `Watch stream`.
 - [ ] User B chooses `Watch stream`; both `ScreenShare` and `ScreenShareAudio` subscribe, while User A's microphone remains continuously audible.
-- [ ] Shared system, game, and music audio remains stereo and continuous without speech-style gating; diagnostics report `musicHighQualityStereo`, 128 kbps, `forceStereo: true`, and `dtx: false`.
+- [ ] While User B watches a stream, hiding/minimizing Voxpery pauses screen video but keeps screen-share audio continuous; restoring the app resumes video without an audio gap or replayed media cue.
+- [ ] Shared system, game, and music audio remains stereo and continuous without speech-style gating; diagnostics report `musicHighQualityStereo`, 128 kbps, `forceStereo: true`, `dtx: false`, and `red: true`.
 - [ ] Sharing a source/platform that provides no audio still publishes video and shows User A one non-fatal `Sharing without audio` notice.
 - [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio sample rate/channel count/content hint/publication profile, simulcast, outbound video bitrate/FPS, actual screen-audio Opus bitrate/channels/packets, packet loss, and quality limitation reason are present without device identifiers.
 - [ ] Under constrained bandwidth, screen share remains watchable by stepping down to a lower simulcast layer instead of freezing on a single high-quality layer.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -234,7 +234,7 @@ await room.localParticipant.publishTrack(audioTrack, {
   audioPreset: AudioPresets.musicHighQualityStereo, // 128 kbps Opus
   forceStereo: true,
   dtx: false,
-  red: false,
+  red: true,
 })
 ```
 
@@ -246,7 +246,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - **Presentation/window share**: `contentHint = 'detail'` at 1080p30 and `maintain-resolution` degradation to preserve text sharpness while limiting traffic.
 - **Browser tab/video and Auto monitor share**: `contentHint = 'motion'` at 1080p60 with an 8 Mbps cap and `maintain-framerate` degradation.
 - **Gaming share**: Explicit 1080p60 high-motion mode with a 12 Mbps cap for users who prefer quality over bandwidth.
-- **Screen-share audio**: `contentHint = 'music'`, stereo 128 kbps Opus, and continuous transmission (`dtx = false`) preserve system, game, and music audio independently from the mono speech microphone profile.
+- **Screen-share audio**: `contentHint = 'music'`, stereo 128 kbps Opus, continuous transmission (`dtx = false`), and RED packet-loss resilience preserve system, game, and music audio independently from the mono speech microphone profile.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement)
 - A share is not published without a live video track. If the selected platform/source does not provide a system or tab audio track, video sharing continues and the sender receives a non-fatal `Sharing without audio` notice with source-picker guidance.
 - Publishing is rollback-safe: if any selected screen track fails to publish, already-published tracks from that attempt are unpublished and the local capture is stopped.
@@ -257,9 +257,9 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - Remote camera tiles can be hidden per viewer without leaving the voice channel.
 - A remote screen share appears first as a compact `Stream available` tile. `Watch stream` subscribes that viewer to both `ScreenShare` and `ScreenShareAudio`; `Stop watching` unsubscribes both while leaving microphone audio untouched.
 - Viewer subscription state is local to the current voice session, survives visibility changes and LiveKit reconnects, and resets when the share ends, the participant disconnects, or the viewer leaves voice.
-- Unwatched shares and shares in a hidden Voxpery window produce no incoming screen video or shared-audio traffic. Returning to a visible window restores only streams the user explicitly chose to watch.
+- Unwatched shares produce no incoming screen video or shared-audio traffic. Hiding Voxpery pauses watched screen video, while watched shared audio remains subscribed so background playback does not cut out.
 - The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
-- When the Voxpery window is hidden or minimized, camera and watched screen-share subscriptions pause while microphone audio continues. Explicitly watched shares resume when the app becomes visible, without replaying media-start cues.
+- When the Voxpery window is hidden or minimized, camera and watched screen video subscriptions pause while microphone and explicitly watched screen-share audio continue. Video resumes when the app becomes visible, without replaying media-start cues.
 - Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, and remote playback without changing per-user volume settings.
 
 ### Voice Event Cues


### PR DESCRIPTION
## Summary

- Reconcile LiveKit participants with sidebar voice presence and participant counts.
- Prevent stale onboarding guides from flashing during server switches.
- Improve screen-share audio continuity with Opus RED and stable background audio subscriptions.
- Preserve bandwidth savings by pausing hidden screen video and keeping unwatched streams unsubscribed.
- Update voice documentation and release smoke coverage.

## Validation

- `npm run lint`
- `npm run test:run` — 266 passed
- `npm run build`
- `npm run test:e2e:ui-smoke` — 39 passed
- `git diff --check`