### PR TITLE
chore: prepare v0.2.8 release

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5389,7 +5389,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3149,7 +3149,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-08-16
+
+### Added
+- Added a wider expression picker with GIPHY search and trending results, persistent GIF favorites, and recent emoji, GIF, and sticker history.
+- Added automatic production deployment for published stable GitHub Releases after both immutable Docker images pass validation, while retaining manual redeploy and rollback controls.
+
+### Changed
+- Separated per-user microphone volume from per-stream shared-audio volume, with independent mute state and Discord-style ranges of 0-200% for voice and 0-100% for streams.
+- Kept explicitly watched screen-share audio playing while Voxpery is hidden or the listener is deafened, without resuming microphone playback.
+
+### Fixed
+- Reconciled LiveKit participants with sidebar voice presence and stabilized onboarding-guide visibility during server navigation.
+- Improved shared-audio continuity with Opus RED packet-loss resilience and preserved subscriptions across visibility changes and reconnects.
+- Prevented user-volume changes from muting, unmuting, or altering screen-share audio preferences.
+- Replaced transient or stale `1 ms` voice ping values with stable selected ICE-path RTT, using current WebSocket RTT while WebRTC measurements settle.
+
 ## [0.2.7] - 2026-08-14
 
 ### Fixed


### PR DESCRIPTION
## Summary
- bump web, server, and desktop metadata to `0.2.8`
- synchronize npm and Cargo lockfiles with the release version
- update Tauri desktop metadata
- document the v0.2.8 changes in the changelog

## Validation
- release version sync check
- `npm run lint`
- `npm run test:run`
- `npm run build`
- server `cargo check --locked`
- desktop `cargo check --locked`