### PR TITLE
feat: automate stable release deployments

### DIFF
--- a/.github/scripts/validate-deploy-workflows.mjs
+++ b/.github/scripts/validate-deploy-workflows.mjs
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+
+const failures = []
+
+function read(path) {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (error) {
+    failures.push(`Unable to read ${path}: ${String(error)}`)
+    return ''
+  }
+}
+
+function requireText(label, text, expected) {
+  if (!text.includes(expected)) failures.push(`${label} must include: ${expected}`)
+}
+
+const ci = read('.github/workflows/ci.yml')
+const deploy = read('.github/workflows/deploy.yml')
+
+requireText('CI', ci, 'needs: docker_publish')
+requireText('CI', ci, 'Verify published stable GitHub Release')
+requireText('CI', ci, "jq -r '.prerelease'")
+requireText('CI', ci, 'uses: ./.github/workflows/deploy.yml')
+requireText('CI', ci, 'image_tag: ${{ github.ref_name }}')
+requireText('CI', ci, 'git_ref: ${{ github.ref_name }}')
+
+requireText('production deploy', deploy, 'workflow_call:')
+requireText('production deploy', deploy, 'workflow_dispatch:')
+requireText('production deploy', deploy, 'group: deploy-production')
+requireText('production deploy', deploy, 'cancel-in-progress: false')
+requireText('production deploy', deploy, 'voxpery/voxpery-server:${IMAGE_TAG}')
+requireText('production deploy', deploy, 'voxpery/voxpery-web:${IMAGE_TAG}')
+requireText('production deploy', deploy, 'smoke:release-deploy')
+requireText('production deploy', deploy, 'SMOKE_EXPECTED_IMAGE_TAG:')
+
+if (failures.length > 0) {
+  console.error('Deploy workflow validation failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Deploy workflow validation passed.')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Validate security policies
         run: node .github/scripts/validate-security-policies.mjs
 
+      - name: Validate deploy automation
+        run: node .github/scripts/validate-deploy-workflows.mjs
+
       - name: Install
         working-directory: apps/web
         run: npm ci
@@ -258,3 +261,60 @@ jobs:
             APP_ENV=production
           cache-from: type=gha,scope=${{ matrix.component }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+
+  release_deploy_gate:
+    name: Release / Production Deploy Gate
+    needs: docker_publish
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify published stable GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          release_json=""
+
+          for attempt in 1 2 3 4 5 6; do
+            if release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" 2>/dev/null)"; then
+              break
+            fi
+            if [ "${attempt}" -lt 6 ]; then
+              echo "Published release ${RELEASE_TAG} is not visible yet; retrying in 10 seconds."
+              sleep 10
+            fi
+          done
+
+          if [ -z "${release_json}" ]; then
+            echo "Refusing automatic deploy: ${RELEASE_TAG} is not a published GitHub Release."
+            exit 1
+          fi
+
+          if [ "$(printf '%s' "${release_json}" | jq -r '.draft')" != "false" ]; then
+            echo "Refusing automatic deploy: draft releases are not production deployable."
+            exit 1
+          fi
+
+          if [ "$(printf '%s' "${release_json}" | jq -r '.prerelease')" != "false" ]; then
+            echo "Refusing automatic deploy: prereleases are not production deployable."
+            exit 1
+          fi
+
+          if [ "$(printf '%s' "${release_json}" | jq -r '.tag_name')" != "${RELEASE_TAG}" ]; then
+            echo "Refusing automatic deploy: release tag does not match the triggering tag."
+            exit 1
+          fi
+
+  deploy_release:
+    name: Release / Production Deploy
+    needs: release_deploy_gate
+    if: needs.release_deploy_gate.result == 'success'
+    uses: ./.github/workflows/deploy.yml
+    with:
+      release_channel: custom
+      image_tag: ${{ github.ref_name }}
+      git_ref: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,20 @@
 name: Deploy / Production
 
 on:
+  workflow_call:
+    inputs:
+      release_channel:
+        description: 'What to deploy: latest release tag, build+deploy a main candidate, or custom tag/ref'
+        required: true
+        type: string
+      image_tag:
+        description: 'Custom mode only: immutable Docker image tag, for example sha-abc123def456 or v1.2.3'
+        required: false
+        type: string
+      git_ref:
+        description: 'Custom mode only: Git ref to checkout on the server for compose/deployment files'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       release_channel:
@@ -25,8 +39,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-manual-main
-  cancel-in-progress: true
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
   prepare:
@@ -187,6 +201,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.git_ref }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Verify immutable release images
+        shell: bash
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "voxpery/voxpery-server:${IMAGE_TAG}" >/dev/null
+          docker buildx imagetools inspect "voxpery/voxpery-web:${IMAGE_TAG}" >/dev/null
+
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.5
         env:
@@ -277,3 +314,28 @@ jobs:
             curl -fsS http://127.0.0.1:3001/health >/dev/null
             curl -fsS http://127.0.0.1:${WEB_PORT:-5173}/healthz >/dev/null
             echo "Deploy complete: release_channel=${RELEASE_CHANNEL} git_ref=${GIT_REF} commit=$(git rev-parse HEAD) image_tag=${IMAGE_TAG}"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Verify production health, version, and cache policy
+        shell: bash
+        env:
+          SMOKE_API_URL: ${{ vars.PRODUCTION_API_URL || 'https://api.voxpery.com' }}
+          SMOKE_WEB_URL: ${{ vars.PRODUCTION_WEB_URL || 'https://voxpery.com' }}
+          SMOKE_EXPECTED_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5 6; do
+            if npm --prefix apps/web run smoke:release-deploy; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 6 ]; then
+              echo "Production smoke attempt ${attempt} failed; retrying in 10 seconds."
+              sleep 10
+            fi
+          done
+          echo "Production smoke failed after 6 attempts."
+          exit 1

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -241,7 +241,16 @@ docker compose pull server web
 docker compose up -d --no-build --remove-orphans
 ```
 
-The bundled manual deploy workflow uses a deploy channel:
+The bundled production deploy workflow supports automatic stable-release deploys
+and manual deploy channels. Publishing a non-prerelease GitHub Release with a
+`vX.Y.Z` tag starts CI validation and publishes both immutable Docker images.
+After both image jobs succeed, CI verifies that the tag belongs to the published
+Release and calls the production deploy workflow. The deploy verifies that both
+the backend and frontend image tags exist before changing the server, then runs
+health, deployed-version, and cache-policy smoke checks.
+
+Manual runs remain available for redeploys, release recovery, candidates, and
+explicit rollback operations:
 
 - `latest-release` (default): finds the newest `v*` tag, checks out that tag,
   and deploys the matching `vX.Y.Z` image tag.
@@ -252,14 +261,23 @@ The bundled manual deploy workflow uses a deploy channel:
   advanced operations.
 
 All channels refuse the Docker `latest` tag. The default `latest-release`
-channel keeps manual deploys close to one-click while still pinning production
-to a concrete release version.
+channel keeps manual redeploys close to one-click while still pinning production
+to a concrete release version. Automatic and manual deploys share one production
+concurrency lock, so they cannot modify production at the same time. Re-running
+the same release deploy is safe and remains pinned to the same immutable images.
 
 Docker images are published automatically only for `v*` tag pushes. Main-branch
 pushes run validation but do not push Docker images, keeping Docker Hub focused
-on stable releases. When you need a pre-release `main-candidate` deploy, run the
+on stable releases. A tag push that is not backed by a published, non-prerelease
+GitHub Release is refused by the automatic production deploy gate. When you need
+a pre-release `main-candidate` deploy, run the
 manual deploy workflow with the `main-candidate` channel; it publishes the
 matching `sha-<commit>` server and web images before deploying them.
+
+Set the optional repository variables `PRODUCTION_API_URL` and
+`PRODUCTION_WEB_URL` when deploying a fork to different public endpoints. They
+default to `https://api.voxpery.com` and `https://voxpery.com` for the hosted
+service and are used by the post-deploy smoke check.
 
 CI-built web images embed the resolved deploy tag as `VITE_APP_VERSION` and show
 it beside the `Beta` badge in the top bar. This should match the selected server
@@ -275,6 +293,14 @@ build produces new URLs. Do not override the entry-point headers with a CDN
 browser-cache rule: the release smoke workflow verifies that the app shell and
 service worker return a revalidation policy, preventing stale releases from
 requiring `Ctrl+F5`.
+
+For Cloudflare, set Browser Cache TTL to `Respect existing headers` and do not
+apply an Edge Cache TTL override to `/`, `/index.html`, `/sw.js`, or
+`/assets/rnnoise-worklet.js`. A broad four-hour Browser Cache TTL rule, for
+example, replaces the origin's revalidation header with `max-age=14400` and
+causes the post-deploy cache smoke to fail. Fingerprinted `/assets/*` files may
+keep a long-lived edge/browser cache rule, except for the stable RNNoise worklet
+path above.
 
 ## 8) Backups
 

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -62,7 +62,7 @@ Voxpery follows Semantic Versioning:
 - **Required PR gates**: `Checks / Secret Scan`, `Checks / Backend`, and `Checks / Frontend`. Keep these fast and deterministic so branch protection can require them on every PR.
 - **Security monitoring gates**: CodeQL and dependency security audit workflows run on PRs, schedules, or manually. Review their output before release; an upstream-blocked advisory needs an explicit release decision rather than being silently ignored.
 - **Release smoke gates**: release metadata sync runs automatically before Docker publishing on `v*` tag builds. The manual `Release / Smoke` workflow can be run against release candidate API and web URLs for post-deploy confidence; it verifies public health endpoints, immutable image-tag format, and the deployed web version tag.
-- **Publish jobs**: Docker publish, tag release, desktop release, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or manually triggered on PRs. Docker publish runs automatically for `v*` tag pushes; the manual deploy workflow builds and publishes immutable `sha-<commit>` images before deploying a `main-candidate`. Docker publish jobs must produce immutable `sha-<commit>` tags for manually deployed main-candidate builds and version tags for `v*` releases; production deploys must resolve to an exact image tag rather than Docker `latest`.
+- **Publish jobs**: Docker publish, tag release, desktop release, deploy, and manual smoke jobs must not be configured as required PR checks because they are intentionally skipped or separately triggered on PRs. Docker publish runs automatically for `v*` tag pushes. A published, non-prerelease GitHub Release automatically deploys only after both release image jobs succeed and the registry contains matching backend/frontend tags. The manual deploy workflow remains available and builds immutable `sha-<commit>` images before deploying a `main-candidate`. All production deploys must resolve to an exact image tag rather than Docker `latest`.
 
 ### Release Checklist
 
@@ -76,7 +76,7 @@ Voxpery follows Semantic Versioning:
 8. Validate critical paths: auth, messaging+websocket, voice join/leave.
 9. Create and push the Git tag (for example `v0.1.5`) from the exact signed-off commit.
 10. Confirm tag-triggered release jobs, Docker publish jobs, and desktop artifact jobs ran against that exact tag/ref.
-11. Record the exact Docker image tag selected for production deploy and verify the manual deploy workflow used that tag.
+11. Record the exact Docker image tag selected for production deploy and verify the automatic release deploy, or an intentional manual deploy, used that tag.
 12. Verify release assets and updater metadata before publishing or announcing the release.
 13. Publish GitHub Release notes only after artifacts, signatures, and smoke sign-off are complete.
 
@@ -84,7 +84,7 @@ Voxpery follows Semantic Versioning:
 
 - Prefer tag-driven releases: push the `v*` tag from the signed-off commit and let tag-triggered CI/release jobs build the immutable candidate.
 - Release Docker images are tagged with both `vX.Y.Z` and `sha-<commit>`. Manually deployed main-candidate Docker images are commit-tagged as `sha-<commit>`. The web image embeds the selected deploy tag in the top-bar version badge. Do not rely on `latest` for production deploys.
-- Manual production deploys should use the default `latest-release` channel for normal stable releases, `main-candidate` for one-click pre-release build-and-deploy verification, and `custom` only for explicit rollback or advanced operations. Each channel resolves to a concrete image tag before deploying.
+- Publishing a stable GitHub Release automatically deploys its exact `vX.Y.Z` images after CI publishing and registry verification. Manual production deploys remain available: use `latest-release` to redeploy the newest stable release, `main-candidate` for one-click pre-release build-and-deploy verification, and `custom` only for explicit rollback or advanced operations. Every path resolves to a concrete image tag before deploying.
 - If a GitHub Release is created manually and workflows do not run, do not announce it as ready. Run the appropriate manual workflow against the exact tag/ref or recreate the tag/release intentionally.
 - Manual desktop release workflow runs must use the exact release tag/ref, set `smoke_checklist_confirmed=yes`, and use `platform=all` for production releases unless the release is explicitly a single-platform hotfix/test.
 - Keep the release draft until `latest.json`, installer assets, signature files, and release notes all point to the same version and tag.

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -40,8 +40,8 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] CI/release workflows ran against the exact release commit SHA or tag recorded above.
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
-- [ ] Manual deploy workflow resolved the expected deploy channel and exact Docker image tag recorded in Release Candidate Info.
-- [ ] Release deploy guardrails verified API `/health`, web `/healthz`, immutable image tag format, and the deployed web bundle version tag.
+- [ ] Stable GitHub Release publishing automatically waited for both immutable Docker images and deployed their exact shared `vX.Y.Z` tag; any intentional manual redeploy is recorded instead.
+- [ ] Release deploy guardrails verified registry presence for both images, API `/health`, web `/healthz`, immutable image tag format, cache policy, and the deployed web bundle version tag.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
 ## 3) Web Smoke Tests (mandatory)


### PR DESCRIPTION
## Summary

- automatically deploy published stable releases after both Docker images are available
- preserve manual latest-release, main-candidate, and custom deploy modes
- verify backend and frontend image tags before changing production
- run health, version, security-header, and cache-policy smoke checks after deploy
- serialize automatic and manual production deployments
- add workflow regression validation and update deployment documentation

## Validation

- actionlint
- deploy workflow validation
- security policy validation
- git diff validation
- production health and version smoke