### PR TITLE
fix: improve audio stability during speaking state changes in ActiveC…

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MemberInfo } from '../api'
@@ -370,6 +370,55 @@ describe('ActiveCallBar regressions', () => {
 
     expect(voiceAudio.muted).toBe(true)
     expect(screenAudio.muted).toBe(false)
+  })
+
+  it('does not restart remote voice or screen audio when speaking indicators change', () => {
+    const sharerMic = mediaTrack('audio', 'peer-1-mic')
+    const screenAudio = mediaTrack('audio', 'peer-screen-audio')
+    const speakerMic = mediaTrack('audio', 'peer-2-mic')
+    markRemoteAudioTrackSource(sharerMic, 'voice')
+    markRemoteAudioTrackSource(screenAudio, 'screen')
+    markRemoteAudioTrackSource(speakerMic, 'voice')
+    const play = vi.mocked(HTMLMediaElement.prototype.play)
+
+    useAppStore.setState({
+      members: [
+        ...members,
+        {
+          user_id: 'peer-2',
+          username: 'viewer',
+          avatar_url: null,
+          role: 'member',
+          status: 'online',
+          role_color: null,
+        },
+      ],
+      voiceStates: {
+        [localUser.id]: voiceChannel.id,
+        'peer-1': voiceChannel.id,
+        'peer-2': voiceChannel.id,
+      },
+    })
+
+    renderActiveCallBar({
+      remoteStreams: new Map([
+        ['peer-1', new MediaStream([sharerMic, screenAudio])],
+        ['peer-2', new MediaStream([speakerMic])],
+      ]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+      livekit: {
+        roomState: 'connected',
+        participants: 3,
+        remoteStreams: 2,
+      },
+    })
+    play.mockClear()
+
+    act(() => useAppStore.getState().setVoiceSpeaking(['peer-2'], false))
+    act(() => useAppStore.getState().setVoiceSpeaking(['peer-1', 'peer-2'], true))
+    act(() => useAppStore.getState().setVoiceSpeaking([], false))
+
+    expect(play).not.toHaveBeenCalled()
   })
 
   it('uses the configured shortcut while the web tab is focused', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff, PhoneOff, Mic, MicOff, Monitor, Volume2, VolumeX, Maximize2, Minimize2, SwitchCamera as SwitchCameraIcon, Users, Video, VideoOff, Wifi } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router'
 import { useLiveKitVoice } from '../webrtc/useLiveKitVoice'
@@ -79,6 +79,17 @@ type RemoteMediaPlaceholder = {
   label: string
 }
 
+type RemoteAudioPlaybackLayerProps = {
+  remoteStreams: Map<string, MediaStream>
+  watchedScreenPeerIds: Set<string>
+  renderAudioElement: (
+    peerId: string,
+    stream: MediaStream,
+    kind: RemoteAudioKind,
+    include: boolean,
+  ) => ReactNode
+}
+
 interface ActiveCallBarProps {
   selectedVoiceChannelId: string | null
   /** Only show the voice stage (participants grid) when user has this channel selected (e.g. clicked voice channel in sidebar). */
@@ -111,6 +122,22 @@ function RemoteVideoTrack({ track }: { track: MediaStreamTrack }) {
 
   return <video ref={videoRef} autoPlay muted playsInline />
 }
+
+const RemoteAudioPlaybackLayer = memo(function RemoteAudioPlaybackLayer({
+  remoteStreams,
+  watchedScreenPeerIds,
+  renderAudioElement,
+}: RemoteAudioPlaybackLayerProps) {
+  return (
+    <div style={{ display: 'none' }}>
+      {Array.from(remoteStreams.entries()).flatMap(([peerId, stream]) => (
+        (['mic', 'screen'] as RemoteAudioKind[]).map((kind) => (
+          renderAudioElement(peerId, stream, kind, kind === 'mic' || watchedScreenPeerIds.has(peerId))
+        ))
+      ))}
+    </div>
+  )
+})
 
 export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId }: ActiveCallBarProps) {
   const navigate = useNavigate()
@@ -710,6 +737,48 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       if (context && context.state !== 'closed') void context.close().catch(() => {})
     }
   }, [disposeRemoteVoicePlaybackGraph])
+
+  const renderRemoteAudioElement = useCallback((
+    peerId: string,
+    stream: MediaStream,
+    kind: RemoteAudioKind,
+    include: boolean,
+  ) => {
+    const playbackKey = remoteAudioPlaybackKey(peerId, kind)
+    return (
+      <audio key={playbackKey} autoPlay playsInline ref={(el) => {
+        if (el) {
+          const audioEl = el as VoxperyAudioElement
+          remoteAudioRefsRef.current.set(playbackKey, audioEl)
+          const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
+          const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
+          if (audioEl.__voxpery_trackIds !== currentTrackIds) {
+            attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
+          }
+          void applyPreferredAudioOutputDevice(audioEl)
+          const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
+          const peerFactor = getPlaybackVolumeFactor(peerId, kind)
+          const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
+          if (voiceGraph) {
+            voiceGraph.gain.gain.value = peerFactor
+          }
+          const vol = voiceGraph
+            ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
+            : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
+          try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
+          audioEl.muted = shouldMute
+          if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
+        } else {
+          remoteAudioRefsRef.current.delete(playbackKey)
+          const timer = remoteAudioRetryTimerRef.current.get(playbackKey)
+          if (timer != null) {
+            window.clearTimeout(timer)
+            remoteAudioRetryTimerRef.current.delete(playbackKey)
+          }
+        }
+      }} />
+    )
+  }, [attachRemoteAudioPlaybackStream, ensureRemoteAudioPlayback, getPlaybackVolumeFactor, remoteAudioPlaybackKey])
 
   const showActiveCallBar = !!(state.joinedChannelId || state.localStream || state.isJoining)
   const channelParticipants = useMemo(() => {
@@ -1474,46 +1543,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
           )}
           <div className="callbar-wrap">
             <div className="active-call-bar">
-              <div style={{ display: 'none' }}>
-                {Array.from(state.remoteStreams.keys()).map((peerId) => {
-                  const stream = state.remoteStreams.get(peerId)
-                  if (!stream) return null
-                  return (['mic', 'screen'] as RemoteAudioKind[]).map((kind) => {
-                    const playbackKey = remoteAudioPlaybackKey(peerId, kind)
-                    return (
-                      <audio key={playbackKey} autoPlay playsInline ref={(el) => {
-                        if (el) {
-                          const audioEl = el as VoxperyAudioElement
-                          remoteAudioRefsRef.current.set(playbackKey, audioEl)
-                          const include = kind === 'mic' || watchedRemoteScreenPeerIds.has(peerId)
-                          const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
-                          const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
-                          if (audioEl.__voxpery_trackIds !== currentTrackIds) {
-                            attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
-                          }
-                          void applyPreferredAudioOutputDevice(audioEl)
-                          const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
-                          const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-                          const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
-                          if (voiceGraph) {
-                            voiceGraph.gain.gain.value = peerFactor
-                          }
-                          const vol = voiceGraph
-                            ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
-                            : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
-                          try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
-                          audioEl.muted = shouldMute
-                          if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
-                        } else {
-                          remoteAudioRefsRef.current.delete(playbackKey)
-                          const t = remoteAudioRetryTimerRef.current.get(playbackKey)
-                          if (t != null) { window.clearTimeout(t); remoteAudioRetryTimerRef.current.delete(playbackKey) }
-                        }
-                      }} />
-                    )
-                  })
-                })}
-              </div>
+              <RemoteAudioPlaybackLayer
+                remoteStreams={state.remoteStreams}
+                watchedScreenPeerIds={watchedRemoteScreenPeerIds}
+                renderAudioElement={renderRemoteAudioElement}
+              />
               <div className="callbar-status">
                 <button type="button" className="active-call-title active-call-title-btn" onClick={goToVoiceChannel} title={voiceLocation.full}>{voiceLocation.display}</button>
               </div>

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -60,6 +60,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding media unsubscribes its remote publications for that viewer while normal microphone audio continues.
+- [ ] In a call with at least three participants, local or remote speaking-state changes do not restart, mute, or interrupt watched screen-share audio; voice and stream audio remain independently audible.
 - [ ] Screen share quality presets match the UI summary: Presentation uses 1080p30 at 4 Mbps, Video uses 1080p60 at 6 Mbps, Gaming uses 1080p60 at 8 Mbps, and Auto does not promote monitor sharing to Gaming.
 - [ ] Hiding or minimizing the app pauses incoming remote video subscriptions while voice audio continues, and restoring visibility resumes video without replaying media-start cues.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.


### PR DESCRIPTION
## Summary

- isolate remote voice and screen audio playback from speaking-state renders
- prevent screen-share audio interruptions during simultaneous conversation
- add three-participant regression coverage
- document the scenario in the release smoke checklist

## Validation

- `npm run lint`
- `npm run test:run`
- `npm run build`