### PR TITLE
fix: stabilize v0.2.9 production release

### DIFF
--- a/.github/scripts/validate-deploy-workflows.mjs
+++ b/.github/scripts/validate-deploy-workflows.mjs
@@ -39,8 +39,11 @@ requireText('production deploy', deploy, 'SMOKE_EXPECTED_IMAGE_TAG:')
 requireText('production deploy', deploy, "SMOKE_SKIP_API_HEALTH: 'true'")
 requireText('production deploy', deploy, 'Checkout current smoke tooling')
 requireText('production deploy', deploy, 'ref: main')
-requireText('release deploy smoke', releaseSmoke, "pathname.startsWith('/assets/')")
-requireText('release deploy smoke', releaseSmoke, 'assertRevalidated(res, `bootstrap asset ${asset}`)')
+requireText('production deploy', deploy, './scripts/ops/stack_healthcheck.sh')
+requireText('production deploy', deploy, 'three consecutive health checks')
+requireText('release deploy smoke', releaseSmoke, "`${WEB_BASE}/sw.js`")
+requireText('release deploy smoke', releaseSmoke, "`${WEB_BASE}/version.json`")
+requireText('release deploy smoke', releaseSmoke, 'metadata.imageTag === EXPECTED_IMAGE_TAG')
 
 if (failures.length > 0) {
   console.error('Deploy workflow validation failed:')

--- a/.github/scripts/validate-migration-history.mjs
+++ b/.github/scripts/validate-migration-history.mjs
@@ -1,0 +1,98 @@
+import { execFileSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+
+const MIGRATIONS_DIR = 'apps/server/migrations'
+const VALIDATOR_PATH = '.github/scripts/validate-migration-history.mjs'
+const migrationPattern = /^(\d+)_.*\.sql$/
+
+function git(args, options = {}) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim()
+}
+
+function isAllZeroSha(value) {
+  return /^0+$/.test(value)
+}
+
+function validateMigrationNames() {
+  const seenVersions = new Map()
+  const failures = []
+
+  for (const fileName of readdirSync(MIGRATIONS_DIR).sort()) {
+    const match = fileName.match(migrationPattern)
+    if (!match) {
+      failures.push(`Unexpected migration filename: ${fileName}`)
+      continue
+    }
+
+    const version = Number(match[1])
+    const existing = seenVersions.get(version)
+    if (existing) {
+      failures.push(`Duplicate migration version ${version}: ${existing}, ${fileName}`)
+    } else {
+      seenVersions.set(version, fileName)
+    }
+  }
+
+  return failures
+}
+
+function baseContainsValidator(baseRef) {
+  try {
+    execFileSync('git', ['cat-file', '-e', `${baseRef}:${VALIDATOR_PATH}`], {
+      stdio: 'ignore',
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function validateHistory(baseRef) {
+  if (!baseRef || isAllZeroSha(baseRef) || baseRef === git(['rev-parse', 'HEAD'])) {
+    console.log('Migration history comparison skipped: no distinct base revision was provided.')
+    return []
+  }
+
+  if (!baseContainsValidator(baseRef)) {
+    console.log('Migration history guard bootstrap: the base revision predates this validator.')
+    return []
+  }
+
+  const diff = git([
+    'diff',
+    '--name-status',
+    '--find-renames',
+    baseRef,
+    'HEAD',
+    '--',
+    MIGRATIONS_DIR,
+  ])
+
+  if (!diff) return []
+
+  const failures = []
+  for (const line of diff.split('\n')) {
+    const [status, ...paths] = line.split('\t')
+    if (status === 'A') continue
+    failures.push(
+      `Applied migration history is immutable; ${status} is not allowed for ${paths.join(' -> ')}`
+    )
+  }
+
+  return failures
+}
+
+const baseRef = process.env.MIGRATION_BASE_REF?.trim()
+const failures = [...validateMigrationNames(), ...validateHistory(baseRef)]
+
+if (failures.length > 0) {
+  console.error('Migration history validation failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Migration history validation passed.')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Validate immutable migration history
+        env:
+          MIGRATION_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: node .github/scripts/validate-migration-history.mjs
+
       - name: Secret scan (gitleaks)
         run: |
           docker run --rm \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,8 +323,30 @@ jobs:
             docker compose --profile security pull server web clamav
             docker compose --profile security up -d --no-build --remove-orphans
             docker image prune -f
-            curl -fsS http://127.0.0.1:3001/health >/dev/null
-            curl -fsS http://127.0.0.1:${WEB_PORT:-5173}/healthz >/dev/null
+
+            stable_health_passes=0
+            for attempt in $(seq 1 18); do
+              if ./scripts/ops/stack_healthcheck.sh; then
+                stable_health_passes=$((stable_health_passes + 1))
+                if [ "${stable_health_passes}" -ge 3 ]; then
+                  break
+                fi
+              else
+                stable_health_passes=0
+              fi
+
+              if [ "${attempt}" -lt 18 ]; then
+                echo "Stack is not stable yet; retrying in 5 seconds."
+                sleep 5
+              fi
+            done
+
+            if [ "${stable_health_passes}" -lt 3 ]; then
+              echo "Refusing deploy: stack did not pass three consecutive health checks."
+              docker compose --profile security ps
+              exit 1
+            fi
+
             echo "Deploy complete: release_channel=${RELEASE_CHANNEL} git_ref=${GIT_REF} commit=$(git rev-parse HEAD) image_tag=${IMAGE_TAG}"
 
       - name: Checkout current smoke tooling

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5389,7 +5389,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3149,7 +3149,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/server/migrations/009_username_changed_at.sql
+++ b/apps/server/migrations/009_username_changed_at.sql
@@ -1,2 +1,2 @@
--- Stores the last username change; the API currently enforces a seven-day cooldown.
+-- Limit username changes to once per 30 days
 ALTER TABLE users ADD COLUMN IF NOT EXISTS username_changed_at TIMESTAMPTZ;

--- a/apps/web/nginx.production.conf
+++ b/apps/web/nginx.production.conf
@@ -30,6 +30,11 @@ server {
         try_files $uri =404;
     }
 
+    location = /version.json {
+        expires -1;
+        try_files $uri =404;
+    }
+
     # This worklet has a stable URL and therefore cannot use immutable caching.
     location = /assets/rnnoise-worklet.js {
         expires -1;

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.6.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/apps/web/scripts/release-deploy-smoke.mjs
+++ b/apps/web/scripts/release-deploy-smoke.mjs
@@ -63,23 +63,8 @@ async function getOk(url, label) {
   return res
 }
 
-function assetUrls(html, webBase) {
-  const urls = new Set()
-  const pattern = /<(?:script|link)\b[^>]+(?:src|href)="([^"]+)"/g
-  for (const match of html.matchAll(pattern)) {
-    const raw = match[1]
-    if (!/\.(?:js|css)(?:\?|$)/.test(raw)) continue
-    urls.add(new URL(raw, `${webBase}/`).toString())
-  }
-  return [...urls]
-}
-
 function cacheControl(response) {
   return response.headers.get('cache-control')?.toLowerCase() || ''
-}
-
-function isFingerprintedBuildAsset(rawUrl) {
-  return new URL(rawUrl).pathname.startsWith('/assets/')
 }
 
 function assertRevalidated(response, label) {
@@ -90,41 +75,21 @@ function assertRevalidated(response, label) {
   )
 }
 
-function assertLongLived(response, label) {
-  const value = cacheControl(response)
-  const maxAge = Number(value.match(/(?:^|,)\s*max-age=(\d+)/)?.[1] || 0)
-  assert(maxAge >= 31_536_000, `${label} must use long-lived caching; received Cache-Control: ${value || '<missing>'}`)
-}
-
-async function checkVersionInDeployedAssets() {
+async function checkDeployedVersion() {
   const rootRes = await getOk(`${WEB_BASE}/`, 'web root')
   assertRevalidated(rootRes, 'web root')
-  const html = await rootRes.text()
-  const assets = assetUrls(html, WEB_BASE)
-  assert(assets.length > 0, 'No JS/CSS assets found in deployed web root')
 
   const serviceWorkerRes = await getOk(`${WEB_BASE}/sw.js`, 'service worker')
   assertRevalidated(serviceWorkerRes, 'service worker')
 
-  const needles = [EXPECTED_BADGE, EXPECTED_IMAGE_TAG].filter(Boolean)
-  const seen = new Set()
-
-  for (const asset of assets) {
-    const res = await getOk(asset, `asset ${asset}`)
-    if (isFingerprintedBuildAsset(asset)) {
-      assertLongLived(res, `fingerprinted asset ${asset}`)
-    } else {
-      assertRevalidated(res, `bootstrap asset ${asset}`)
-    }
-    const text = await res.text()
-    for (const needle of needles) {
-      if (text.includes(needle)) seen.add(needle)
-    }
-  }
-
-  for (const needle of needles) {
-    assert(seen.has(needle), `Expected deployed web assets to contain ${needle}`)
-  }
+  const versionRes = await getOk(`${WEB_BASE}/version.json`, 'version metadata')
+  assertRevalidated(versionRes, 'version metadata')
+  const metadata = await versionRes.json().catch(() => null)
+  assert(metadata && typeof metadata === 'object', 'Version metadata must be valid JSON')
+  assert(
+    metadata.imageTag === EXPECTED_IMAGE_TAG,
+    `Expected deployed image tag ${EXPECTED_IMAGE_TAG}; received ${metadata.imageTag || '<missing>'}`
+  )
 }
 
 async function main() {
@@ -149,8 +114,8 @@ async function main() {
   assertSecurityHeaders(webHealth, { surface: 'web', url: `${WEB_BASE}/healthz` })
   console.log('[release-smoke] web health and security headers OK')
 
-  await checkVersionInDeployedAssets()
-  console.log('[release-smoke] deployed version assets OK')
+  await checkDeployedVersion()
+  console.log('[release-smoke] deployed version metadata OK')
   console.log('[release-smoke] deploy guardrails OK')
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,5 +1,19 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
+
+function releaseMetadataPlugin(): Plugin {
+  return {
+    name: 'release-metadata',
+    generateBundle() {
+      const imageTag = process.env.VITE_APP_VERSION?.trim() || null
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: `${JSON.stringify({ imageTag })}\n`,
+      })
+    },
+  }
+}
 
 // In production, remove worklet path so main bundle has no dependency on it (no extra 5 kB chunk).
 function rnnoiseProdStripPlugin() {
@@ -24,7 +38,9 @@ const RNNOISE_WORKLET_URL = `/assets/rnnoise-worklet.js?v=${Date.now().toString(
 
 export default defineConfig(({ mode }) => ({
   envDir: '../../',
-  plugins: [react(), mode === 'production' ? rnnoiseProdStripPlugin() : null].filter(Boolean),
+  plugins: [react(), releaseMetadataPlugin(), mode === 'production' ? rnnoiseProdStripPlugin() : null].filter(
+    Boolean
+  ),
   define: mode === 'production' ? { __RNNOISE_PROCESSOR_URL__: JSON.stringify(RNNOISE_WORKLET_URL) } : {},
   build: {
     // Strip console in production to avoid leaking room/user IDs (e.g. from LiveKit SDK) and other debug output

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-08-20
+
+### Changed
+- Added deterministic `/version.json` metadata to production web builds so deploy validation checks the exact immutable image tag without depending on lazy bundle contents.
+- Strengthened production deploy readiness with three consecutive full-stack health checks covering required services, API health, PostgreSQL, Redis, attachment storage, and web health.
+
 ### Fixed
+- Restored the original byte content of migration 009 so existing databases retain their recorded SQLx checksum, and added CI enforcement that keeps applied migration history immutable.
 - Updated `h2` to `0.4.16` to address `RUSTSEC-2026-0258`, preventing unbounded empty DATA frames from exhausting server resources.
 - Restored the CSP-safe automatic desktop Google OAuth handoff and branded fallback page, preserved local passwords when connecting Google, and enabled email recovery for Google-connected accounts.
 - Added bounded integration-feature retries and an explicit retry state so transient feature discovery failures no longer silently hide Google Sign-In and password recovery.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -221,6 +221,12 @@ WebSocket broadcasts and LiveKit reconciliation happen only after the database c
 
 ## Migrations
 
+Committed migrations are immutable after they have been applied. Never edit,
+rename, or delete an existing migration, including comments or whitespace,
+because SQLx verifies the complete file checksum at startup. Add a new numbered
+migration for every subsequent schema change. CI rejects historical migration
+changes once the migration-history guard is present on the target branch.
+
 All migrations currently present:
 
 - `001_initial.sql`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -255,19 +255,25 @@ job succeeds. The deploy gate retries both backend and frontend immutable image
 lookups before touching production and fails closed if either tag never becomes
 visible. Manual and automatic deploys use this same registry guard.
 
-The deploy host performs authoritative origin-local API and web health checks.
+The deploy host runs `scripts/ops/stack_healthcheck.sh` until the stack passes
+three consecutive rounds. This verifies that every required Compose service is
+running, the API reports `status=ok`, PostgreSQL and Redis are ready, attachment
+storage is writable, and the web health endpoint responds. A transient
+`docker ps` running state is not accepted because a restart-looping backend can
+briefly appear healthy between crashes.
 The runner then checks out the current `main` deployment tooling before it
-validates the public web health endpoint, security headers, release version,
-and cache policy. This keeps smoke guardrail fixes effective when an older
-immutable release tag is deployed. Public API edge and security-header checks
+validates the public web health endpoint, security headers, `/version.json`
+release metadata, and stable entry-point cache policy. This keeps smoke
+guardrail fixes effective when an older immutable release tag is deployed.
+Public API edge and security-header checks
 remain part of the independent manual release smoke because Cloudflare may
 intentionally reject requests from both GitHub-hosted runner networks and the
 production host's datacenter address.
 
-The public cache check distinguishes fingerprinted Vite files under `/assets/`
-from stable bootstrap files such as `/theme-init.js`. Fingerprinted files must
-be long-lived, while stable bootstrap files must revalidate so normal reloads
-can pick up deployment changes.
+The public cache check verifies that the app shell, service worker, and
+`/version.json` revalidate so normal reloads can pick up deployment changes.
+Fingerprint asset caching remains an origin/CDN configuration concern rather
+than a production availability gate.
 
 Manual runs remain available for redeploys, release recovery, candidates, and
 explicit rollback operations:
@@ -306,17 +312,19 @@ deployed main candidates). For manual image builds, pass
 `--build-arg VITE_APP_VERSION=<tag>` to keep the visible badge aligned with the
 image tag.
 
-The web container requires release entry points (`/`, `/index.html`, and
-`/sw.js`) and the stable RNNoise worklet URL to be revalidated on every normal
-reload. Fingerprinted `/assets/` files are cached for one year because a new
+The web container requires release entry points (`/`, `/index.html`, `/sw.js`,
+and `/version.json`) and the stable RNNoise worklet URL to be revalidated on
+every normal reload. Fingerprinted `/assets/` files are cached for one year
+because a new
 build produces new URLs. Do not override the entry-point headers with a CDN
-browser-cache rule: the release smoke workflow verifies that the app shell and
-service worker return a revalidation policy, preventing stale releases from
-requiring `Ctrl+F5`.
+browser-cache rule: the release smoke workflow verifies that the app shell,
+service worker, and release metadata return a revalidation policy, preventing
+stale releases from requiring `Ctrl+F5`.
 
 For Cloudflare, set Browser Cache TTL to `Respect existing headers` and do not
-apply an Edge Cache TTL override to `/`, `/index.html`, `/sw.js`, or
-`/assets/rnnoise-worklet.js`. A broad four-hour Browser Cache TTL rule, for
+apply an Edge Cache TTL override to `/`, `/index.html`, `/sw.js`,
+`/version.json`, or `/assets/rnnoise-worklet.js`. A broad four-hour Browser
+Cache TTL rule, for
 example, replaces the origin's revalidation header with `max-age=14400` and
 causes the post-deploy cache smoke to fail. Fingerprinted `/assets/*` files may
 keep a long-lived edge/browser cache rule, except for the stable RNNoise worklet

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -41,7 +41,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Docker images were built with an immutable `sha-<commit>` or `vX.Y.Z` tag, and production deploy did not use `latest`.
 - [ ] For `main-candidate` deploys, the manual deploy workflow built and published Docker images for the exact candidate ref before starting deploy.
 - [ ] Stable GitHub Release publishing automatically waited for both immutable Docker images and deployed their exact shared `vX.Y.Z` tag; any intentional manual redeploy is recorded instead.
-- [ ] Release deploy guardrails verified registry presence for both images, origin-local API `/health`, origin-local and public web `/healthz`, immutable image tag format, cache policy, and the deployed web bundle version tag.
+- [ ] Release deploy guardrails verified registry presence for both images, three consecutive origin stack health checks, public web `/healthz`, immutable image tag format, stable entry-point cache policy, and the exact `/version.json` image tag.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
 ## 3) Web Smoke Tests (mandatory)


### PR DESCRIPTION
## Summary

- restore migration 009 byte-for-byte to match existing SQLx checksums
- prevent future edits to committed migration history in CI
- add deterministic `/version.json` release metadata
- require three consecutive full-stack health checks after deployment
- simplify production smoke validation around exact image tags
- synchronize web, server, and desktop versions to `0.2.9`
- update release, database, deployment, and smoke documentation

## Validation

- Frontend lint: passed
- Frontend tests: 301 passed
- Frontend production build: passed
- Backend check: passed
- Backend tests: 89 unit and 50 integration tests passed
- Desktop check: passed
- Production npm audit: 0 vulnerabilities
- v0.2.9 Docker production image smoke: passed
- Release version synchronization: passed