### PR TITLE
fix: stabilize v0.2.11 voice and chat regressions

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5389,7 +5389,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3149,7 +3149,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/e2e/channel-permission-core-regressions.spec.ts
+++ b/apps/web/e2e/channel-permission-core-regressions.spec.ts
@@ -175,6 +175,64 @@ test.describe('mocked channel permission regressions', () => {
     )).toBeLessThanOrEqual(4)
   })
 
+  test('remeasures consecutive reaction rows without moving a history reader', async ({ page }) => {
+    const server = buildCoreServer()
+    const channels = buildCoreChannels(server.id)
+    const general = channels.find((channel) => channel.name === 'general')
+    if (!general) throw new Error('Core channel fixture is incomplete.')
+
+    const targetIds = ['reaction-stack-a', 'reaction-stack-b', 'reaction-stack-c']
+    const messages = Array.from({ length: 50 }, (_, index) =>
+      buildServerMessage(general.id, `Reaction stack message ${index + 1}`, {
+        id: index >= 2 && index <= 4 ? targetIds[index - 2] : `reaction-stack-${index}`,
+        created_at: new Date(Date.UTC(2026, 0, 15, 11, index)).toISOString(),
+      })
+    )
+    const state = createMockCoreState({
+      servers: [server],
+      channelsByServerId: { [server.id]: channels },
+      membersByServerId: { [server.id]: buildCoreMembers() },
+      messagesByChannelId: { [general.id]: messages },
+    })
+    await installMockCoreApi(page, state)
+    await page.setViewportSize({ width: 1366, height: 768 })
+    await page.goto('/servers')
+
+    const scroller = page.locator('.chat-messages')
+    await scroller.evaluate((element) => {
+      element.scrollTop = 0
+      element.dispatchEvent(new Event('scroll'))
+    })
+    await expect.poll(() => scroller.evaluate((element) => (
+      element.scrollHeight - element.clientHeight
+    ))).toBeGreaterThan(200)
+    const firstRow = page.locator(`[data-message-id="${targetIds[0]}"]`)
+    await expect(firstRow).toBeVisible()
+    const anchorBefore = await firstRow.evaluate((element) => {
+      const scrollerRect = element.closest('.chat-messages')?.getBoundingClientRect()
+      return Math.round(element.getBoundingClientRect().top - (scrollerRect?.top ?? 0))
+    })
+
+    for (const targetId of targetIds) {
+      const row = page.locator(`[data-message-id="${targetId}"]`)
+      await row.hover()
+      await row.getByRole('button', { name: 'Add reaction' }).click()
+      await page.getByRole('button', { name: 'thumbs up' }).click()
+      await expect(row.locator('.message-reaction-btn')).toContainText('1')
+    }
+
+    const bounds = await Promise.all(targetIds.map((targetId) =>
+      page.locator(`[data-message-id="${targetId}"]`).boundingBox()
+    ))
+    expect(bounds.every(Boolean)).toBe(true)
+    expect(bounds[0]!.y + bounds[0]!.height).toBeLessThanOrEqual(bounds[1]!.y + 1)
+    expect(bounds[1]!.y + bounds[1]!.height).toBeLessThanOrEqual(bounds[2]!.y + 1)
+    await expect.poll(() => firstRow.evaluate((element) => {
+      const scrollerRect = element.closest('.chat-messages')?.getBoundingClientRect()
+      return Math.round(element.getBoundingClientRect().top - (scrollerRect?.top ?? 0))
+    })).toBe(anchorBefore)
+  })
+
   test('exposes moderator controls only when channel permission bits allow them', async ({ page }) => {
     const server = buildCoreServer({ owner_id: 'server-owner' })
     const channels = buildCoreChannels(server.id).map((channel) => ({

--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -111,6 +111,16 @@ test.describe('mocked mobile web smoke', () => {
               reactions: [{ emoji: '👍', count: 1, reacted: false }],
             }
           ),
+          buildServerMessage(general.id, 'Mobile consecutive reaction two', {
+            id: 'mobile-reaction-two',
+            created_at: new Date(Date.now() + 1_000).toISOString(),
+            reactions: [{ emoji: '🎉', count: 1, reacted: false }],
+          }),
+          buildServerMessage(general.id, 'Mobile consecutive reaction three', {
+            id: 'mobile-reaction-three',
+            created_at: new Date(Date.now() + 2_000).toISOString(),
+            reactions: [{ emoji: '❤️', count: 1, reacted: false }],
+          }),
         ],
       },
     })
@@ -173,12 +183,24 @@ test.describe('mocked mobile web smoke', () => {
     })).toBe(true)
     await mobileActionsMenu.getByRole('menuitem', { name: 'Add reaction' }).click()
     await expect(page.locator('.message-reaction-picker-portal')).toBeVisible()
-    await page.keyboard.press('Escape')
+    await page.getByRole('button', { name: 'thumbs up' }).click()
+    await expect(mediaRow.locator('.message-reaction-btn')).toContainText('2')
     await expect.poll(async () =>
       mediaRow.locator('.chat-inline-gif-link, .dm-attachments, .message-reactions').evaluateAll(
         (elements) => elements.map((element) => element.className)
       )
     ).toEqual(['chat-inline-gif-link', 'dm-attachments', 'message-reactions'])
+    const consecutiveReactionIds = [
+      'mobile-media-reaction-message',
+      'mobile-reaction-two',
+      'mobile-reaction-three',
+    ]
+    const reactionBounds = await Promise.all(consecutiveReactionIds.map((messageId) =>
+      page.locator(`[data-message-id="${messageId}"]`).boundingBox()
+    ))
+    expect(reactionBounds.every(Boolean)).toBe(true)
+    expect(reactionBounds[0]!.y + reactionBounds[0]!.height).toBeLessThanOrEqual(reactionBounds[1]!.y + 1)
+    expect(reactionBounds[1]!.y + reactionBounds[1]!.height).toBeLessThanOrEqual(reactionBounds[2]!.y + 1)
 
     const content = `Mobile smoke message ${Date.now()}`
     const messageInput = page.getByPlaceholder('Message', { exact: true })

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.6.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -372,50 +372,80 @@ describe('ActiveCallBar regressions', () => {
     expect(screenAudio.muted).toBe(false)
   })
 
-  it('does not restart remote voice or screen audio when speaking indicators change', () => {
+  it('hides remote speaking indicators while locally deafened and restores them on undeafen', () => {
+    useAppStore.setState({ voiceSpeakingUserIds: ['peer-1'] })
+
+    const { container } = renderActiveCallBar()
+    const remoteTile = screen.getByText('admin').closest('.voice-stage-tile')
+    expect(remoteTile?.querySelector('.voice-stage-avatar')).toHaveClass('is-speaking')
+    expect(remoteTile?.querySelector('.voice-stage-name')).toHaveClass('is-speaking')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
+
+    expect(remoteTile?.querySelector('.voice-stage-avatar')).not.toHaveClass('is-speaking')
+    expect(remoteTile?.querySelector('.voice-stage-name')).not.toHaveClass('is-speaking')
+    expect(useAppStore.getState().voiceSpeakingUserIds).toEqual(['peer-1'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undeafen' }))
+
+    expect(container.querySelector('.voice-stage-avatar.is-speaking')).not.toBeNull()
+    expect(remoteTile?.querySelector('.voice-stage-name')).toHaveClass('is-speaking')
+  })
+
+  it('keeps five remote voices and watched screen audio stable across speaking changes', () => {
     const sharerMic = mediaTrack('audio', 'peer-1-mic')
     const screenAudio = mediaTrack('audio', 'peer-screen-audio')
-    const speakerMic = mediaTrack('audio', 'peer-2-mic')
     markRemoteAudioTrackSource(sharerMic, 'voice')
     markRemoteAudioTrackSource(screenAudio, 'screen')
-    markRemoteAudioTrackSource(speakerMic, 'voice')
+    const additionalPeerTracks = Array.from({ length: 4 }, (_, index) => {
+      const track = mediaTrack('audio', `peer-${index + 2}-mic`)
+      markRemoteAudioTrackSource(track, 'voice')
+      return track
+    })
     const play = vi.mocked(HTMLMediaElement.prototype.play)
 
     useAppStore.setState({
       members: [
         ...members,
-        {
-          user_id: 'peer-2',
-          username: 'viewer',
+        ...additionalPeerTracks.map((_, index) => ({
+          user_id: `peer-${index + 2}`,
+          username: `viewer-${index + 2}`,
           avatar_url: null,
           role: 'member',
           status: 'online',
           role_color: null,
-        },
+        })),
       ],
       voiceStates: {
         [localUser.id]: voiceChannel.id,
         'peer-1': voiceChannel.id,
-        'peer-2': voiceChannel.id,
+        ...Object.fromEntries(additionalPeerTracks.map((_, index) => [
+          `peer-${index + 2}`,
+          voiceChannel.id,
+        ])),
       },
     })
 
-    renderActiveCallBar({
-      remoteStreams: new Map([
+    const { container } = renderActiveCallBar({
+      remoteStreams: new Map<string, MediaStream>([
         ['peer-1', new MediaStream([sharerMic, screenAudio])],
-        ['peer-2', new MediaStream([speakerMic])],
+        ...additionalPeerTracks.map((track, index) => [
+          `peer-${index + 2}`,
+          new MediaStream([track]),
+        ] as [string, MediaStream]),
       ]),
       watchedRemoteScreenPeerIds: new Set(['peer-1']),
       livekit: {
         roomState: 'connected',
-        participants: 3,
-        remoteStreams: 2,
+        participants: 6,
+        remoteStreams: 5,
       },
     })
+    expect(container.querySelectorAll('audio').length).toBeGreaterThanOrEqual(6)
     play.mockClear()
 
-    act(() => useAppStore.getState().setVoiceSpeaking(['peer-2'], false))
-    act(() => useAppStore.getState().setVoiceSpeaking(['peer-1', 'peer-2'], true))
+    act(() => useAppStore.getState().setVoiceSpeaking(['peer-2', 'peer-3'], false))
+    act(() => useAppStore.getState().setVoiceSpeaking(['peer-1', 'peer-2', 'peer-5'], true))
     act(() => useAppStore.getState().setVoiceSpeaking([], false))
 
     expect(play).not.toHaveBeenCalled()

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -60,11 +60,11 @@ interface VoxperyAudioElement extends HTMLAudioElement {
   __voxpery_trackIds?: string
 }
 
-interface RemoteVoicePlaybackGraph {
+interface RemoteAudioPlaybackGraph {
   trackIds: string
   source: MediaStreamAudioSourceNode
   gain: GainNode
-  limiter: DynamicsCompressorNode
+  limiter: DynamicsCompressorNode | null
   destination: MediaStreamAudioDestinationNode
 }
 
@@ -285,8 +285,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const micTestPrevMutedRef = useRef(false)
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
-  const remoteVoiceAudioContextRef = useRef<AudioContext | null>(null)
-  const remoteVoicePlaybackGraphsRef = useRef<Map<string, RemoteVoicePlaybackGraph>>(new Map())
+  const remoteAudioContextRef = useRef<AudioContext | null>(null)
+  const remotePlaybackGraphsRef = useRef<Map<string, RemoteAudioPlaybackGraph>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
   const cameraPreviewCleanupRef = useRef<(() => void) | null>(null)
@@ -372,25 +372,25 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     return getRemotePlaybackVolume(peerVolumeByUserId, kind === 'screen' ? 'screen' : 'voice', volumeKey) / 100
   }, [peerVolumeByUserId, resolvePeerVolumeKey])
 
-  const disposeRemoteVoicePlaybackGraph = useCallback((playbackKey: string) => {
-    const graph = remoteVoicePlaybackGraphsRef.current.get(playbackKey)
+  const disposeRemotePlaybackGraph = useCallback((playbackKey: string) => {
+    const graph = remotePlaybackGraphsRef.current.get(playbackKey)
     if (!graph) return
     graph.source.disconnect()
     graph.gain.disconnect()
-    graph.limiter.disconnect()
+    graph.limiter?.disconnect()
     graph.destination.disconnect()
     graph.destination.stream.getTracks().forEach((track) => track.stop())
-    remoteVoicePlaybackGraphsRef.current.delete(playbackKey)
+    remotePlaybackGraphsRef.current.delete(playbackKey)
   }, [])
 
-  const getRemoteVoiceAudioContext = useCallback((): AudioContext | null => {
-    if (remoteVoiceAudioContextRef.current?.state !== 'closed') return remoteVoiceAudioContextRef.current
+  const getRemoteAudioContext = useCallback((): AudioContext | null => {
+    if (remoteAudioContextRef.current?.state !== 'closed') return remoteAudioContextRef.current
     const AudioCtor = window.AudioContext
       || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
     if (!AudioCtor) return null
     try {
       const context = new AudioCtor()
-      remoteVoiceAudioContextRef.current = context
+      remoteAudioContextRef.current = context
       return context
     } catch {
       return null
@@ -405,21 +405,21 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     element: VoxperyAudioElement,
   ) => {
     if (shouldUseDirectRemoteAudioPlayback(kind, lightweightMobileVoice, playbackStream.getAudioTracks().length)) {
-      disposeRemoteVoicePlaybackGraph(playbackKey)
+      disposeRemotePlaybackGraph(playbackKey)
       element.srcObject = playbackStream
       element.__voxpery_trackIds = trackIds
       return
     }
 
-    const current = remoteVoicePlaybackGraphsRef.current.get(playbackKey)
+    const current = remotePlaybackGraphsRef.current.get(playbackKey)
     if (current?.trackIds === trackIds) {
       if (element.srcObject !== current.destination.stream) element.srcObject = current.destination.stream
       element.__voxpery_trackIds = trackIds
       return
     }
 
-    disposeRemoteVoicePlaybackGraph(playbackKey)
-    const context = getRemoteVoiceAudioContext()
+    disposeRemotePlaybackGraph(playbackKey)
+    const context = getRemoteAudioContext()
     if (!context) {
       element.srcObject = playbackStream
       element.__voxpery_trackIds = trackIds
@@ -427,21 +427,27 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
 
     try {
-      // Voice amplification uses its own gain bus; stream audio stays on the direct media path.
+      // Voice and stream playback share one stable AudioContext while keeping
+      // independent gain buses. Only voice needs peak limiting; screen audio
+      // remains uncompressed so music/game playback is not flattened.
       const source = context.createMediaStreamSource(playbackStream)
       const gain = context.createGain()
-      const limiter = context.createDynamicsCompressor()
       const destination = context.createMediaStreamDestination()
-      limiter.threshold.value = -1
-      limiter.knee.value = 0
-      limiter.ratio.value = 20
-      limiter.attack.value = 0.003
-      limiter.release.value = 0.1
+      const limiter = kind === 'mic' ? context.createDynamicsCompressor() : null
       source.connect(gain)
-      gain.connect(limiter)
-      limiter.connect(destination)
+      if (limiter) {
+        limiter.threshold.value = -1
+        limiter.knee.value = 0
+        limiter.ratio.value = 20
+        limiter.attack.value = 0.003
+        limiter.release.value = 0.1
+        gain.connect(limiter)
+        limiter.connect(destination)
+      } else {
+        gain.connect(destination)
+      }
       const graph = { trackIds, source, gain, limiter, destination }
-      remoteVoicePlaybackGraphsRef.current.set(playbackKey, graph)
+      remotePlaybackGraphsRef.current.set(playbackKey, graph)
       element.srcObject = destination.stream
       element.__voxpery_trackIds = trackIds
       if (context.state === 'suspended') void context.resume().catch(() => {})
@@ -449,7 +455,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       element.srcObject = playbackStream
       element.__voxpery_trackIds = trackIds
     }
-  }, [disposeRemoteVoicePlaybackGraph, getRemoteVoiceAudioContext, lightweightMobileVoice])
+  }, [disposeRemotePlaybackGraph, getRemoteAudioContext, lightweightMobileVoice])
 
   const ensureRemoteAudioPlayback = useCallback((playbackKey: string, el: HTMLAudioElement) => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -512,11 +518,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       try {
         const { peerId, kind } = parseRemoteAudioPlaybackKey(playbackKey)
         const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-        const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
-        if (voiceGraph) {
-          const now = voiceGraph.gain.context.currentTime
-          voiceGraph.gain.gain.cancelScheduledValues(now)
-          voiceGraph.gain.gain.setTargetAtTime(peerFactor, now, 0.015)
+        const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
+        if (playbackGraph) {
+          const now = playbackGraph.gain.context.currentTime
+          playbackGraph.gain.gain.cancelScheduledValues(now)
+          playbackGraph.gain.gain.setTargetAtTime(peerFactor, now, 0.015)
           el.volume = global
         } else {
           el.volume = Math.min(1, Math.max(0, global * peerFactor))
@@ -532,8 +538,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
     applyOutputDeviceToElements()
 
-    const voiceContext = remoteVoiceAudioContextRef.current
-    if (!deafenedRef.current && voiceContext?.state === 'suspended') void voiceContext.resume().catch(() => {})
+    const audioContext = remoteAudioContextRef.current
+    if (audioContext?.state === 'suspended') void audioContext.resume().catch(() => {})
     for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
       const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
       if (shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) continue
@@ -710,33 +716,33 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         }
       }
     }
-    for (const playbackKey of remoteVoicePlaybackGraphsRef.current.keys()) {
+    for (const playbackKey of remotePlaybackGraphsRef.current.keys()) {
       const { peerId } = parseRemoteAudioPlaybackKey(playbackKey)
-      if (!state.remoteStreams.has(peerId)) disposeRemoteVoicePlaybackGraph(playbackKey)
+      if (!state.remoteStreams.has(peerId)) disposeRemotePlaybackGraph(playbackKey)
     }
-    if (remoteVoicePlaybackGraphsRef.current.size === 0) {
-      const context = remoteVoiceAudioContextRef.current
+    if (remotePlaybackGraphsRef.current.size === 0) {
+      const context = remoteAudioContextRef.current
       if (context?.state === 'running') void context.suspend().catch(() => {})
     }
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
-  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemoteVoicePlaybackGraph, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemotePlaybackGraph, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
-    const voicePlaybackGraphs = remoteVoicePlaybackGraphsRef.current
+    const playbackGraphs = remotePlaybackGraphsRef.current
     return () => {
       for (const t of retryTimers.values()) {
         window.clearTimeout(t)
       }
       retryTimers.clear()
-      for (const playbackKey of voicePlaybackGraphs.keys()) {
-        disposeRemoteVoicePlaybackGraph(playbackKey)
+      for (const playbackKey of playbackGraphs.keys()) {
+        disposeRemotePlaybackGraph(playbackKey)
       }
-      const context = remoteVoiceAudioContextRef.current
-      remoteVoiceAudioContextRef.current = null
+      const context = remoteAudioContextRef.current
+      remoteAudioContextRef.current = null
       if (context && context.state !== 'closed') void context.close().catch(() => {})
     }
-  }, [disposeRemoteVoicePlaybackGraph])
+  }, [disposeRemotePlaybackGraph])
 
   const renderRemoteAudioElement = useCallback((
     peerId: string,
@@ -758,11 +764,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
           void applyPreferredAudioOutputDevice(audioEl)
           const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
           const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-          const voiceGraph = kind === 'mic' ? remoteVoicePlaybackGraphsRef.current.get(playbackKey) : undefined
-          if (voiceGraph) {
-            voiceGraph.gain.gain.value = peerFactor
+          const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
+          if (playbackGraph) {
+            playbackGraph.gain.gain.value = peerFactor
           }
-          const vol = voiceGraph
+          const vol = playbackGraph
             ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
             : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
           try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
@@ -1345,7 +1351,16 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
             <div className="screen-share-stage" style={{ gridTemplateColumns: `repeat(${stageColumns}, minmax(0, 1fr))` }}>
               {channelParticipants.map((p) => {
                 const isLocal = p.user_id === user?.id
-                const pSpeaking = isLocal ? voiceLocalSpeaking && !voiceControls[p.user_id]?.muted && !voiceControls[p.user_id]?.deafened : voiceSpeakingUserIds.includes(p.user_id) && !voiceControls[p.user_id]?.muted && !voiceControls[p.user_id]?.deafened
+                const participantControl = voiceControls[p.user_id]
+                const participantSilenced = !!(
+                  participantControl?.muted
+                  || participantControl?.deafened
+                  || participantControl?.serverMuted
+                  || participantControl?.serverDeafened
+                )
+                const pSpeaking = (
+                  isLocal ? voiceLocalSpeaking : voiceSpeakingUserIds.includes(p.user_id)
+                ) && !participantSilenced && (isLocal || !effectiveDeafened)
                 return (
                   <div key={`participant-${p.user_id}`} className="voice-stage-tile">
                     <div className={`voice-stage-avatar${pSpeaking ? ' is-speaking' : ''}`}>

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -88,6 +88,44 @@ describe('ChannelSidebar voice media presence', () => {
         expect(useAppStore.getState().joinedVoiceChannelId).toBeNull()
     })
 
+    it('does not show remote speaking rings while the local listener is deafened', () => {
+        const voiceControls = {
+            'local-1': {
+                muted: true,
+                deafened: true,
+                serverMuted: false,
+                serverDeafened: false,
+                screenSharing: false,
+                cameraOn: false,
+            },
+            [remoteMember.user_id]: {
+                muted: false,
+                deafened: false,
+                serverMuted: false,
+                serverDeafened: false,
+                screenSharing: false,
+                cameraOn: false,
+            },
+        }
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            members: [remoteMember],
+            voiceStates: { [remoteMember.user_id]: voiceChannel.id },
+            voiceStateServerIds: { [remoteMember.user_id]: server.id },
+            voiceSpeakingUserIds: [remoteMember.user_id],
+        })
+
+        const { container } = render(
+            <ChannelSidebar channelCategories={['Voice']} voiceControls={voiceControls} />,
+        )
+
+        expect(container.querySelector('.voice-participant-avatar.is-speaking')).toBeNull()
+        expect(screen.getByText(remoteMember.username)).not.toHaveClass('is-speaking')
+        expect(useAppStore.getState().voiceSpeakingUserIds).toEqual([remoteMember.user_id])
+    })
+
     it('stores Discord-style user volume independently up to 200 percent', () => {
         useAppStore.setState({
             servers: [server],

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -552,13 +552,17 @@ export default function ChannelSidebar({
                                             {voiceMembers.map((vm) => {
                                                 const isSelf = user?.id === vm.user_id
                                                 const control = voiceControls[vm.user_id]
+                                                const localControl = user?.id ? voiceControls[user.id] : undefined
+                                                const localPlaybackDeafened = !!(localControl?.deafened || localControl?.serverDeafened)
                                                 const isScreenSharing = !!control?.screenSharing
                                                 const isCameraOn = !!control?.cameraOn
                                                 const isDeafened = !!control?.deafened
                                                 const isMuted = !!control?.muted
                                                 const isServerMuted = !!control?.serverMuted
                                                 const isServerDeafened = !!control?.serverDeafened
-                                                const isSpeaking = (isSelf ? voiceLocalSpeaking : voiceSpeakingUserIds.includes(vm.user_id)) && !isMuted && !isDeafened
+                                                const isSpeaking = (
+                                                    isSelf ? voiceLocalSpeaking : voiceSpeakingUserIds.includes(vm.user_id)
+                                                ) && !isMuted && !isDeafened && !isServerMuted && !isServerDeafened && (isSelf || !localPlaybackDeafened)
                                                 return (
                                                     <div
                                                         key={vm.user_id}

--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -4,6 +4,8 @@ import type { Channel } from '../api'
 import ChatArea from './ChatArea'
 
 const scrollToIndex = vi.fn()
+const measureVirtualElement = vi.fn()
+const measureVirtualizer = vi.fn()
 let estimateVirtualRow: ((index: number) => number) | undefined
 
 vi.mock('@tanstack/react-virtual', () => ({
@@ -25,8 +27,8 @@ vi.mock('@tanstack/react-virtual', () => ({
           key: getItemKey(index),
           start: index * 120,
         })),
-      measureElement: vi.fn(),
-      measure: vi.fn(),
+      measureElement: measureVirtualElement,
+      measure: measureVirtualizer,
       scrollToIndex,
     }
   },
@@ -106,6 +108,8 @@ describe('ChatArea regressions', () => {
   beforeEach(() => {
     vi.useRealTimers()
     scrollToIndex.mockClear()
+    measureVirtualElement.mockClear()
+    measureVirtualizer.mockClear()
     estimateVirtualRow = undefined
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 })
   })
@@ -666,5 +670,43 @@ describe('ChatArea regressions', () => {
         messageRow!.querySelectorAll('.chat-inline-gif-link, .dm-attachments, .message-reactions')
       ).map((element) => element.className)
     ).toEqual(['chat-inline-gif-link', 'dm-attachments', 'message-reactions'])
+  })
+
+  it('remeasures every visible row whose reactions change', () => {
+    const rows = [
+      message('reaction-row-1', 'first', 0),
+      message('reaction-row-2', 'second', 1),
+      message('reaction-row-3', 'third', 2),
+    ]
+    const { rerender } = renderChatArea({ messages: rows })
+    measureVirtualElement.mockClear()
+
+    rerender(
+      <ChatArea
+        activeChannel={channel('general', 'general')}
+        messages={rows.map((row, index) => ({
+          ...row,
+          reactions: [{ emoji: ['👍', '❤️', '🎉'][index], count: index + 1, reacted: false }],
+        }))}
+        draftAttachments={[]}
+        messageInput=""
+        onPickAttachments={vi.fn()}
+        onRemoveAttachment={vi.fn()}
+        onMessageInputChange={vi.fn()}
+        onSendMessage={vi.fn()}
+        onRetryMessage={vi.fn()}
+        onScrollRefReady={setScrollableMetrics}
+        onToggleReaction={vi.fn()}
+      />
+    )
+
+    const remeasuredIds = measureVirtualElement.mock.calls
+      .map(([element]) => (element as HTMLElement | null)?.dataset.messageId)
+      .filter(Boolean)
+    expect(remeasuredIds).toEqual(expect.arrayContaining([
+      'reaction-row-1',
+      'reaction-row-2',
+      'reaction-row-3',
+    ]))
   })
 })

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -62,6 +62,7 @@ const ESTIMATED_ATTACHMENT_ROW_PX = 36
 const ESTIMATED_MEDIA_ROW_PX = 228
 const ESTIMATED_STICKER_ROW_PX = 128
 const ESTIMATED_TEXT_CHARS_PER_LINE = 92
+const ESTIMATED_REACTION_LINE_PX = 30
 
 function mentionPresenceRank(status?: string | null): number {
     const normalized = (status ?? 'offline').toLowerCase()
@@ -329,7 +330,24 @@ function estimateMessageRowHeight(
     estimate += estimateTextExtraHeight(message.content ?? '')
     estimate += estimateEmbeddedMediaHeight(message.content ?? '')
     estimate += estimateAttachmentHeight(message.attachments)
+    const reactionCount = Array.isArray(message.reactions) ? message.reactions.length : 0
+    if (reactionCount > 0) {
+        const reactionsPerLine = mobileLayout ? 4 : 8
+        estimate += Math.ceil(reactionCount / reactionsPerLine) * ESTIMATED_REACTION_LINE_PX
+    }
     return Math.max(metrics.grouped, estimate)
+}
+
+function captureVisibleMessageAnchor(element: HTMLDivElement): { messageId: string; offsetTop: number } | null {
+    const scrollerRect = element.getBoundingClientRect()
+    const candidate = Array.from(element.querySelectorAll<HTMLElement>('[data-message-id]'))
+        .map((item) => ({ item, rect: item.getBoundingClientRect() }))
+        .filter(({ rect }) => rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom)
+        .sort((left, right) => Math.abs(left.rect.top - scrollerRect.top) - Math.abs(right.rect.top - scrollerRect.top))[0]
+    const messageId = candidate?.item.dataset.messageId
+    return messageId
+        ? { messageId, offsetTop: candidate.rect.top - scrollerRect.top }
+        : null
 }
 
 function AttachmentLink({ attachment, index }: { attachment: Attachment; index: number }) {
@@ -681,6 +699,7 @@ export default function ChatArea({
     const resizeAutoScrollRafRef = useRef<number | null>(null)
     const pendingReactionBottomAnchorRef = useRef(false)
     const pendingReactionBottomAnchorTimeoutRef = useRef<number | null>(null)
+    const reactionHistoryAnchorRef = useRef<{ messageId: string; offsetTop: number } | null>(null)
     const userReadingHistoryRef = useRef(false)
     const userScrollIntentUntilRef = useRef(0)
     const lastKnownScrollTopRef = useRef(0)
@@ -856,16 +875,21 @@ export default function ChatArea({
         () => messages.map((message) => message.id).join('|'),
         [messages],
     )
-    const reactionLayoutSignature = useMemo(() => messages.map((message) => {
+    const reactionRowSignatures = useMemo(() => messages.map((message) => {
         const reactions = Array.isArray(message.reactions)
             ? message.reactions.map((reaction) => `${reaction.emoji}:${reaction.count}`).join(',')
             : ''
         return reactions
-    }).join('|'), [messages])
+    }), [messages])
+    const reactionLayoutSignature = useMemo(
+        () => reactionRowSignatures.join('|'),
+        [reactionRowSignatures],
+    )
     const previousReactionLayoutSnapshotRef = useRef({
         channelId: currentChatChannelId,
         messageIds: reactionMessageIdsSignature,
         reactions: reactionLayoutSignature,
+        reactionRows: reactionRowSignatures,
     })
 
     const isAtBottom = useCallback((el: HTMLDivElement) => {
@@ -936,6 +960,7 @@ export default function ChatArea({
     const armReactionBottomAnchor = useCallback(() => {
         const el = messagesScrollRef.current
         if (el && isAtBottom(el) && !userReadingHistoryRef.current && !preservingOlderMessagesRef.current) {
+            reactionHistoryAnchorRef.current = null
             pendingReactionBottomAnchorRef.current = true
             if (pendingReactionBottomAnchorTimeoutRef.current != null) {
                 window.clearTimeout(pendingReactionBottomAnchorTimeoutRef.current)
@@ -944,6 +969,8 @@ export default function ChatArea({
                 pendingReactionBottomAnchorRef.current = false
                 pendingReactionBottomAnchorTimeoutRef.current = null
             }, 5000)
+        } else if (el && userReadingHistoryRef.current && !preservingOlderMessagesRef.current) {
+            reactionHistoryAnchorRef.current = captureVisibleMessageAnchor(el)
         }
     }, [isAtBottom])
 
@@ -1165,6 +1192,9 @@ export default function ChatArea({
             if (movedUp && isUserInitiatedScroll) {
                 markUserReadingHistory()
             }
+            if (userReadingHistoryRef.current && !preservingOlderMessagesRef.current) {
+                reactionHistoryAnchorRef.current = captureVisibleMessageAnchor(el)
+            }
             lastKnownScrollTopRef.current = currentScrollTop
         }
         syncAutoScrollState()
@@ -1213,6 +1243,7 @@ export default function ChatArea({
         lastKnownScrollTopRef.current = messagesScrollRef.current?.scrollTop ?? 0
         preservingOlderMessagesRef.current = false
         olderMessagesAnchorRef.current = null
+        reactionHistoryAnchorRef.current = null
         shouldAutoScrollRef.current = true
         scheduleLatestAnchor(channelId)
         return () => {
@@ -1245,29 +1276,60 @@ export default function ChatArea({
             channelId: currentChatChannelId,
             messageIds: reactionMessageIdsSignature,
             reactions: reactionLayoutSignature,
+            reactionRows: reactionRowSignatures,
         }
         const isReactionOnlyUpdate = previousSnapshot.channelId === currentChatChannelId
             && previousSnapshot.messageIds === reactionMessageIdsSignature
             && previousSnapshot.reactions !== reactionLayoutSignature
         if (!isReactionOnlyUpdate) return
+        reactionRowSignatures.forEach((signature, index) => {
+            if (signature === previousSnapshot.reactionRows[index]) return
+            const row = messagesScrollRef.current?.querySelector<HTMLElement>(
+                `.virtual-list-item[data-index="${index}"]`,
+            )
+            if (row) rowVirtualizer.measureElement(row)
+        })
+        const historyAnchor = reactionHistoryAnchorRef.current
         const hasPendingBottomAnchor = pendingReactionBottomAnchorRef.current
         pendingReactionBottomAnchorRef.current = false
         if (pendingReactionBottomAnchorTimeoutRef.current != null) {
             window.clearTimeout(pendingReactionBottomAnchorTimeoutRef.current)
             pendingReactionBottomAnchorTimeoutRef.current = null
         }
+        if (historyAnchor && userReadingHistoryRef.current && !preservingOlderMessagesRef.current) {
+            const restoreHistoryAnchor = () => {
+                const el = messagesScrollRef.current
+                if (!el) return
+                const row = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]'))
+                    .find((item) => item.dataset.messageId === historyAnchor.messageId)
+                if (!row) return
+                const currentOffset = row.getBoundingClientRect().top - el.getBoundingClientRect().top
+                const delta = currentOffset - historyAnchor.offsetTop
+                if (Math.abs(delta) <= 1) return
+                runProgrammaticScroll(() => {
+                    el.scrollTop += delta
+                    lastKnownScrollTopRef.current = el.scrollTop
+                })
+            }
+            restoreHistoryAnchor()
+            const rafId = window.requestAnimationFrame(() => {
+                restoreHistoryAnchor()
+                const el = messagesScrollRef.current
+                if (el) reactionHistoryAnchorRef.current = captureVisibleMessageAnchor(el)
+            })
+            return () => window.cancelAnimationFrame(rafId)
+        }
         if (!hasPendingBottomAnchor && !shouldAutoScrollRef.current) return
         if (userReadingHistoryRef.current || preservingOlderMessagesRef.current) return
 
         shouldAutoScrollRef.current = true
-        rowVirtualizer.measure()
         snapToBottom()
         const rafId = window.requestAnimationFrame(() => {
             if (!shouldAutoScrollRef.current || userReadingHistoryRef.current || preservingOlderMessagesRef.current) return
             snapToBottom()
         })
         return () => window.cancelAnimationFrame(rafId)
-    }, [currentChatChannelId, reactionLayoutSignature, reactionMessageIdsSignature, rowVirtualizer, snapToBottom])
+    }, [currentChatChannelId, reactionLayoutSignature, reactionMessageIdsSignature, reactionRowSignatures, rowVirtualizer, runProgrammaticScroll, snapToBottom])
 
     /* If user sends while reading older messages, force snap to newest after the new row mounts. */
     useLayoutEffect(() => {
@@ -1631,6 +1693,7 @@ export default function ChatArea({
         userReadingHistoryRef.current = false
         preservingOlderMessagesRef.current = false
         olderMessagesAnchorRef.current = null
+        reactionHistoryAnchorRef.current = null
         pendingReactionBottomAnchorRef.current = false
         if (pendingReactionBottomAnchorTimeoutRef.current != null) {
             window.clearTimeout(pendingReactionBottomAnchorTimeoutRef.current)

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -69,6 +69,9 @@ describe('screen share quality profiles', () => {
     expect(toScreenShareDisplayMediaOptions(video)).toEqual({
       video,
       systemAudio: 'include',
+      windowAudio: 'window',
+      selfBrowserSurface: 'exclude',
+      surfaceSwitching: 'include',
       audio: {
         suppressLocalAudioPlayback: false,
       },

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -93,6 +93,9 @@ type DisplayAudioConstraints = MediaTrackConstraints & {
 
 type ScreenShareDisplayMediaOptions = DisplayMediaStreamOptions & {
     systemAudio: 'include'
+    windowAudio: 'window'
+    selfBrowserSurface: 'exclude'
+    surfaceSwitching: 'include'
 }
 
 export function toScreenShareDisplayMediaOptions(
@@ -101,6 +104,13 @@ export function toScreenShareDisplayMediaOptions(
     return {
         video,
         systemAudio: 'include',
+        // When the picker selects one window, capture only that window's
+        // audio instead of the entire system/call output. Browsers without
+        // window-audio support safely ignore the preference and generally
+        // omit window audio rather than substituting system loopback.
+        windowAudio: 'window',
+        selfBrowserSurface: 'exclude',
+        surfaceSwitching: 'include',
         audio: {
             // Keep the active call audible while the native/macOS share picker changes focus.
             suppressLocalAudioPlayback: false,

--- a/apps/web/src/webrtc/hooks/useVoiceActivity.test.tsx
+++ b/apps/web/src/webrtc/hooks/useVoiceActivity.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '../../stores/app'
+import { useVoiceActivity } from './useVoiceActivity'
+
+describe('useVoiceActivity', () => {
+  let animationFrames: FrameRequestCallback[]
+  let amplitude: number
+
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('voxpery-settings-voice-mode', 'voice_activity')
+    localStorage.setItem('voxpery-settings-noise-suppression', '0')
+    useAppStore.setState({ voiceControls: {}, voiceSpeakingUserIds: [], voiceLocalSpeaking: false })
+    animationFrames = []
+    amplitude = 0.4
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    }))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the published microphone state stable across VAD speaking edges', () => {
+    const source = { connect: vi.fn(), disconnect: vi.fn() }
+    const analyser = {
+      fftSize: 256,
+      frequencyBinCount: 128,
+      smoothingTimeConstant: 0,
+      getFloatTimeDomainData: vi.fn((buffer: Float32Array) => buffer.fill(amplitude)),
+      getFloatFrequencyData: vi.fn((buffer: Float32Array) => buffer.fill(-40)),
+      disconnect: vi.fn(),
+    }
+    const audioContext = {
+      state: 'running',
+      sampleRate: 48_000,
+      createMediaStreamSource: vi.fn(() => source),
+      createAnalyser: vi.fn(() => analyser),
+    } as unknown as AudioContext
+    const setLocalMicMuted = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useVoiceActivity({
+      userId: 'local-user',
+      joinedChannelId: 'voice-1',
+      localStream: {} as MediaStream,
+      getAudioContext: () => audioContext,
+      setLocalMicMuted,
+    }))
+
+    act(() => result.current.startLocalSpeakingMonitor())
+    act(() => {
+      for (let index = 0; index < 8; index += 1) {
+        animationFrames.shift()?.(index * 16)
+      }
+    })
+    expect(useAppStore.getState().voiceLocalSpeaking).toBe(true)
+
+    amplitude = 0
+    act(() => {
+      for (let index = 0; index < 240; index += 1) {
+        animationFrames.shift()?.((index + 8) * 16)
+      }
+    })
+
+    expect(useAppStore.getState().voiceLocalSpeaking).toBe(false)
+    expect(setLocalMicMuted).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/webrtc/hooks/useVoiceActivity.ts
+++ b/apps/web/src/webrtc/hooks/useVoiceActivity.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { LocalAudioTrack } from 'livekit-client'
 import { useAppStore } from '../../stores/app'
 import { getThresholdsFromStorage } from '../sensitivityThreshold'
 import { getStoredVoiceInputProfile, shouldUseAggressiveVoiceIsolation } from '../voiceInputProfile'
@@ -19,9 +18,8 @@ export function useVoiceActivity(options: {
     localStream: MediaStream | null
     getAudioContext: () => AudioContext | null
     setLocalMicMuted: (muted: boolean) => Promise<void>
-    localAudioTrackRef: React.MutableRefObject<LocalAudioTrack | null>
 }) {
-    const { userId, joinedChannelId, localStream, getAudioContext, setLocalMicMuted, localAudioTrackRef } = options
+    const { userId, joinedChannelId, localStream, getAudioContext, setLocalMicMuted } = options
     const [voiceMode, setVoiceMode] = useState<VoiceMode>(() => {
         const modeRaw = localStorage.getItem(VOICE_MODE_KEY)
         return modeRaw === 'push_to_talk' ? 'push_to_talk' : 'voice_activity'
@@ -53,13 +51,6 @@ export function useVoiceActivity(options: {
         void setLocalMicMuted(!shouldEnable)
     }, [getVoiceModeSettings, setLocalMicMuted, userId])
 
-    // ── VAD gate: directly swap the RTCRtpSender's track ──
-    // We go straight to the WebRTC layer: save the sender's real track,
-    // then swap it with a silent track when below threshold.
-    const realSenderTrackRef = useRef<MediaStreamTrack | null>(null)
-    const silentTrackRef = useRef<MediaStreamTrack | null>(null)
-    const silentTrackContextRef = useRef<AudioContext | null>(null)
-    const silentOscillatorRef = useRef<OscillatorNode | null>(null)
     const gateOpenRef = useRef(true)
 
     const cleanupMonitorNodes = useCallback(() => {
@@ -77,103 +68,21 @@ export function useVoiceActivity(options: {
         monitorAnalyserRef.current = null
     }, [])
 
-    const cleanupSilentTrack = useCallback(() => {
-        try {
-            silentOscillatorRef.current?.stop()
-        } catch {
-            // ignore
-        }
-        try {
-            silentOscillatorRef.current?.disconnect()
-        } catch {
-            // ignore
-        }
-        silentOscillatorRef.current = null
-
-        try {
-            silentTrackRef.current?.stop()
-        } catch {
-            // ignore
-        }
-        silentTrackRef.current = null
-
-        const silentContext = silentTrackContextRef.current
-        silentTrackContextRef.current = null
-        if (silentContext) {
-            void silentContext.close().catch(() => {
-                // ignore
-            })
-        }
-    }, [])
-
     const resetVoiceActivityGate = useCallback(() => {
-        const track = localAudioTrackRef.current
-        const sender = (track as unknown as { sender?: RTCRtpSender })?.sender
-        const realTrack = realSenderTrackRef.current
-
         gateOpenRef.current = true
         voiceActivitySpeakingRef.current = false
-
-        if (sender && realTrack && sender.track !== realTrack) {
-            void sender.replaceTrack(realTrack).catch(() => {
-                // ignore
-            })
-        }
-
-        realSenderTrackRef.current = null
-        cleanupSilentTrack()
-    }, [cleanupSilentTrack, localAudioTrackRef])
+    }, [])
 
     const applyVoiceActivityGate = useCallback((speaking: boolean, options?: { updateSpeakingRef?: boolean }) => {
         if (options?.updateSpeakingRef !== false) {
             voiceActivitySpeakingRef.current = speaking
         }
-        const { mode } = getVoiceModeSettings()
-        if (mode !== 'voice_activity') return
-        // Don't override manual mute/deafen
-        if (userId) {
-            const control = useAppStore.getState().voiceControls[userId]
-            if (control?.muted || control?.deafened) return
-        }
-
-        const track = localAudioTrackRef.current
-        const sender = (track as unknown as { sender?: RTCRtpSender })?.sender
-        if (!sender) return
-
-        if (speaking && !gateOpenRef.current) {
-            // ── OPEN gate: restore real track ──
-            gateOpenRef.current = true
-            if (realSenderTrackRef.current) {
-                void sender.replaceTrack(realSenderTrackRef.current)
-            }
-        } else if (!speaking && gateOpenRef.current) {
-            // ── CLOSE gate: swap to silence ──
-            gateOpenRef.current = false
-            // Save the real track on first close
-            if (!realSenderTrackRef.current && sender.track) {
-                realSenderTrackRef.current = sender.track
-            }
-            // Lazily create a silent track
-            if (!silentTrackRef.current) {
-                try {
-                    const ctx = new AudioContext()
-                    const osc = ctx.createOscillator()
-                    const gain = ctx.createGain()
-                    gain.gain.value = 0
-                    const dest = ctx.createMediaStreamDestination()
-                    osc.connect(gain)
-                    gain.connect(dest)
-                    osc.start()
-                    silentTrackContextRef.current = ctx
-                    silentOscillatorRef.current = osc
-                    silentTrackRef.current = dest.stream.getAudioTracks()[0]
-                } catch {
-                    return
-                }
-            }
-            void sender.replaceTrack(silentTrackRef.current)
-        }
-    }, [getVoiceModeSettings, userId, localAudioTrackRef])
+        // Keep the published microphone sender stable. LiveKit's Opus DTX and
+        // the existing suppression pipeline already handle quiet periods;
+        // swapping sender tracks at every VAD edge can interrupt multi-party
+        // audio sessions and remote media playback on some platforms.
+        gateOpenRef.current = true
+    }, [])
 
     const startLocalSpeakingMonitor = useCallback((streamOverride?: MediaStream | null) => {
         const stream = streamOverride ?? localStream

--- a/apps/web/src/webrtc/remoteMediaControls.test.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.test.ts
@@ -60,9 +60,11 @@ describe('remote media controls', () => {
     expect(shouldMuteRemoteAudioPlayback('screen', false)).toBe(false)
   })
 
-  it('keeps mobile microphone playback on the direct low-overhead media path', () => {
+  it('uses one stable Web Audio playback path on desktop and the direct path on mobile', () => {
     expect(shouldUseDirectRemoteAudioPlayback('mic', true, 1)).toBe(true)
+    expect(shouldUseDirectRemoteAudioPlayback('screen', true, 1)).toBe(true)
     expect(shouldUseDirectRemoteAudioPlayback('mic', false, 1)).toBe(false)
-    expect(shouldUseDirectRemoteAudioPlayback('screen', false, 1)).toBe(true)
+    expect(shouldUseDirectRemoteAudioPlayback('screen', false, 1)).toBe(false)
+    expect(shouldUseDirectRemoteAudioPlayback('screen', false, 0)).toBe(true)
   })
 })

--- a/apps/web/src/webrtc/remoteMediaControls.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.ts
@@ -57,9 +57,9 @@ export function shouldMuteRemoteAudioPlayback(kind: RemoteAudioKind, voiceDeafen
 }
 
 export function shouldUseDirectRemoteAudioPlayback(
-  kind: RemoteAudioKind,
+  _kind: RemoteAudioKind,
   lightweightMobileVoice: boolean,
   audioTrackCount: number,
 ): boolean {
-  return kind === 'screen' || lightweightMobileVoice || audioTrackCount === 0
+  return lightweightMobileVoice || audioTrackCount === 0
 }

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -560,7 +560,6 @@ export function useLiveKitVoice() {
     localStream,
     getAudioContext,
     setLocalMicMuted,
-    localAudioTrackRef
   })
 
   const { pingMs, wsPingMs, rtcPingMs, packetLossPct, jitterMs, pingJitterMs } = useWebrtcDiagnostics({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-08-22
+
+### Fixed
+- Kept remote microphone and watched screen-share playback stable across local speaking-state changes, preserving independent voice and shared-audio mixing for multi-participant calls.
+- Prevented consecutive reaction updates from overlapping virtualized message rows or displacing the reader's scroll anchor.
+- Suppressed remote speaking rings while the local listener is deafened, restoring the current indicators immediately after undeafen.
+
 ## [0.2.10] - 2026-08-21
 
 ### Fixed

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -60,7 +60,10 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Voice access revocation works: kick, ban, moderator disconnect, and removing `Connect to Voice` immediately remove the affected user from the active voice room.
 - [ ] Camera self-preview recovers after switching from an active voice channel to another chat, DM, or server and then returning, while the remote user keeps seeing the camera feed.
 - [ ] Remote camera and screen-share tiles can be hidden and shown again without leaving voice; hiding media unsubscribes its remote publications for that viewer while normal microphone audio continues.
-- [ ] In a call with at least three participants, local or remote speaking-state changes do not restart, mute, or interrupt watched screen-share audio; voice and stream audio remain independently audible.
+- [ ] In a call with at least five participants, local or remote speaking-state changes do not restart, mute, or interrupt watched screen-share audio; voice and stream audio remain independently audible.
+- [ ] While self-deafened or server-deafened, remote participant speaking rings stay hidden in both the channel sidebar and voice stage; undeafening restores current speaking feedback without reconnecting.
+- [ ] Sharing a window requests only that selected window's audio and excludes Voxpery's own browser surface; runtimes without selected-window audio support fall back to a silent window share rather than broadcasting unrelated system/call audio.
+- [ ] Adding reactions to three consecutive messages keeps every reaction row below its own message on desktop and mobile; a user reading history keeps the same scroll anchor while a bottom-anchored user remains at the latest message.
 - [ ] Screen share quality presets match the UI summary: Presentation uses 1080p30 at 4 Mbps, Video uses 1080p60 at 6 Mbps, Gaming uses 1080p60 at 8 Mbps, and Auto does not promote monitor sharing to Gaming.
 - [ ] Hiding or minimizing the app pauses incoming remote video subscriptions while voice audio continues, and restoring visibility resumes video without replaying media-start cues.
 - [ ] Moderation flows (kick/ban/timeout/clear-timeout) work.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -139,11 +139,12 @@ Room.localParticipant.publishTrack
 
 Two modes:
 
-1. **Voice Activity**: Mic auto-mutes when RMS below threshold (Discord-like)
+1. **Voice Activity**: Mic pickup and speaking feedback follow the configured RMS threshold
    - Analyser reads RMS from the post-suppression signal (`post-denoise`, `post-floor-suppression`, `pre-volume`)
-   - If above `onThreshold`, enable track; below `offThreshold` for enough held frames, disable
+   - Threshold crossings update speaking state without replacing or restarting the published WebRTC sender track
    - Fast attack + slower release + hysteresis keep speaking feedback responsive without flicker during short pauses
-   - Suppression-enabled mode requires consecutive speech-like frames before opening the gate, and aggressive isolation rejects noise-dominant frames such as keyboard clicks, mouse clicks, and breath-heavy broadband noise
+   - Suppression-enabled mode requires consecutive speech-like frames before reporting speech, and aggressive isolation rejects noise-dominant frames such as keyboard clicks, mouse clicks, and breath-heavy broadband noise
+   - Quiet transport is handled by the processed audio pipeline and Opus DTX. Manual mute, deafen, and push-to-talk remain the only controls that change the microphone's published state.
 2. **Push-to-Talk**: Manual control via keyboard (default: `V` key)
 
 ### Microphone Mute Shortcut
@@ -178,17 +179,21 @@ LiveKit RemoteTrack
     |
 MediaStream
     |
-<audio> element (volume 0.0-1.0)
+Shared AudioContext (desktop) / direct media path (mobile)
     |
-AudioContext analyser (speaking indicator)
+Independent microphone and screen-share gain buses
+    |
+<audio> element (global output volume)
     |
 Speaker
 ```
 
-- **Output volume**: Global 1-100%, per-peer microphone 0-100%, and per-screen-share audio 0-100%.
-- **Distortion-safe playback**: Remote media stays on the native media-element path. Legacy values above 100% are migrated to 100% so playback is not clipped or stranded on a closed Web Audio graph.
+- **Output volume**: Global 1-100%, per-peer microphone 0-200%, and per-screen-share audio 0-100%.
+- **Stable desktop mixing**: Remote microphone and screen-share audio use one long-lived `AudioContext` with independent gain buses. Speaking-state changes never rebuild, mute, or restart watched stream audio.
+- **Source-aware dynamics**: Microphone amplification keeps its peak limiter, while screen-share audio bypasses voice compression so music and game dynamics are preserved. Mobile web keeps the lower-overhead direct media path.
 - **Deafen**: Mutes remote microphone playback while leaving watched screen-share audio under its independent stream volume/mute controls
 - **Immediate deafen**: The playback ref and every active remote microphone element are muted synchronously with the control click, closing the render/effect window where a new track could remain audible briefly.
+- **Deafened speaking feedback**: Self-deafen and server-deafen suppress remote speaking rings in both the channel sidebar and voice stage. The underlying speaking state remains intact, so indicators resume immediately after undeafen without waiting for a new speaking event.
 - **Watch screen share**: Screen-share video and shared audio remain unsubscribed until the viewer chooses `Watch stream`; `Stop watching` removes only those viewer subscriptions while the peer's normal microphone audio remains active.
 - **Pre-join media presence**: Server members can see a camera icon and `LIVE` screen-share badge beside voice participants before joining the channel. These indicators use the server-broadcast voice control state and do not subscribe the viewer to media.
 
@@ -252,6 +257,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - **Screen-share audio**: `contentHint = 'music'`, stereo 128 kbps Opus, continuous transmission (`dtx = false`), and RED packet-loss resilience preserve system, game, and music audio independently from the mono speech microphone profile.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement). On mobile devices with more than one camera, the local preview exposes a front/rear switch that restarts the existing published LiveKit video track in place. Devices with only one available camera do not show the control.
 - A share is not published without a live video track. A missing system/tab audio track is treated as an intentional silent share; capture or publication failures still surface as errors. System-audio availability is determined by the operating system, browser/runtime, selected share surface, and the picker audio option rather than the GPU vendor.
+- Display capture requests selected-window audio for window shares, exclude Voxpery's own browser surface, and let the native picker expose broader system-audio capture only for surfaces where the runtime supports it. Voxpery never substitutes whole-system audio when selected-window audio is unavailable.
 - Publishing is rollback-safe: if any selected screen track fails to publish, already-published tracks from that attempt are unpublished and the local capture is stopped.
 - Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio sample rate/channel count/content hint/publish profile, codec/scalability mode, simulcast state, outbound video resolution/FPS/bitrate/packet/quality-limitation samples, and actual screen-audio Opus bitrate/channel/packet samples without device identifiers.
 


### PR DESCRIPTION
## Summary

- Stabilized concurrent remote voice and screen-share playback during speaking-state changes.
- Fixed reaction row measurement and scroll-anchor preservation in virtualized chat.
- Hid remote speaking indicators while the local user is deafened.
- Updated screen-share capture behavior, voice regression coverage, and release smoke checks.
- Bumped web, server, and desktop metadata to v0.2.11.

## Validation

- `npm run lint`
- `npm run test:run -- --maxWorkers=1`
- `npm run build`
- Local verification of voice/stream audio, reaction layout, and deafen speaking indicators