### PR TITLE
fix: enhance scrolling behavior for friends and requests sections on …

### DIFF
--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -62,9 +62,9 @@ test.describe('mocked mobile web smoke', () => {
     await expectNoHorizontalOverflow(page.locator('.shell-layout'))
 
     await page.getByRole('button', { name: /All/ }).click()
-    const homeScroller = page.locator('.home-main').first()
-    await expectScrollable(homeScroller)
-    await homeScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
+    const friendsScroller = page.locator('.home-friends-scroll').first()
+    await expectScrollable(friendsScroller)
+    await friendsScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
     await expect(page.getByText('Friend 24')).toBeVisible()
     await expect(page.getByRole('button', { name: 'Open DM with Friend 24' })).toBeVisible()
 
@@ -75,8 +75,9 @@ test.describe('mocked mobile web smoke', () => {
 
     await page.goto('/social')
     await page.getByRole('button', { name: /Requests/ }).click()
-    await expectScrollable(homeScroller)
-    await homeScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
+    const requestsScroller = page.locator('.home-friends-scroll--requests')
+    await expectScrollable(requestsScroller)
+    await requestsScroller.evaluate((element) => element.scrollTo(0, element.scrollHeight))
     await expect(page.getByText('Request Out 18')).toBeVisible()
     await expectNoHorizontalOverflow(page.locator('.shell-layout'))
   })

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15097,22 +15097,24 @@ textarea {
   }
 
   .home-main:not(.home-main-dm) {
-    overflow-x: hidden;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    -webkit-overflow-scrolling: touch;
-    touch-action: pan-y;
+    overflow: hidden;
   }
 
   .home-main:not(.home-main-dm) .social-content {
-    flex: 0 0 auto;
-    min-height: max-content;
-    overflow: visible;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
     padding-bottom: calc(12px + var(--mobile-bottom-dock-height) + env(safe-area-inset-bottom, 0px));
   }
 
   .home-friends-scroll {
-    padding-bottom: 16px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+    padding-bottom: calc(16px + var(--mobile-bottom-dock-height) + env(safe-area-inset-bottom, 0px));
     scrollbar-gutter: auto;
   }
 


### PR DESCRIPTION
## Summary

- restore reliable touch scrolling for long Friends and Requests lists on mobile
- keep social filter tabs visible while list content scrolls
- extend the mobile smoke test to verify the Friends and Requests containers reach their final entries

## Validation

- `npm run test:e2e -- e2e/mobile-web-smoke.spec.ts --project=mobile-chromium`
- `npm run lint`
- `npm run test:run`
- `npm run build`