### PR TITLE
fix: use origin health for release deploys

### DIFF
--- a/.github/scripts/validate-deploy-workflows.mjs
+++ b/.github/scripts/validate-deploy-workflows.mjs
@@ -33,8 +33,6 @@ requireText('production deploy', deploy, 'voxpery/voxpery-server:${IMAGE_TAG}')
 requireText('production deploy', deploy, 'voxpery/voxpery-web:${IMAGE_TAG}')
 requireText('production deploy', deploy, 'smoke:release-deploy')
 requireText('production deploy', deploy, 'SMOKE_EXPECTED_IMAGE_TAG:')
-requireText('production deploy', deploy, 'DEPLOY_PUBLIC_API_URL:')
-requireText('production deploy', deploy, 'Public API edge health OK:')
 requireText('production deploy', deploy, "SMOKE_SKIP_API_HEALTH: 'true'")
 
 if (failures.length > 0) {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,12 +231,11 @@ jobs:
           DEPLOY_RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
           DEPLOY_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
           DEPLOY_GIT_REF: ${{ needs.prepare.outputs.git_ref }}
-          DEPLOY_PUBLIC_API_URL: ${{ vars.PRODUCTION_API_URL || 'https://api.voxpery.com' }}
         with:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: DEPLOY_RELEASE_CHANNEL,DEPLOY_IMAGE_TAG,DEPLOY_GIT_REF,DEPLOY_PUBLIC_API_URL
+          envs: DEPLOY_RELEASE_CHANNEL,DEPLOY_IMAGE_TAG,DEPLOY_GIT_REF
           command_timeout: 25m
           script: |
             cd ~/voxpery
@@ -315,25 +314,6 @@ jobs:
             docker image prune -f
             curl -fsS http://127.0.0.1:3001/health >/dev/null
             curl -fsS http://127.0.0.1:${WEB_PORT:-5173}/healthz >/dev/null
-
-            PUBLIC_API_URL="${DEPLOY_PUBLIC_API_URL%/}"
-            case "${PUBLIC_API_URL}" in
-              https://*) ;;
-              *)
-                echo "Refusing deploy smoke: production API URL must use HTTPS."
-                exit 1
-                ;;
-            esac
-            public_api_health="$(
-              curl --fail --silent --show-error \
-                --retry 5 --retry-delay 2 --retry-all-errors --max-time 20 \
-                "${PUBLIC_API_URL}/health"
-            )"
-            if ! printf '%s' "${public_api_health}" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"'; then
-              echo "Public API health response did not report status=ok."
-              exit 1
-            fi
-            echo "Public API edge health OK: ${PUBLIC_API_URL}/health"
             echo "Deploy complete: release_channel=${RELEASE_CHANNEL} git_ref=${GIT_REF} commit=$(git rev-parse HEAD) image_tag=${IMAGE_TAG}"
 
       - name: Setup Node

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Made automatic production smoke checks tolerate Cloudflare blocks against GitHub-hosted runner IPs by verifying public API health from the deploy host while retaining independent web, version, security-header, and cache validation.
+- Made automatic production smoke checks tolerate Cloudflare blocks against CI and production-host datacenter IPs by using origin-local API health while retaining independent public web, version, security-header, and cache validation.
 
 ## [0.2.8] - 2026-08-16
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -250,12 +250,12 @@ Release and calls the production deploy workflow. The deploy verifies that both
 the backend and frontend image tags exist before changing the server, then runs
 health, deployed-version, and cache-policy smoke checks.
 
-The deploy host performs both origin-local health checks and the authoritative
-public API edge health check. This avoids treating a Cloudflare block against a
-GitHub-hosted runner ASN as an application outage. The GitHub runner still
-validates the public web health endpoint, security headers, release version, and
-cache policy. Manual release smoke remains responsible for strict public API
-security-header validation from an independent client.
+The deploy host performs authoritative origin-local API and web health checks.
+The GitHub runner validates the public web health endpoint, security headers,
+release version, and cache policy. Public API edge and security-header checks
+remain part of the independent manual release smoke because Cloudflare may
+intentionally reject requests from both GitHub-hosted runner networks and the
+production host's datacenter address.
 
 Manual runs remain available for redeploys, release recovery, candidates, and
 explicit rollback operations:

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -41,7 +41,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
 - [ ] Stable GitHub Release publishing automatically waited for both immutable Docker images and deployed their exact shared `vX.Y.Z` tag; any intentional manual redeploy is recorded instead.
-- [ ] Release deploy guardrails verified registry presence for both images, deploy-host and public-edge API `/health`, web `/healthz`, immutable image tag format, cache policy, and the deployed web bundle version tag.
+- [ ] Release deploy guardrails verified registry presence for both images, origin-local API `/health`, origin-local and public web `/healthz`, immutable image tag format, cache policy, and the deployed web bundle version tag.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
 ## 3) Web Smoke Tests (mandatory)


### PR DESCRIPTION
## Summary
- use origin-local API health as the authoritative deploy check
- avoid false failures caused by Cloudflare blocking datacenter IPs
- retain public web health, version, security-header, and cache validation
- keep independent public API validation in the manual release smoke process

## Validation
- deploy workflow validation
- release smoke script syntax check