### PR TITLE
chore: update version to 0.2.10 and enhance changelog with fixes for …

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5389,7 +5389,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3149,7 +3149,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.6.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.9",
+  "version": "0.2.10",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-08-21
+
+### Fixed
+- Prevented speaking-state updates from restarting remote microphone or watched screen-share audio, preserving concurrent voice and shared audio in multi-participant calls.
+- Restored reliable touch scrolling for long Friends and Requests lists in the mobile Social view.
+
 ## [0.2.9] - 2026-08-20
 
 ### Changed


### PR DESCRIPTION
## Summary

- bump Voxpery to `v0.2.10` across web, server, desktop, Tauri metadata, and lockfiles
- document the release in the changelog
- include the merged voice playback stability and mobile Social scrolling fixes

## Validation

- `npm run build`
- `cargo check --locked` in `apps/server`
- `cargo check --locked` in `apps/desktop/src-tauri`