### PR TITLE
fix: separate user and stream playback volume

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -13,6 +13,13 @@ import {
 } from '../globalMuteShortcut'
 import ActiveCallBar from './ActiveCallBar'
 import { SCREEN_SHARE_CAPTURE_READY_EVENT } from '../webrtc/hooks/useLocalMedia'
+import { markRemoteAudioTrackSource } from '../webrtc/remoteMediaControls'
+import {
+  getRemotePlaybackVolume,
+  readRemotePlaybackVolumes,
+  writePreviousScreenPlaybackVolume,
+  writeRemotePlaybackVolumes,
+} from '../webrtc/remotePlaybackVolume'
 
 vi.mock('../webrtc/useLiveKitVoice', () => ({
   useLiveKitVoice: vi.fn(),
@@ -185,6 +192,40 @@ describe('ActiveCallBar regressions', () => {
 
     expect(voice.setRemoteMediaSubscribed).toHaveBeenCalledWith('peer-1', 'screen', false)
     expect(voice.leaveVoice).not.toHaveBeenCalled()
+  })
+
+  it('keeps user volume and stream mute state independent', async () => {
+    const micTrack = mediaTrack('audio', 'peer-mic')
+    const screenAudioTrack = mediaTrack('audio', 'peer-screen-audio')
+    const screenTrack = mediaTrack('video', 'peer-screen-video')
+    markRemoteAudioTrackSource(micTrack, 'voice')
+    markRemoteAudioTrackSource(screenAudioTrack, 'screen')
+    writeRemotePlaybackVolumes({
+      'voice:peer-1': 200,
+      'screen:peer-1': 0,
+    })
+    writePreviousScreenPlaybackVolume('peer-1', 40)
+
+    renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', new MediaStream([micTrack, screenAudioTrack, screenTrack])]]),
+      remoteScreenTrackIds: new Set(['peer-screen-video']),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+
+    expect(screen.getByTitle('Unmute')).toBeVisible()
+    writeRemotePlaybackVolumes({
+      ...readRemotePlaybackVolumes(),
+      'voice:peer-1': 25,
+    })
+    expect(screen.getByTitle('Unmute')).toBeVisible()
+    let volumes = readRemotePlaybackVolumes()
+    expect(getRemotePlaybackVolume(volumes, 'voice', 'peer-1')).toBe(25)
+    expect(getRemotePlaybackVolume(volumes, 'screen', 'peer-1')).toBe(0)
+
+    fireEvent.click(screen.getByTitle('Unmute'))
+    volumes = readRemotePlaybackVolumes()
+    expect(getRemotePlaybackVolume(volumes, 'voice', 'peer-1')).toBe(25)
+    expect(getRemotePlaybackVolume(volumes, 'screen', 'peer-1')).toBe(40)
   })
 
   it('uses an isolated preview stream for the local screen share', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -36,9 +36,13 @@ import {
 } from '../globalMuteShortcut'
 import {
   DEFAULT_REMOTE_PLAYBACK_VOLUME,
-  normalizeRemotePlaybackVolume,
+  getRemotePlaybackVolume,
+  normalizeRemoteScreenPlaybackVolume,
   readRemotePlaybackVolumes,
+  readPreviousScreenPlaybackVolume,
+  remotePlaybackVolumeKey,
   REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT,
+  writePreviousScreenPlaybackVolume,
   writeRemotePlaybackVolumes,
 } from '../webrtc/remotePlaybackVolume'
 
@@ -46,6 +50,14 @@ type VoxperyTrack = VoxperyMediaStreamTrack
 
 interface VoxperyAudioElement extends HTMLAudioElement {
   __voxpery_trackIds?: string
+}
+
+interface RemoteVoicePlaybackGraph {
+  trackIds: string
+  source: MediaStreamAudioSourceNode
+  gain: GainNode
+  limiter: DynamicsCompressorNode
+  destination: MediaStreamAudioDestinationNode
 }
 
 interface VoxperyHTMLDivElement extends HTMLDivElement {
@@ -237,6 +249,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const micTestPrevMutedRef = useRef(false)
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
+  const remoteVoiceAudioContextRef = useRef<AudioContext | null>(null)
+  const remoteVoicePlaybackGraphsRef = useRef<Map<string, RemoteVoicePlaybackGraph>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
   const cameraPreviewCleanupRef = useRef<(() => void) | null>(null)
@@ -306,10 +320,10 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   }, [deafened, serverDeafened])
 
   const resolvePeerVolumeKey = useCallback((peerId: string) => {
-    if (peerVolumeByUserId[peerId] !== undefined) return peerId
-    const member = members.find((m) => m.username === peerId)
+    const member = members.find((candidate) => candidate.user_id === peerId)
+      ?? members.find((candidate) => candidate.username === peerId)
     return member?.user_id ?? peerId
-  }, [members, peerVolumeByUserId])
+  }, [members])
 
   const remoteAudioPlaybackKey = useCallback((peerId: string, kind: RemoteAudioKind) => `${kind}:${peerId}`, [])
   const parseRemoteAudioPlaybackKey = useCallback((playbackKey: string): { peerId: string; kind: RemoteAudioKind } => {
@@ -323,10 +337,87 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   }, [])
   const getPlaybackVolumeFactor = useCallback((peerId: string, kind: RemoteAudioKind) => {
     const volumeKey = resolvePeerVolumeKey(peerId)
-    const storageKey = kind === 'screen' ? `screen:${volumeKey}` : volumeKey
-    const raw = peerVolumeByUserId[storageKey]
-    return normalizeRemotePlaybackVolume(raw) / 100
+    return getRemotePlaybackVolume(peerVolumeByUserId, kind === 'screen' ? 'screen' : 'voice', volumeKey) / 100
   }, [peerVolumeByUserId, resolvePeerVolumeKey])
+
+  const disposeRemoteVoicePlaybackGraph = useCallback((playbackKey: string) => {
+    const graph = remoteVoicePlaybackGraphsRef.current.get(playbackKey)
+    if (!graph) return
+    graph.source.disconnect()
+    graph.gain.disconnect()
+    graph.limiter.disconnect()
+    graph.destination.disconnect()
+    graph.destination.stream.getTracks().forEach((track) => track.stop())
+    remoteVoicePlaybackGraphsRef.current.delete(playbackKey)
+  }, [])
+
+  const getRemoteVoiceAudioContext = useCallback((): AudioContext | null => {
+    if (remoteVoiceAudioContextRef.current?.state !== 'closed') return remoteVoiceAudioContextRef.current
+    const AudioCtor = window.AudioContext
+      || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!AudioCtor) return null
+    try {
+      const context = new AudioCtor()
+      remoteVoiceAudioContextRef.current = context
+      return context
+    } catch {
+      return null
+    }
+  }, [])
+
+  const attachRemoteAudioPlaybackStream = useCallback((
+    playbackKey: string,
+    kind: RemoteAudioKind,
+    playbackStream: MediaStream,
+    trackIds: string,
+    element: VoxperyAudioElement,
+  ) => {
+    if (kind === 'screen' || playbackStream.getAudioTracks().length === 0) {
+      disposeRemoteVoicePlaybackGraph(playbackKey)
+      element.srcObject = playbackStream
+      element.__voxpery_trackIds = trackIds
+      return
+    }
+
+    const current = remoteVoicePlaybackGraphsRef.current.get(playbackKey)
+    if (current?.trackIds === trackIds) {
+      if (element.srcObject !== current.destination.stream) element.srcObject = current.destination.stream
+      element.__voxpery_trackIds = trackIds
+      return
+    }
+
+    disposeRemoteVoicePlaybackGraph(playbackKey)
+    const context = getRemoteVoiceAudioContext()
+    if (!context) {
+      element.srcObject = playbackStream
+      element.__voxpery_trackIds = trackIds
+      return
+    }
+
+    try {
+      // Voice amplification uses its own gain bus; stream audio stays on the direct media path.
+      const source = context.createMediaStreamSource(playbackStream)
+      const gain = context.createGain()
+      const limiter = context.createDynamicsCompressor()
+      const destination = context.createMediaStreamDestination()
+      limiter.threshold.value = -1
+      limiter.knee.value = 0
+      limiter.ratio.value = 20
+      limiter.attack.value = 0.003
+      limiter.release.value = 0.1
+      source.connect(gain)
+      gain.connect(limiter)
+      limiter.connect(destination)
+      const graph = { trackIds, source, gain, limiter, destination }
+      remoteVoicePlaybackGraphsRef.current.set(playbackKey, graph)
+      element.srcObject = destination.stream
+      element.__voxpery_trackIds = trackIds
+      if (context.state === 'suspended') void context.resume().catch(() => {})
+    } catch {
+      element.srcObject = playbackStream
+      element.__voxpery_trackIds = trackIds
+    }
+  }, [disposeRemoteVoicePlaybackGraph, getRemoteVoiceAudioContext])
 
   const ensureRemoteAudioPlayback = useCallback((peerId: string, el: HTMLAudioElement) => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -388,8 +479,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       try {
         const { peerId, kind } = parseRemoteAudioPlaybackKey(playbackKey)
         const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-        const combined = isDeafened ? 0 : global * peerFactor
-        el.volume = Math.min(1, Math.max(0, combined))
+        const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
+        if (voiceGraph) {
+          const now = voiceGraph.gain.context.currentTime
+          voiceGraph.gain.gain.cancelScheduledValues(now)
+          voiceGraph.gain.gain.setTargetAtTime(peerFactor, now, 0.015)
+          el.volume = global
+        } else {
+          el.volume = Math.min(1, Math.max(0, global * peerFactor))
+        }
         el.muted = isDeafened
       } catch {
         // ignore
@@ -402,6 +500,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     applyOutputDeviceToElements()
 
     if (deafenedRef.current) return
+    const voiceContext = remoteVoiceAudioContextRef.current
+    if (voiceContext?.state === 'suspended') void voiceContext.resume().catch(() => {})
     for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
       const stream = element.srcObject
       if (!(stream instanceof MediaStream) || stream.getAudioTracks().length === 0) continue
@@ -562,8 +662,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
         const prevTrackIds = el.__voxpery_trackIds
         if (currentTrackIds !== prevTrackIds) {
-          el.srcObject = playbackStream
-          el.__voxpery_trackIds = currentTrackIds
+          attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, el)
           void applyPreferredAudioOutputDevice(el)
         }
         el.muted = deafenedRef.current
@@ -572,17 +671,33 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         }
       }
     }
-  }, [watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+    for (const playbackKey of remoteVoicePlaybackGraphsRef.current.keys()) {
+      const { peerId } = parseRemoteAudioPlaybackKey(playbackKey)
+      if (!state.remoteStreams.has(peerId)) disposeRemoteVoicePlaybackGraph(playbackKey)
+    }
+    if (remoteVoicePlaybackGraphsRef.current.size === 0) {
+      const context = remoteVoiceAudioContextRef.current
+      if (context?.state === 'running') void context.suspend().catch(() => {})
+    }
+    applyOutputVolumeToElements(outputVolumeRef.current / 100)
+  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemoteVoicePlaybackGraph, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
+    const voicePlaybackGraphs = remoteVoicePlaybackGraphsRef.current
     return () => {
       for (const t of retryTimers.values()) {
         window.clearTimeout(t)
       }
       retryTimers.clear()
+      for (const playbackKey of voicePlaybackGraphs.keys()) {
+        disposeRemoteVoicePlaybackGraph(playbackKey)
+      }
+      const context = remoteVoiceAudioContextRef.current
+      remoteVoiceAudioContextRef.current = null
+      if (context && context.state !== 'closed') void context.close().catch(() => {})
     }
-  }, [])
+  }, [disposeRemoteVoicePlaybackGraph])
 
   const showActiveCallBar = !!(state.joinedChannelId || state.localStream || state.isJoining)
   const channelParticipants = useMemo(() => {
@@ -1238,9 +1353,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               ))}
               {remoteVideoTrackEntries.map(({ peerId, track, label, kind }) => {
                 const volumeKey = resolvePeerVolumeKey(peerId)
-                const screenVolumeKey = `screen:${volumeKey}`
-                const currentVol = normalizeRemotePlaybackVolume(
-                  kind === 'screen' ? peerVolumeByUserId[screenVolumeKey] : peerVolumeByUserId[volumeKey],
+                const screenVolumeKey = remotePlaybackVolumeKey('screen', volumeKey)
+                const currentVol = getRemotePlaybackVolume(
+                  peerVolumeByUserId,
+                  kind === 'screen' ? 'screen' : 'voice',
+                  volumeKey,
                 )
                 const tileKey = `${peerId}-${track.id}`
                 const owner = remoteShareOwner(peerId)
@@ -1257,30 +1374,32 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                           <div className="screen-share-volume-container">
                             <button type="button" className="screen-share-volume-btn" title={currentVol === 0 ? 'Unmute' : 'Mute'} onClick={() => {
                               const isMuted = currentVol === 0
-                              const prevVolumeKey = `${screenVolumeKey}_prev`
                               let newVal: number
                               if (isMuted) {
-                                const savedStr = localStorage.getItem(prevVolumeKey)
-                                const savedVal = normalizeRemotePlaybackVolume(
-                                  savedStr ? Number(savedStr) : DEFAULT_REMOTE_PLAYBACK_VOLUME,
-                                )
+                                const savedVal = readPreviousScreenPlaybackVolume(volumeKey)
                                 newVal = savedVal > 0 ? savedVal : DEFAULT_REMOTE_PLAYBACK_VOLUME
                               } else {
-                                localStorage.setItem(prevVolumeKey, String(currentVol))
+                                writePreviousScreenPlaybackVolume(volumeKey, currentVol)
                                 newVal = 0
                               }
-                              const next = writeRemotePlaybackVolumes({ ...peerVolumeByUserId, [screenVolumeKey]: newVal })
+                              const next = writeRemotePlaybackVolumes({
+                                ...readRemotePlaybackVolumes(),
+                                [screenVolumeKey]: newVal,
+                              })
                               setPeerVolumeByUserId(next)
-                              applyOutputVolumeToElements(outputVolumeRef.current / 100)
+                              window.dispatchEvent(new CustomEvent(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT))
                             }}>
                               {currentVol === 0 ? <VolumeX size={16} /> : <Volume2 size={16} />}
                             </button>
                             <div className="screen-share-volume-slider-wrap">
                               <input type="range" min={0} max={100} value={currentVol} className="screen-share-volume-slider" title={`Volume: ${currentVol}%`} onChange={(e) => {
-                                const val = normalizeRemotePlaybackVolume(Number(e.target.value))
-                                const next = writeRemotePlaybackVolumes({ ...peerVolumeByUserId, [screenVolumeKey]: val })
+                                const val = normalizeRemoteScreenPlaybackVolume(Number(e.target.value))
+                                const next = writeRemotePlaybackVolumes({
+                                  ...readRemotePlaybackVolumes(),
+                                  [screenVolumeKey]: val,
+                                })
                                 setPeerVolumeByUserId(next)
-                                applyOutputVolumeToElements(outputVolumeRef.current / 100)
+                                window.dispatchEvent(new CustomEvent(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT))
                               }} />
                               <span className="screen-share-volume-value">{currentVol}%</span>
                             </div>
@@ -1331,13 +1450,18 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                           const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
                           const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
                           if (audioEl.__voxpery_trackIds !== currentTrackIds) {
-                            audioEl.srcObject = playbackStream
-                            audioEl.__voxpery_trackIds = currentTrackIds
+                            attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
                           }
                           void applyPreferredAudioOutputDevice(audioEl)
                           const shouldMute = deafenedRef.current
                           const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-                          const vol = Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
+                          const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
+                          if (voiceGraph) {
+                            voiceGraph.gain.gain.value = peerFactor
+                          }
+                          const vol = voiceGraph
+                            ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
+                            : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
                           try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
                           audioEl.muted = shouldMute
                           if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -4,6 +4,7 @@ import type { Channel, MemberInfo, Server } from '../api'
 import { useAppStore } from '../stores/app'
 import { useAuthStore } from '../stores/auth'
 import { useSocketStore } from '../stores/socket'
+import { getRemotePlaybackVolume, readRemotePlaybackVolumes, writeRemotePlaybackVolumes } from '../webrtc/remotePlaybackVolume'
 import ChannelSidebar from './ChannelSidebar'
 
 const server: Server = {
@@ -85,6 +86,30 @@ describe('ChannelSidebar voice media presence', () => {
         expect(screen.getByLabelText(`${remoteMember.username} camera on`)).toBeVisible()
         expect(screen.getByLabelText(`${remoteMember.username} screen sharing`)).toHaveTextContent('LIVE')
         expect(useAppStore.getState().joinedVoiceChannelId).toBeNull()
+    })
+
+    it('stores Discord-style user volume independently up to 200 percent', () => {
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            members: [remoteMember],
+            voiceStates: { [remoteMember.user_id]: voiceChannel.id },
+            voiceStateServerIds: { [remoteMember.user_id]: server.id },
+        })
+
+        render(<ChannelSidebar channelCategories={['Voice']} />)
+        // Simulate a stream mute written after the sidebar captured its initial volume state.
+        writeRemotePlaybackVolumes({ 'screen:remote-1': 0 })
+        fireEvent.contextMenu(screen.getByText(remoteMember.username))
+
+        const slider = screen.getByRole('slider')
+        expect(slider).toHaveAttribute('max', '200')
+        fireEvent.change(slider, { target: { value: '200' } })
+
+        const volumes = readRemotePlaybackVolumes()
+        expect(getRemotePlaybackVolume(volumes, 'voice', remoteMember.user_id)).toBe(200)
+        expect(getRemotePlaybackVolume(volumes, 'screen', remoteMember.user_id)).toBe(0)
     })
 
     it('offers compact, permission-aware channel creation controls', () => {

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -10,8 +10,11 @@ import { preloadRnnoiseWorklet } from '../webrtc/rnnoise'
 import { formatBadgeCount } from '../formatUnreadBadgeCount'
 import { formatVoiceChannelDuration } from '../voiceChannelDuration'
 import {
-    normalizeRemotePlaybackVolume,
+    getRemotePlaybackVolume,
+    MAX_REMOTE_VOICE_PLAYBACK_VOLUME,
+    normalizeRemoteVoicePlaybackVolume,
     readRemotePlaybackVolumes,
+    remotePlaybackVolumeKey,
     REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT,
     writeRemotePlaybackVolumes,
 } from '../webrtc/remotePlaybackVolume'
@@ -213,13 +216,20 @@ export default function ChannelSidebar({
     }, [voiceChannelActiveSince])
 
     const savePeerVolume = (userId: string, volume: number) => {
+        const current = readRemotePlaybackVolumes()
         const next = writeRemotePlaybackVolumes({
-            ...peerVolumeByUserId,
-            [userId]: normalizeRemotePlaybackVolume(volume),
+            ...current,
+            [remotePlaybackVolumeKey('voice', userId)]: normalizeRemoteVoicePlaybackVolume(volume),
         })
         setPeerVolumeByUserId(next)
         window.dispatchEvent(new CustomEvent(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT))
     }
+
+    useEffect(() => {
+        const syncPeerVolumes = () => setPeerVolumeByUserId(readRemotePlaybackVolumes())
+        window.addEventListener(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT, syncPeerVolumes)
+        return () => window.removeEventListener(REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT, syncPeerVolumes)
+    }, [])
 
     const handleJoinVoice = async (id: string) => {
         closeMobileSidebar()
@@ -784,7 +794,7 @@ export default function ChannelSidebar({
 
             {participantMenu && (() => {
                 const isSelf = participantMenu.userId === user?.id
-                const currentVolume = normalizeRemotePlaybackVolume(peerVolumeByUserId[participantMenu.userId])
+                const currentVolume = getRemotePlaybackVolume(peerVolumeByUserId, 'voice', participantMenu.userId)
                 const targetVoice = voiceControls[participantMenu.userId] ?? {
                     muted: false,
                     deafened: false,
@@ -877,7 +887,7 @@ export default function ChannelSidebar({
                         <div className="server-context-menu-item member-volume-menu-control">
                             <div className="member-volume-menu-section-label">
                                 <Volume2 size={12} />
-                                Local volume
+                                User Volume
                             </div>
                             <div className="member-volume-menu-section-hint">Only affects what you hear</div>
                             <div className="member-volume-menu-label">
@@ -886,7 +896,7 @@ export default function ChannelSidebar({
                             <input
                                 type="range"
                                 min={0}
-                                max={100}
+                                max={MAX_REMOTE_VOICE_PLAYBACK_VOLUME}
                                 step={5}
                                 value={currentVolume}
                                 onChange={(e) => savePeerVolume(participantMenu.userId, Number(e.target.value))}

--- a/apps/web/src/webrtc/remoteMediaControls.test.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.test.ts
@@ -3,6 +3,7 @@ import {
   getRemoteMicrophoneAudioTracks,
   getRemoteScreenShareAudioTracks,
   isScreenShareAudioTrack,
+  markRemoteAudioTrackSource,
   remoteMediaVisibilityKey,
 } from './remoteMediaControls'
 
@@ -20,7 +21,13 @@ describe('remote media controls', () => {
   })
 
   it('detects Voxpery screen share audio tracks', () => {
-    expect(isScreenShareAudioTrack(audioTrack())).toBe(false)
+    const voice = audioTrack()
+    const screen = audioTrack()
+    markRemoteAudioTrackSource(voice, 'voice')
+    markRemoteAudioTrackSource(screen, 'screen')
+
+    expect(isScreenShareAudioTrack(voice)).toBe(false)
+    expect(isScreenShareAudioTrack(screen)).toBe(true)
     expect(isScreenShareAudioTrack(audioTrack(true))).toBe(true)
   })
 
@@ -35,7 +42,9 @@ describe('remote media controls', () => {
 
   it('splits microphone and screen share audio for independent playback controls', () => {
     const mic = audioTrack()
-    const screen = audioTrack(true)
+    const screen = audioTrack()
+    markRemoteAudioTrackSource(mic, 'voice')
+    markRemoteAudioTrackSource(screen, 'screen')
     const source = { getAudioTracks: () => [mic, screen] } as unknown as MediaStream
 
     expect(getRemoteMicrophoneAudioTracks(source)).toEqual([mic])

--- a/apps/web/src/webrtc/remoteMediaControls.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.ts
@@ -2,6 +2,7 @@ export type RemoteMediaKind = 'camera' | 'screen'
 
 export interface VoxperyRemoteMediaTrack extends MediaStreamTrack {
   __voxpery_isScreenShareAudio?: boolean
+  __voxpery_audioSource?: 'voice' | 'screen'
 }
 
 export function remoteMediaVisibilityKey(channelId: string, peerId: string, kind: RemoteMediaKind): string {
@@ -9,7 +10,15 @@ export function remoteMediaVisibilityKey(channelId: string, peerId: string, kind
 }
 
 export function isScreenShareAudioTrack(track: MediaStreamTrack): boolean {
-  return !!(track as VoxperyRemoteMediaTrack).__voxpery_isScreenShareAudio
+  const remoteTrack = track as VoxperyRemoteMediaTrack
+  return remoteTrack.__voxpery_audioSource === 'screen' || !!remoteTrack.__voxpery_isScreenShareAudio
+}
+
+export function markRemoteAudioTrackSource(track: MediaStreamTrack, source: 'voice' | 'screen'): void {
+  Object.defineProperties(track, {
+    __voxpery_audioSource: { value: source, writable: true, configurable: true },
+    __voxpery_isScreenShareAudio: { value: source === 'screen', writable: true, configurable: true },
+  })
 }
 
 export function getRemoteAudioPlaybackTracks(stream: MediaStream, includeScreenShareAudio: boolean): MediaStreamTrack[] {

--- a/apps/web/src/webrtc/remotePlaybackVolume.test.ts
+++ b/apps/web/src/webrtc/remotePlaybackVolume.test.ts
@@ -1,42 +1,81 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getRemotePlaybackVolume,
+  normalizeRemoteScreenPlaybackVolume,
   normalizeRemotePlaybackVolume,
+  normalizeRemoteVoicePlaybackVolume,
   parseRemotePlaybackVolumes,
+  readPreviousScreenPlaybackVolume,
   readRemotePlaybackVolumes,
   REMOTE_PLAYBACK_VOLUME_STORAGE_KEY,
+  remotePlaybackVolumeKey,
+  writePreviousScreenPlaybackVolume,
   writeRemotePlaybackVolumes,
 } from './remotePlaybackVolume'
 
 describe('remote playback volume', () => {
-  it('keeps playback in the distortion-safe media element range', () => {
+  it('keeps voice and screen playback in their independent ranges', () => {
     expect(normalizeRemotePlaybackVolume(-20)).toBe(0)
-    expect(normalizeRemotePlaybackVolume(65.6)).toBe(66)
-    expect(normalizeRemotePlaybackVolume(100)).toBe(100)
-    expect(normalizeRemotePlaybackVolume(200)).toBe(100)
+    expect(normalizeRemoteVoicePlaybackVolume(65.6)).toBe(66)
+    expect(normalizeRemoteVoicePlaybackVolume(200)).toBe(200)
+    expect(normalizeRemoteVoicePlaybackVolume(250)).toBe(200)
+    expect(normalizeRemoteScreenPlaybackVolume(200)).toBe(100)
   })
 
-  it('sanitizes saved peer and screen-share volumes', () => {
+  it('migrates legacy peer keys and sanitizes each source independently', () => {
     expect(parseRemotePlaybackVolumes(JSON.stringify({
       peer: 150,
-      'screen:peer': 80,
+      'voice:other': 175,
+      'screen:peer': 180,
       invalid: 'loud',
     }))).toEqual({
-      peer: 100,
-      'screen:peer': 80,
+      'voice:peer': 150,
+      'voice:other': 175,
+      'screen:peer': 100,
     })
   })
 
-  it('migrates legacy amplified values in storage', () => {
+  it('persists user and stream volume without either value changing the other', () => {
     const storage = window.localStorage
     storage.clear()
-    storage.setItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY, JSON.stringify({ peer: 200 }))
+    storage.setItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY, JSON.stringify({ peer: 125, 'screen:peer': 0 }))
 
-    expect(readRemotePlaybackVolumes(storage)).toEqual({ peer: 100 })
-    expect(storage.getItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY)).toBe('{"peer":100}')
+    expect(readRemotePlaybackVolumes(storage)).toEqual({ 'voice:peer': 125, 'screen:peer': 0 })
+    expect(storage.getItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY)).toBe('{"voice:peer":125,"screen:peer":0}')
 
-    expect(writeRemotePlaybackVolumes({ peer: 125, 'screen:peer': 40 }, storage)).toEqual({
-      peer: 100,
-      'screen:peer': 40,
-    })
+    const voiceChanged = writeRemotePlaybackVolumes({
+      ...readRemotePlaybackVolumes(storage),
+      [remotePlaybackVolumeKey('voice', 'peer')]: 200,
+    }, storage)
+    expect(getRemotePlaybackVolume(voiceChanged, 'voice', 'peer')).toBe(200)
+    expect(getRemotePlaybackVolume(voiceChanged, 'screen', 'peer')).toBe(0)
+
+    const streamChanged = writeRemotePlaybackVolumes({
+      ...voiceChanged,
+      [remotePlaybackVolumeKey('screen', 'peer')]: 25,
+    }, storage)
+    expect(getRemotePlaybackVolume(streamChanged, 'voice', 'peer')).toBe(200)
+    expect(getRemotePlaybackVolume(streamChanged, 'screen', 'peer')).toBe(25)
+
+    const voiceMuted = writeRemotePlaybackVolumes({
+      ...streamChanged,
+      [remotePlaybackVolumeKey('voice', 'peer')]: 0,
+    }, storage)
+    expect(getRemotePlaybackVolume(voiceMuted, 'voice', 'peer')).toBe(0)
+    expect(getRemotePlaybackVolume(voiceMuted, 'screen', 'peer')).toBe(25)
+  })
+
+  it('keeps the screen unmute restore value outside user volume state', () => {
+    const storage = window.localStorage
+    storage.clear()
+
+    expect(writePreviousScreenPlaybackVolume('peer', 40, storage)).toBe(40)
+    expect(readPreviousScreenPlaybackVolume('peer', storage)).toBe(40)
+
+    writeRemotePlaybackVolumes({
+      'voice:peer': 200,
+      'screen:peer': 0,
+    }, storage)
+    expect(readPreviousScreenPlaybackVolume('peer', storage)).toBe(40)
   })
 })

--- a/apps/web/src/webrtc/remotePlaybackVolume.ts
+++ b/apps/web/src/webrtc/remotePlaybackVolume.ts
@@ -1,14 +1,43 @@
 export const REMOTE_PLAYBACK_VOLUME_STORAGE_KEY = 'voxpery-voice-peer-volume'
+export const REMOTE_SCREEN_PREVIOUS_VOLUME_STORAGE_KEY = 'voxpery-screen-peer-previous-volume'
 export const REMOTE_PLAYBACK_VOLUME_CHANGED_EVENT = 'voxpery-voice-peer-volume-changed'
 export const DEFAULT_REMOTE_PLAYBACK_VOLUME = 100
-export const MAX_REMOTE_PLAYBACK_VOLUME = 100
+export const MAX_REMOTE_VOICE_PLAYBACK_VOLUME = 200
+export const MAX_REMOTE_SCREEN_PLAYBACK_VOLUME = 100
+
+export type RemotePlaybackVolumeKind = 'voice' | 'screen'
+
+export function remotePlaybackVolumeKey(kind: RemotePlaybackVolumeKind, userId: string): string {
+  return `${kind}:${userId}`
+}
 
 export function normalizeRemotePlaybackVolume(
   value: unknown,
   fallback = DEFAULT_REMOTE_PLAYBACK_VOLUME,
+  maximum = MAX_REMOTE_SCREEN_PLAYBACK_VOLUME,
 ): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
-  return Math.min(MAX_REMOTE_PLAYBACK_VOLUME, Math.max(0, Math.round(value)))
+  return Math.min(maximum, Math.max(0, Math.round(value)))
+}
+
+export function normalizeRemoteVoicePlaybackVolume(
+  value: unknown,
+  fallback = DEFAULT_REMOTE_PLAYBACK_VOLUME,
+): number {
+  return normalizeRemotePlaybackVolume(value, fallback, MAX_REMOTE_VOICE_PLAYBACK_VOLUME)
+}
+
+export function normalizeRemoteScreenPlaybackVolume(
+  value: unknown,
+  fallback = DEFAULT_REMOTE_PLAYBACK_VOLUME,
+): number {
+  return normalizeRemotePlaybackVolume(value, fallback, MAX_REMOTE_SCREEN_PLAYBACK_VOLUME)
+}
+
+function normalizeStoredVolume(key: string, value: number): [string, number] {
+  if (key.startsWith('screen:')) return [key, normalizeRemoteScreenPlaybackVolume(value)]
+  if (key.startsWith('voice:')) return [key, normalizeRemoteVoicePlaybackVolume(value)]
+  return [remotePlaybackVolumeKey('voice', key), normalizeRemoteVoicePlaybackVolume(value)]
 }
 
 export function parseRemotePlaybackVolumes(raw: string | null): Record<string, number> {
@@ -20,7 +49,8 @@ export function parseRemotePlaybackVolumes(raw: string | null): Record<string, n
     const volumes: Record<string, number> = {}
     for (const [key, value] of Object.entries(parsed)) {
       if (typeof value !== 'number' || !Number.isFinite(value)) continue
-      volumes[key] = normalizeRemotePlaybackVolume(value)
+      const [normalizedKey, normalizedValue] = normalizeStoredVolume(key, value)
+      volumes[normalizedKey] = normalizedValue
     }
     return volumes
   } catch {
@@ -42,8 +72,65 @@ export function writeRemotePlaybackVolumes(
   storage: Storage = localStorage,
 ): Record<string, number> {
   const normalized = Object.fromEntries(
-    Object.entries(volumes).map(([key, value]) => [key, normalizeRemotePlaybackVolume(value)]),
+    Object.entries(volumes).map(([key, value]) => normalizeStoredVolume(key, value)),
   )
   storage.setItem(REMOTE_PLAYBACK_VOLUME_STORAGE_KEY, JSON.stringify(normalized))
+  return normalized
+}
+
+export function getRemotePlaybackVolume(
+  volumes: Record<string, number>,
+  kind: RemotePlaybackVolumeKind,
+  userId: string,
+): number {
+  const value = volumes[remotePlaybackVolumeKey(kind, userId)]
+  return kind === 'voice'
+    ? normalizeRemoteVoicePlaybackVolume(value)
+    : normalizeRemoteScreenPlaybackVolume(value)
+}
+
+function parsePreviousScreenVolumes(raw: string | null): Record<string, number> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    return Object.fromEntries(Object.entries(parsed).flatMap(([userId, value]) => {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return []
+      const normalized = normalizeRemoteScreenPlaybackVolume(value)
+      return normalized > 0 ? [[userId, normalized]] : []
+    }))
+  } catch {
+    return {}
+  }
+}
+
+export function readPreviousScreenPlaybackVolume(
+  userId: string,
+  storage: Storage = localStorage,
+): number {
+  const volumes = parsePreviousScreenVolumes(storage.getItem(REMOTE_SCREEN_PREVIOUS_VOLUME_STORAGE_KEY))
+  const saved = volumes[userId]
+  if (saved !== undefined) return saved
+
+  const legacyKey = `${remotePlaybackVolumeKey('screen', userId)}_prev`
+  const legacyValue = Number(storage.getItem(legacyKey))
+  storage.removeItem(legacyKey)
+  if (!Number.isFinite(legacyValue) || legacyValue <= 0) return DEFAULT_REMOTE_PLAYBACK_VOLUME
+
+  const normalized = normalizeRemoteScreenPlaybackVolume(legacyValue)
+  writePreviousScreenPlaybackVolume(userId, normalized, storage)
+  return normalized
+}
+
+export function writePreviousScreenPlaybackVolume(
+  userId: string,
+  volume: number,
+  storage: Storage = localStorage,
+): number {
+  const normalized = normalizeRemoteScreenPlaybackVolume(volume)
+  if (normalized <= 0) return DEFAULT_REMOTE_PLAYBACK_VOLUME
+  const volumes = parsePreviousScreenVolumes(storage.getItem(REMOTE_SCREEN_PREVIOUS_VOLUME_STORAGE_KEY))
+  volumes[userId] = normalized
+  storage.setItem(REMOTE_SCREEN_PREVIOUS_VOLUME_STORAGE_KEY, JSON.stringify(volumes))
   return normalized
 }

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -30,7 +30,7 @@ import {
   shouldRebuildSuppressionPipeline,
 } from './voiceInputProfile'
 import { updateVoiceDiagnostics } from './voiceDiagnostics'
-import type { RemoteMediaKind } from './remoteMediaControls'
+import { markRemoteAudioTrackSource, type RemoteMediaKind } from './remoteMediaControls'
 import { reportObservabilityEvent } from '../observability'
 import { associateLiveKitVideoTrack } from './livekitVideoAttachment'
 
@@ -938,10 +938,13 @@ export function useLiveKitVoice() {
             Object.defineProperty(mediaTrack, '__voxpery_isScreenShare', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.add(mediaTrack.id)
           } else if (pub.source === Track.Source.ScreenShareAudio) {
-            Object.defineProperty(mediaTrack, '__voxpery_isScreenShareAudio', { value: true, writable: true, configurable: true })
+            markRemoteAudioTrackSource(mediaTrack, 'screen')
           } else if (pub.source === Track.Source.Camera) {
             Object.defineProperty(mediaTrack, '__voxpery_isCamera', { value: true, writable: true, configurable: true })
             remoteScreenTrackIdsRef.current.delete(mediaTrack.id)
+          }
+          if (track.kind === Track.Kind.Audio && pub.source !== Track.Source.ScreenShareAudio) {
+            markRemoteAudioTrackSource(mediaTrack, 'voice')
           }
 
           mediaTrack.onmute = () => { syncParticipantMediaState(participant); bumpRemote() }

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -67,7 +67,9 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] User B chooses `Stop watching`; the screen tile returns to `Stream available` and its screen video/audio publications unsubscribe for that viewer.
 - [ ] User A's normal microphone audio continues while User B is not watching the stream.
 - [ ] User B mutes or lowers the screen-share volume; only screen-share audio changes and User A's normal microphone audio remains audible.
-- [ ] Per-user microphone and screen-share volume controls stay within 0-100%; repeated mute/unmute and 0/100 transitions do not cut out, clip, or change the selected output device.
+- [ ] Per-user microphone volume stays within 0-200% and screen-share volume stays within 0-100%; repeated mute/unmute and boundary transitions do not cut out, clip, or change the selected output device.
+- [ ] With stream audio muted at 0%, changing User Volume through 0/25/100/200% never unmutes the stream; with User Volume at 0%, changing Stream Volume through 0/25/100% never changes microphone playback.
+- [ ] Voice and stream volume independence survives stop/watch, reconnect, reload, and desktop relaunch, including users with duplicate display names.
 - [ ] User B chooses `Watch stream` again and screen video/audio return without replaying the publisher start cue.
 - [ ] Minimizing or hiding User B's Voxpery window pauses incoming camera and watched screen video/audio traffic while microphone audio continues; restoring the window resumes only explicitly watched media without replaying start cues.
 - [ ] User A repeatedly enters and leaves fullscreen on the local screen preview; capture stays live, no green/frozen frame appears, and User B's remote stream does not restart.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -258,7 +258,9 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - A remote screen share appears first as a compact `Stream available` tile. `Watch stream` subscribes that viewer to both `ScreenShare` and `ScreenShareAudio`; `Stop watching` unsubscribes both while leaving microphone audio untouched.
 - Viewer subscription state is local to the current voice session, survives visibility changes and LiveKit reconnects, and resets when the share ends, the participant disconnects, or the viewer leaves voice.
 - Unwatched shares produce no incoming screen video or shared-audio traffic. Hiding Voxpery pauses watched screen video, while watched shared audio remains subscribed so background playback does not cut out.
-- The screen-share volume slider controls only `Track.Source.ScreenShareAudio`; the participant's normal microphone audio keeps using the peer volume control.
+- `User Volume` controls only the participant's `Track.Source.Microphone` audio from 0-200%. Values above 100% use a per-user Web Audio gain and limiter path instead of being clamped by `HTMLMediaElement.volume`.
+- `Stream Volume` and stream mute control only `Track.Source.ScreenShareAudio` from 0-100%. Voice and stream values, mute restore values, and persisted keys are independent, so changing one source never unmutes or changes the other.
+- Global output volume and deafen remain top-level playback controls for both sources without rewriting either per-source preference.
 - When the Voxpery window is hidden or minimized, camera and watched screen video subscriptions pause while microphone and explicitly watched screen-share audio continue. Video resumes when the app becomes visible, without replaying media-start cues.
 - Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, and remote playback without changing per-user volume settings.
 


### PR DESCRIPTION
## Summary

- separate per-user microphone volume from screen-share audio volume
- support Discord-style User Volume from 0-200% with a dedicated Web Audio gain and limiter path
- keep Stream Volume and mute independently constrained to 0-100%
- migrate legacy playback settings to explicit `voice:<userId>` and `screen:<userId>` keys
- prevent stale UI state from restoring or unmuting screen-share audio
- preserve independent volume state across reloads, reconnects, and stream watch cycles
- explicitly classify LiveKit microphone and screen-share audio tracks

## Validation

- `npm run lint`
- `npm run test:run` — 269 passed
- `npm run test:e2e:ui-smoke` — 39 passed
- `npm run build`