### PR TITLE
fix: harden production release smoke

### DIFF
--- a/.github/scripts/validate-deploy-workflows.mjs
+++ b/.github/scripts/validate-deploy-workflows.mjs
@@ -33,6 +33,9 @@ requireText('production deploy', deploy, 'voxpery/voxpery-server:${IMAGE_TAG}')
 requireText('production deploy', deploy, 'voxpery/voxpery-web:${IMAGE_TAG}')
 requireText('production deploy', deploy, 'smoke:release-deploy')
 requireText('production deploy', deploy, 'SMOKE_EXPECTED_IMAGE_TAG:')
+requireText('production deploy', deploy, 'DEPLOY_PUBLIC_API_URL:')
+requireText('production deploy', deploy, 'Public API edge health OK:')
+requireText('production deploy', deploy, "SMOKE_SKIP_API_HEALTH: 'true'")
 
 if (failures.length > 0) {
   console.error('Deploy workflow validation failed:')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,11 +231,12 @@ jobs:
           DEPLOY_RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
           DEPLOY_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
           DEPLOY_GIT_REF: ${{ needs.prepare.outputs.git_ref }}
+          DEPLOY_PUBLIC_API_URL: ${{ vars.PRODUCTION_API_URL || 'https://api.voxpery.com' }}
         with:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: DEPLOY_RELEASE_CHANNEL,DEPLOY_IMAGE_TAG,DEPLOY_GIT_REF
+          envs: DEPLOY_RELEASE_CHANNEL,DEPLOY_IMAGE_TAG,DEPLOY_GIT_REF,DEPLOY_PUBLIC_API_URL
           command_timeout: 25m
           script: |
             cd ~/voxpery
@@ -314,6 +315,25 @@ jobs:
             docker image prune -f
             curl -fsS http://127.0.0.1:3001/health >/dev/null
             curl -fsS http://127.0.0.1:${WEB_PORT:-5173}/healthz >/dev/null
+
+            PUBLIC_API_URL="${DEPLOY_PUBLIC_API_URL%/}"
+            case "${PUBLIC_API_URL}" in
+              https://*) ;;
+              *)
+                echo "Refusing deploy smoke: production API URL must use HTTPS."
+                exit 1
+                ;;
+            esac
+            public_api_health="$(
+              curl --fail --silent --show-error \
+                --retry 5 --retry-delay 2 --retry-all-errors --max-time 20 \
+                "${PUBLIC_API_URL}/health"
+            )"
+            if ! printf '%s' "${public_api_health}" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"'; then
+              echo "Public API health response did not report status=ok."
+              exit 1
+            fi
+            echo "Public API edge health OK: ${PUBLIC_API_URL}/health"
             echo "Deploy complete: release_channel=${RELEASE_CHANNEL} git_ref=${GIT_REF} commit=$(git rev-parse HEAD) image_tag=${IMAGE_TAG}"
 
       - name: Setup Node
@@ -327,6 +347,7 @@ jobs:
           SMOKE_API_URL: ${{ vars.PRODUCTION_API_URL || 'https://api.voxpery.com' }}
           SMOKE_WEB_URL: ${{ vars.PRODUCTION_WEB_URL || 'https://voxpery.com' }}
           SMOKE_EXPECTED_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          SMOKE_SKIP_API_HEALTH: 'true'
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5 6; do

--- a/apps/web/scripts/release-deploy-smoke.mjs
+++ b/apps/web/scripts/release-deploy-smoke.mjs
@@ -8,6 +8,7 @@ const EXPECTED_VERSION = RAW_EXPECTED_VERSION
   : normalizeVersion(process.env.npm_package_version)
 const EXPECTED_IMAGE_TAG = (process.env.SMOKE_EXPECTED_IMAGE_TAG || `v${EXPECTED_VERSION}`).trim()
 const EXPECTED_BADGE = formatAppVersionBadge(EXPECTED_IMAGE_TAG)
+const SKIP_API_HEALTH = process.env.SMOKE_SKIP_API_HEALTH?.trim().toLowerCase() === 'true'
 
 function requiredUrl(name) {
   const value = process.env[name]?.trim()
@@ -48,7 +49,17 @@ function validateImmutableImageTag(tag) {
 
 async function getOk(url, label) {
   const res = await fetch(url, { redirect: 'manual' })
-  assert(res.ok, `${label} failed (${res.status}) at ${url}`)
+  if (!res.ok) {
+    const server = res.headers.get('server') || '<missing>'
+    const cfRay = res.headers.get('cf-ray') || '<missing>'
+    const body = (await res.clone().text().catch(() => ''))
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 240)
+    throw new Error(
+      `${label} failed (${res.status}) at ${url}; server=${server}; cf-ray=${cfRay}; body=${body || '<empty>'}`
+    )
+  }
   return res
 }
 
@@ -116,11 +127,15 @@ async function main() {
 
   validateImmutableImageTag(EXPECTED_IMAGE_TAG)
 
-  const apiHealth = await getOk(`${API_BASE}/health`, 'API health')
-  assertSecurityHeaders(apiHealth, { surface: 'api', url: `${API_BASE}/health` })
-  const apiHealthJson = await apiHealth.json().catch(() => null)
-  assert(apiHealthJson?.status === 'ok', 'API health response must be {"status":"ok"}')
-  console.log('[release-smoke] API health and security headers OK')
+  if (SKIP_API_HEALTH) {
+    console.log('[release-smoke] API edge health already verified from the deploy host')
+  } else {
+    const apiHealth = await getOk(`${API_BASE}/health`, 'API health')
+    assertSecurityHeaders(apiHealth, { surface: 'api', url: `${API_BASE}/health` })
+    const apiHealthJson = await apiHealth.json().catch(() => null)
+    assert(apiHealthJson?.status === 'ok', 'API health response must be {"status":"ok"}')
+    console.log('[release-smoke] API health and security headers OK')
+  }
 
   const webHealth = await getOk(`${WEB_BASE}/healthz`, 'web health')
   assertSecurityHeaders(webHealth, { surface: 'web', url: `${WEB_BASE}/healthz` })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Made automatic production smoke checks tolerate Cloudflare blocks against GitHub-hosted runner IPs by verifying public API health from the deploy host while retaining independent web, version, security-header, and cache validation.
+
 ## [0.2.8] - 2026-08-16
 
 ### Added

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -250,6 +250,13 @@ Release and calls the production deploy workflow. The deploy verifies that both
 the backend and frontend image tags exist before changing the server, then runs
 health, deployed-version, and cache-policy smoke checks.
 
+The deploy host performs both origin-local health checks and the authoritative
+public API edge health check. This avoids treating a Cloudflare block against a
+GitHub-hosted runner ASN as an application outage. The GitHub runner still
+validates the public web health endpoint, security headers, release version, and
+cache policy. Manual release smoke remains responsible for strict public API
+security-header validation from an independent client.
+
 Manual runs remain available for redeploys, release recovery, candidates, and
 explicit rollback operations:
 

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -41,7 +41,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
 - [ ] Stable GitHub Release publishing automatically waited for both immutable Docker images and deployed their exact shared `vX.Y.Z` tag; any intentional manual redeploy is recorded instead.
-- [ ] Release deploy guardrails verified registry presence for both images, API `/health`, web `/healthz`, immutable image tag format, cache policy, and the deployed web bundle version tag.
+- [ ] Release deploy guardrails verified registry presence for both images, deploy-host and public-edge API `/health`, web `/healthz`, immutable image tag format, cache policy, and the deployed web bundle version tag.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
 ## 3) Web Smoke Tests (mandatory)


### PR DESCRIPTION
## Summary
- verify public API edge health from the production deploy host
- avoid false deployment failures when Cloudflare blocks GitHub-hosted runner IPs
- retain public web, version, security-header, and cache validation
- include Cloudflare response details in future smoke failures
- document the updated production smoke architecture

## Validation
- deploy workflow validation
- `npm run lint`
- `npm run test:run` (280 tests)
- `npm run build`