### PR TITLE
fix: preserve stream audio while deafened

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -326,6 +326,26 @@ describe('ActiveCallBar regressions', () => {
     expect(voice.leaveVoice).toHaveBeenCalledOnce()
   })
 
+  it('deafens remote microphones without muting watched screen audio', () => {
+    const micTrack = mediaTrack('audio', 'peer-mic')
+    const screenAudioTrack = mediaTrack('audio', 'peer-screen-audio')
+    markRemoteAudioTrackSource(micTrack, 'voice')
+    markRemoteAudioTrackSource(screenAudioTrack, 'screen')
+
+    const { container } = renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', new MediaStream([micTrack, screenAudioTrack])]]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+
+    const [voiceAudio, screenAudio] = Array.from(container.querySelectorAll('audio'))
+    if (!voiceAudio || !screenAudio) throw new Error('Remote audio playback elements were not rendered.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
+
+    expect(voiceAudio.muted).toBe(true)
+    expect(screenAudio.muted).toBe(false)
+  })
+
   it('uses the configured shortcut while the web tab is focused', () => {
     localStorage.setItem(GLOBAL_MUTE_SHORTCUT_STORAGE_KEY, 'CommandOrControl+Shift+M')
     const localMic = mediaTrack('audio', 'local-mic')

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -22,7 +22,13 @@ import {
 import { ROUTES } from '../routes'
 import { attachMediaStreamPreview } from '../mediaStreamPreview'
 import { resolveAvatarUrl } from '../api'
-import { createRemoteAudioKindPlaybackStream, remoteMediaVisibilityKey, type RemoteMediaKind } from '../webrtc/remoteMediaControls'
+import {
+  createRemoteAudioKindPlaybackStream,
+  remoteMediaVisibilityKey,
+  shouldMuteRemoteAudioPlayback,
+  type RemoteAudioKind,
+  type RemoteMediaKind,
+} from '../webrtc/remoteMediaControls'
 import {
   attachRemoteVideoElement,
   type VoxperyMediaStreamTrack,
@@ -63,8 +69,6 @@ interface RemoteVoicePlaybackGraph {
 interface VoxperyHTMLDivElement extends HTMLDivElement {
   _idleTimeout?: ReturnType<typeof setTimeout>
 }
-
-type RemoteAudioKind = 'mic' | 'screen'
 
 type RemoteMediaPlaceholder = {
   key: string
@@ -419,35 +423,36 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   }, [disposeRemoteVoicePlaybackGraph, getRemoteVoiceAudioContext])
 
-  const ensureRemoteAudioPlayback = useCallback((peerId: string, el: HTMLAudioElement) => {
+  const ensureRemoteAudioPlayback = useCallback((playbackKey: string, el: HTMLAudioElement) => {
     const retryTimers = remoteAudioRetryTimerRef.current
     const clearRetry = () => {
-      const t = retryTimers.get(peerId)
+      const t = retryTimers.get(playbackKey)
       if (t != null) {
         window.clearTimeout(t)
-        retryTimers.delete(peerId)
+        retryTimers.delete(playbackKey)
       }
     }
     const attempt = () => {
       // Check if element is still available and not muted/deafened
       if (!el || !el.isConnected) {
-        console.warn('[ensureRemoteAudioPlayback] Element not connected for peer', peerId)
+        console.warn('[ensureRemoteAudioPlayback] Element not connected for playback', playbackKey)
         clearRetry()
         return
       }
-      if (el.muted || deafenedRef.current) {
+      const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
+      if (el.muted || shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) {
         clearRetry()
         return
       }
       if (!el.srcObject) {
-        console.warn('[ensureRemoteAudioPlayback] No srcObject for peer', peerId)
+        console.warn('[ensureRemoteAudioPlayback] No srcObject for playback', playbackKey)
         clearRetry()
         return
       }
 
       const p = el.play()
       if (!p || typeof p.catch !== 'function') {
-        console.warn('[ensureRemoteAudioPlayback] play() did not return a promise for peer', peerId)
+        console.warn('[ensureRemoteAudioPlayback] play() did not return a promise for playback', playbackKey)
         clearRetry()
         return
       }
@@ -455,16 +460,16 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         clearRetry()
       }).catch(() => {
         // Suppress expected "The play() request was interrupted by a new load request" warnings
-        // console.warn('[ensureRemoteAudioPlayback] Failed to play for peer', peerId, ':', err.message)
+        // Expected interruptions are retried below without surfacing a noisy console warning.
         clearRetry()
         const retry = window.setTimeout(() => {
           attempt()
         }, 500) // Increased delay to 500ms for more stable retry
-        retryTimers.set(peerId, retry)
+        retryTimers.set(playbackKey, retry)
       })
     }
     attempt()
-  }, [])
+  }, [parseRemoteAudioPlaybackKey])
 
   const applyOutputDeviceToElements = useCallback(() => {
     for (const el of remoteAudioRefsRef.current.values()) {
@@ -488,7 +493,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         } else {
           el.volume = Math.min(1, Math.max(0, global * peerFactor))
         }
-        el.muted = isDeafened
+        el.muted = shouldMuteRemoteAudioPlayback(kind, isDeafened)
       } catch {
         // ignore
       }
@@ -499,15 +504,16 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
     applyOutputDeviceToElements()
 
-    if (deafenedRef.current) return
     const voiceContext = remoteVoiceAudioContextRef.current
-    if (voiceContext?.state === 'suspended') void voiceContext.resume().catch(() => {})
+    if (!deafenedRef.current && voiceContext?.state === 'suspended') void voiceContext.resume().catch(() => {})
     for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
+      const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
+      if (shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) continue
       const stream = element.srcObject
       if (!(stream instanceof MediaStream) || stream.getAudioTracks().length === 0) continue
       ensureRemoteAudioPlayback(playbackKey, element)
     }
-  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback])
+  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback, parseRemoteAudioPlaybackKey])
 
   useEffect(() => {
     const recoverWhenVisible = () => {
@@ -665,8 +671,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
           attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, el)
           void applyPreferredAudioOutputDevice(el)
         }
-        el.muted = deafenedRef.current
-        if (!deafenedRef.current && currentTrackIds) {
+        const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
+        el.muted = shouldMute
+        if (!shouldMute && currentTrackIds) {
           ensureRemoteAudioPlayback(playbackKey, el)
         }
       }
@@ -1453,7 +1460,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                             attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
                           }
                           void applyPreferredAudioOutputDevice(audioEl)
-                          const shouldMute = deafenedRef.current
+                          const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
                           const peerFactor = getPlaybackVolumeFactor(peerId, kind)
                           const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
                           if (voiceGraph) {

--- a/apps/web/src/webrtc/remoteMediaControls.test.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.test.ts
@@ -5,6 +5,7 @@ import {
   isScreenShareAudioTrack,
   markRemoteAudioTrackSource,
   remoteMediaVisibilityKey,
+  shouldMuteRemoteAudioPlayback,
 } from './remoteMediaControls'
 
 function audioTrack(screenShareAudio = false) {
@@ -49,5 +50,12 @@ describe('remote media controls', () => {
 
     expect(getRemoteMicrophoneAudioTracks(source)).toEqual([mic])
     expect(getRemoteScreenShareAudioTracks(source)).toEqual([screen])
+  })
+
+  it('keeps watched screen audio audible while voice playback is deafened', () => {
+    expect(shouldMuteRemoteAudioPlayback('mic', true)).toBe(true)
+    expect(shouldMuteRemoteAudioPlayback('screen', true)).toBe(false)
+    expect(shouldMuteRemoteAudioPlayback('mic', false)).toBe(false)
+    expect(shouldMuteRemoteAudioPlayback('screen', false)).toBe(false)
   })
 })

--- a/apps/web/src/webrtc/remoteMediaControls.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.ts
@@ -1,4 +1,5 @@
 export type RemoteMediaKind = 'camera' | 'screen'
+export type RemoteAudioKind = 'mic' | 'screen'
 
 export interface VoxperyRemoteMediaTrack extends MediaStreamTrack {
   __voxpery_isScreenShareAudio?: boolean
@@ -44,9 +45,13 @@ export function getRemoteScreenShareAudioTracks(stream: MediaStream): MediaStrea
     .filter((track) => isScreenShareAudioTrack(track))
 }
 
-export function createRemoteAudioKindPlaybackStream(stream: MediaStream, kind: 'mic' | 'screen'): MediaStream {
+export function createRemoteAudioKindPlaybackStream(stream: MediaStream, kind: RemoteAudioKind): MediaStream {
   const tracks = kind === 'screen'
     ? getRemoteScreenShareAudioTracks(stream)
     : getRemoteMicrophoneAudioTracks(stream)
   return new MediaStream(tracks)
+}
+
+export function shouldMuteRemoteAudioPlayback(kind: RemoteAudioKind, voiceDeafened: boolean): boolean {
+  return kind === 'mic' && voiceDeafened
 }

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -24,7 +24,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] In desktop builds, the configured mute shortcut also works while Voxpery is unfocused, minimized, or running in the tray.
 - [ ] On a clean macOS install, the first voice join prompts for microphone access and Voxpery appears in Privacy & Security -> Microphone after the decision.
 - [ ] Rebinding or clearing the mute shortcut takes effect immediately; a conflicting desktop shortcut shows an error without losing the previous working binding.
-- [ ] Deafen stops remote audio playback and restores it when disabled.
+- [ ] Deafen stops remote microphone playback and restores it when disabled; watched screen-share audio continues at its independent stream volume.
 - [ ] User B leaves and User A hears a leave cue that is clearly different from the join cue.
 - [ ] Rejoining the same channel does not leave duplicate participants or stale voice controls.
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -186,7 +186,7 @@ Speaker
 
 - **Output volume**: Global 1-100%, per-peer microphone 0-100%, and per-screen-share audio 0-100%.
 - **Distortion-safe playback**: Remote media stays on the native media-element path. Legacy values above 100% are migrated to 100% so playback is not clipped or stranded on a closed Web Audio graph.
-- **Deafen**: Sets `audio.muted = true` on all remote elements
+- **Deafen**: Mutes remote microphone playback while leaving watched screen-share audio under its independent stream volume/mute controls
 - **Watch screen share**: Screen-share video and shared audio remain unsubscribed until the viewer chooses `Watch stream`; `Stop watching` removes only those viewer subscriptions while the peer's normal microphone audio remains active.
 - **Pre-join media presence**: Server members can see a camera icon and `LIVE` screen-share badge beside voice participants before joining the channel. These indicators use the server-broadcast voice control state and do not subscribe the viewer to media.
 
@@ -260,7 +260,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - Unwatched shares produce no incoming screen video or shared-audio traffic. Hiding Voxpery pauses watched screen video, while watched shared audio remains subscribed so background playback does not cut out.
 - `User Volume` controls only the participant's `Track.Source.Microphone` audio from 0-200%. Values above 100% use a per-user Web Audio gain and limiter path instead of being clamped by `HTMLMediaElement.volume`.
 - `Stream Volume` and stream mute control only `Track.Source.ScreenShareAudio` from 0-100%. Voice and stream values, mute restore values, and persisted keys are independent, so changing one source never unmutes or changes the other.
-- Global output volume and deafen remain top-level playback controls for both sources without rewriting either per-source preference.
+- Global output volume remains a top-level playback control for both sources without rewriting either per-source preference. Deafen suppresses remote microphone playback only; watched screen-share audio remains controlled by its independent stream volume and mute state.
 - When the Voxpery window is hidden or minimized, camera and watched screen video subscriptions pause while microphone and explicitly watched screen-share audio continue. Video resumes when the app becomes visible, without replaying media-start cues.
 - Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, and remote playback without changing per-user volume settings.
 


### PR DESCRIPTION
## Summary
- mute only remote microphone playback when self-deafened
- keep watched screen-share audio audible and independently controlled
- preserve screen-audio playback recovery while voice playback is deafened
- add regression coverage for source-aware deafen behavior
- update voice documentation and release smoke checks

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`