### PR TITLE
fix: enhance remote audio mixing and deafen functionality for improve…

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MemberInfo } from '../api'
 import type { Channel, Server, User } from '../types'
 import { useAppStore } from '../stores/app'
@@ -92,6 +92,70 @@ function mockMobileViewport(matches: boolean) {
   }))
 }
 
+type MockAudioContextInstance = {
+  createMediaStreamDestination: ReturnType<typeof vi.fn>
+  createMediaStreamSource: ReturnType<typeof vi.fn>
+  createGain: ReturnType<typeof vi.fn>
+}
+
+let restoreAudioContextMock: (() => void) | null = null
+
+function installAudioContextMock(): MockAudioContextInstance[] {
+  const original = Object.getOwnPropertyDescriptor(window, 'AudioContext')
+  const instances: MockAudioContextInstance[] = []
+
+  class MockAudioContext {
+    state: AudioContextState = 'running'
+    currentTime = 0
+    createMediaStreamSource = vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }))
+    createGain = vi.fn(() => ({
+      context: this,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      gain: {
+        value: 1,
+        cancelScheduledValues: vi.fn(),
+        setValueAtTime: vi.fn(),
+        setTargetAtTime: vi.fn(),
+      },
+    }))
+    createDynamicsCompressor = vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      threshold: { value: 0 },
+      knee: { value: 0 },
+      ratio: { value: 0 },
+      attack: { value: 0 },
+      release: { value: 0 },
+    }))
+    createMediaStreamDestination = vi.fn(() => ({
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      stream: new MediaStream([mediaTrack('audio', 'mixed-output', { stop: vi.fn() })]),
+    }))
+    resume = vi.fn(async () => { this.state = 'running' })
+    suspend = vi.fn(async () => { this.state = 'suspended' })
+    close = vi.fn(async () => { this.state = 'closed' })
+
+    constructor() {
+      instances.push(this)
+    }
+  }
+
+  Object.defineProperty(window, 'AudioContext', {
+    configurable: true,
+    value: MockAudioContext,
+  })
+  restoreAudioContextMock = () => {
+    if (original) Object.defineProperty(window, 'AudioContext', original)
+    else delete (window as Window & { AudioContext?: typeof AudioContext }).AudioContext
+  }
+  return instances
+}
+
 function voiceState(overrides?: Record<string, unknown>) {
   return {
     joinedChannelId: voiceChannel.id,
@@ -155,6 +219,11 @@ function renderActiveCallBar(overrides?: Record<string, unknown>) {
 }
 
 describe('ActiveCallBar regressions', () => {
+  afterEach(() => {
+    restoreAudioContextMock?.()
+    restoreAudioContextMock = null
+  })
+
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
@@ -363,13 +432,69 @@ describe('ActiveCallBar regressions', () => {
       watchedRemoteScreenPeerIds: new Set(['peer-1']),
     })
 
-    const [voiceAudio, screenAudio] = Array.from(container.querySelectorAll('audio'))
+    const voiceAudio = container.querySelector('audio[data-remote-audio-kind="mic"]') as HTMLAudioElement | null
+    const screenAudio = container.querySelector('audio[data-remote-audio-kind="screen"]') as HTMLAudioElement | null
     if (!voiceAudio || !screenAudio) throw new Error('Remote audio playback elements were not rendered.')
 
     fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
 
     expect(voiceAudio.muted).toBe(true)
     expect(screenAudio.muted).toBe(false)
+  })
+
+  it('immediately gates desktop microphone buses while keeping watched screen audio active', () => {
+    const audioContexts = installAudioContextMock()
+    const micTrack = mediaTrack('audio', 'peer-mic')
+    const screenAudioTrack = mediaTrack('audio', 'peer-screen-audio')
+    markRemoteAudioTrackSource(micTrack, 'voice')
+    markRemoteAudioTrackSource(screenAudioTrack, 'screen')
+
+    const { container } = renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', new MediaStream([micTrack, screenAudioTrack])]]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+
+    expect(audioContexts).toHaveLength(1)
+    const gainNodes = audioContexts[0].createGain.mock.results.map((result) => result.value)
+    const microphoneBus = gainNodes[1]
+    const screenBus = gainNodes[2]
+    if (!microphoneBus || !screenBus) throw new Error('Remote mixer gain buses were not created.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
+
+    expect(microphoneBus.gain.setValueAtTime).toHaveBeenLastCalledWith(0, 0)
+    expect(screenBus.gain.setValueAtTime).not.toHaveBeenCalled()
+    expect(screenBus.gain.setTargetAtTime).toHaveBeenLastCalledWith(1, 0, 0.015)
+    const mixerOutput = container.querySelector('audio[data-remote-audio-output="mixed"]') as HTMLAudioElement | null
+    expect(mixerOutput?.muted).toBe(false)
+  })
+
+  it('starts microphone tracks that arrive while deafened at zero gain', () => {
+    const audioContexts = installAudioContextMock()
+    const { voice, rerender } = renderActiveCallBar()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
+
+    const reconnectingMic = mediaTrack('audio', 'peer-reconnected-mic')
+    markRemoteAudioTrackSource(reconnectingMic, 'voice')
+    voice.state = voiceState({
+      remoteStreams: new Map([['peer-1', new MediaStream([reconnectingMic])]]),
+    })
+    rerender(
+      <MemoryRouter>
+        <ActiveCallBar
+          selectedVoiceChannelId={voiceChannel.id}
+          activeChannelId={voiceChannel.id}
+        />
+      </MemoryRouter>
+    )
+
+    expect(audioContexts).toHaveLength(1)
+    const microphoneBus = audioContexts[0].createGain.mock.results[1]?.value
+    if (!microphoneBus) throw new Error('The reconnecting microphone bus was not created.')
+    expect(microphoneBus.gain.value).toBe(0)
+    const remoteMic = document.querySelector('audio[data-remote-audio-kind="mic"]') as HTMLAudioElement | null
+    expect(remoteMic?.muted).toBe(true)
   })
 
   it('hides remote speaking indicators while locally deafened and restores them on undeafen', () => {
@@ -393,6 +518,7 @@ describe('ActiveCallBar regressions', () => {
   })
 
   it('keeps five remote voices and watched screen audio stable across speaking changes', () => {
+    const audioContexts = installAudioContextMock()
     const sharerMic = mediaTrack('audio', 'peer-1-mic')
     const screenAudio = mediaTrack('audio', 'peer-screen-audio')
     markRemoteAudioTrackSource(sharerMic, 'voice')
@@ -441,7 +567,19 @@ describe('ActiveCallBar regressions', () => {
         remoteStreams: 5,
       },
     })
-    expect(container.querySelectorAll('audio').length).toBeGreaterThanOrEqual(6)
+    const mixerOutput = container.querySelector('audio[data-remote-audio-output="mixed"]') as HTMLAudioElement | null
+    if (!mixerOutput) throw new Error('The stable remote audio mixer output was not rendered.')
+    expect(audioContexts).toHaveLength(1)
+    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledOnce()
+    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledTimes(6)
+    expect(mixerOutput.srcObject).toBeInstanceOf(MediaStream)
+    const mixedSourceElements = Array.from(container.querySelectorAll<HTMLAudioElement>(
+      'audio[data-remote-audio-kind="mic"], audio[data-peer-id="peer-1"][data-remote-audio-kind="screen"]',
+    ))
+    expect(mixedSourceElements).toHaveLength(6)
+    expect(mixedSourceElements.every((element) => element.srcObject === null && element.muted)).toBe(true)
+    expect(play.mock.instances.every((element) => element === mixerOutput)).toBe(true)
+    const initialMixerStream = mixerOutput.srcObject
     play.mockClear()
 
     act(() => useAppStore.getState().setVoiceSpeaking(['peer-2', 'peer-3'], false))
@@ -449,6 +587,9 @@ describe('ActiveCallBar regressions', () => {
     act(() => useAppStore.getState().setVoiceSpeaking([], false))
 
     expect(play).not.toHaveBeenCalled()
+    expect(mixerOutput.srcObject).toBe(initialMixerStream)
+    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledOnce()
+    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledTimes(6)
   })
 
   it('uses the configured shortcut while the web tab is focused', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -65,6 +65,11 @@ interface RemoteAudioPlaybackGraph {
   source: MediaStreamAudioSourceNode
   gain: GainNode
   limiter: DynamicsCompressorNode | null
+}
+
+interface RemoteAudioMixer {
+  context: AudioContext
+  masterGain: GainNode
   destination: MediaStreamAudioDestinationNode
 }
 
@@ -82,6 +87,7 @@ type RemoteMediaPlaceholder = {
 type RemoteAudioPlaybackLayerProps = {
   remoteStreams: Map<string, MediaStream>
   watchedScreenPeerIds: Set<string>
+  renderMixerOutput: () => ReactNode
   renderAudioElement: (
     peerId: string,
     stream: MediaStream,
@@ -126,10 +132,12 @@ function RemoteVideoTrack({ track }: { track: MediaStreamTrack }) {
 const RemoteAudioPlaybackLayer = memo(function RemoteAudioPlaybackLayer({
   remoteStreams,
   watchedScreenPeerIds,
+  renderMixerOutput,
   renderAudioElement,
 }: RemoteAudioPlaybackLayerProps) {
   return (
     <div style={{ display: 'none' }}>
+      {renderMixerOutput()}
       {Array.from(remoteStreams.entries()).flatMap(([peerId, stream]) => (
         (['mic', 'screen'] as RemoteAudioKind[]).map((kind) => (
           renderAudioElement(peerId, stream, kind, kind === 'mic' || watchedScreenPeerIds.has(peerId))
@@ -286,6 +294,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
   const remoteAudioContextRef = useRef<AudioContext | null>(null)
+  const remoteAudioMixerRef = useRef<RemoteAudioMixer | null>(null)
+  const remoteAudioMixerOutputRef = useRef<HTMLAudioElement | null>(null)
   const remotePlaybackGraphsRef = useRef<Map<string, RemoteAudioPlaybackGraph>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
@@ -378,13 +388,12 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     graph.source.disconnect()
     graph.gain.disconnect()
     graph.limiter?.disconnect()
-    graph.destination.disconnect()
-    graph.destination.stream.getTracks().forEach((track) => track.stop())
     remotePlaybackGraphsRef.current.delete(playbackKey)
   }, [])
 
   const getRemoteAudioContext = useCallback((): AudioContext | null => {
-    if (remoteAudioContextRef.current?.state !== 'closed') return remoteAudioContextRef.current
+    const current = remoteAudioContextRef.current
+    if (current && current.state !== 'closed') return current
     const AudioCtor = window.AudioContext
       || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
     if (!AudioCtor) return null
@@ -396,6 +405,24 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       return null
     }
   }, [])
+
+  const getRemoteAudioMixer = useCallback((): RemoteAudioMixer | null => {
+    const context = getRemoteAudioContext()
+    if (!context) return null
+    const current = remoteAudioMixerRef.current
+    if (current?.context === context) return current
+
+    try {
+      const masterGain = context.createGain()
+      const destination = context.createMediaStreamDestination()
+      masterGain.connect(destination)
+      const mixer = { context, masterGain, destination }
+      remoteAudioMixerRef.current = mixer
+      return mixer
+    } catch {
+      return null
+    }
+  }, [getRemoteAudioContext])
 
   const attachRemoteAudioPlaybackStream = useCallback((
     playbackKey: string,
@@ -413,27 +440,31 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
     const current = remotePlaybackGraphsRef.current.get(playbackKey)
     if (current?.trackIds === trackIds) {
-      if (element.srcObject !== current.destination.stream) element.srcObject = current.destination.stream
+      element.srcObject = null
+      element.muted = true
       element.__voxpery_trackIds = trackIds
       return
     }
 
     disposeRemotePlaybackGraph(playbackKey)
-    const context = getRemoteAudioContext()
-    if (!context) {
+    const mixer = getRemoteAudioMixer()
+    if (!mixer) {
       element.srcObject = playbackStream
       element.__voxpery_trackIds = trackIds
       return
     }
 
     try {
-      // Voice and stream playback share one stable AudioContext while keeping
-      // independent gain buses. Only voice needs peak limiting; screen audio
-      // remains uncompressed so music/game playback is not flattened.
-      const source = context.createMediaStreamSource(playbackStream)
-      const gain = context.createGain()
-      const destination = context.createMediaStreamDestination()
-      const limiter = kind === 'mic' ? context.createDynamicsCompressor() : null
+      // All desktop remote sources feed one persistent output stream. This keeps
+      // local microphone/VAD activity from competing with a separate media
+      // element for every peer and screen-share track.
+      const source = mixer.context.createMediaStreamSource(playbackStream)
+      const gain = mixer.context.createGain()
+      const limiter = kind === 'mic' ? mixer.context.createDynamicsCompressor() : null
+      const { peerId } = parseRemoteAudioPlaybackKey(playbackKey)
+      gain.gain.value = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
+        ? 0
+        : getPlaybackVolumeFactor(peerId, kind)
       source.connect(gain)
       if (limiter) {
         limiter.threshold.value = -1
@@ -442,20 +473,21 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         limiter.attack.value = 0.003
         limiter.release.value = 0.1
         gain.connect(limiter)
-        limiter.connect(destination)
+        limiter.connect(mixer.masterGain)
       } else {
-        gain.connect(destination)
+        gain.connect(mixer.masterGain)
       }
-      const graph = { trackIds, source, gain, limiter, destination }
+      const graph = { trackIds, source, gain, limiter }
       remotePlaybackGraphsRef.current.set(playbackKey, graph)
-      element.srcObject = destination.stream
+      element.srcObject = null
+      element.muted = true
       element.__voxpery_trackIds = trackIds
-      if (context.state === 'suspended') void context.resume().catch(() => {})
+      if (mixer.context.state === 'suspended') void mixer.context.resume().catch(() => {})
     } catch {
       element.srcObject = playbackStream
       element.__voxpery_trackIds = trackIds
     }
-  }, [disposeRemotePlaybackGraph, getRemoteAudioContext, lightweightMobileVoice])
+  }, [disposeRemotePlaybackGraph, getPlaybackVolumeFactor, getRemoteAudioMixer, lightweightMobileVoice, parseRemoteAudioPlaybackKey])
 
   const ensureRemoteAudioPlayback = useCallback((playbackKey: string, el: HTMLAudioElement) => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -473,8 +505,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         clearRetry()
         return
       }
+      const isMixerOutput = playbackKey === 'remote-mixer-output'
       const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
-      if (el.muted || shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) {
+      if (el.muted || (!isMixerOutput && shouldMuteRemoteAudioPlayback(kind, deafenedRef.current))) {
         clearRetry()
         return
       }
@@ -505,7 +538,20 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     attempt()
   }, [parseRemoteAudioPlaybackKey])
 
+  const syncRemoteAudioMixerOutput = useCallback(() => {
+    const mixer = remoteAudioMixerRef.current
+    const element = remoteAudioMixerOutputRef.current
+    if (!mixer || !element || remotePlaybackGraphsRef.current.size === 0) return
+    if (element.srcObject !== mixer.destination.stream) element.srcObject = mixer.destination.stream
+    element.volume = Math.min(1, Math.max(0, outputVolumeRef.current / 100))
+    element.muted = false
+    void applyPreferredAudioOutputDevice(element)
+    ensureRemoteAudioPlayback('remote-mixer-output', element)
+  }, [ensureRemoteAudioPlayback])
+
   const applyOutputDeviceToElements = useCallback(() => {
+    const mixerOutput = remoteAudioMixerOutputRef.current
+    if (mixerOutput) void applyPreferredAudioOutputDevice(mixerOutput)
     for (const el of remoteAudioRefsRef.current.values()) {
       void applyPreferredAudioOutputDevice(el)
     }
@@ -514,23 +560,34 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const applyOutputVolumeToElements = useCallback((vol: number) => {
     const global = Math.min(1, Math.max(0, vol))
     const isDeafened = deafenedRef.current
+    for (const [playbackKey, playbackGraph] of remotePlaybackGraphsRef.current.entries()) {
+      const { peerId, kind } = parseRemoteAudioPlaybackKey(playbackKey)
+      const peerFactor = getPlaybackVolumeFactor(peerId, kind)
+      const target = shouldMuteRemoteAudioPlayback(kind, isDeafened) ? 0 : peerFactor
+      const now = playbackGraph.gain.context.currentTime
+      playbackGraph.gain.gain.cancelScheduledValues(now)
+      if (target === 0) playbackGraph.gain.gain.setValueAtTime(0, now)
+      else playbackGraph.gain.gain.setTargetAtTime(target, now, 0.015)
+    }
     for (const [playbackKey, el] of remoteAudioRefsRef.current.entries()) {
       try {
         const { peerId, kind } = parseRemoteAudioPlaybackKey(playbackKey)
         const peerFactor = getPlaybackVolumeFactor(peerId, kind)
         const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
         if (playbackGraph) {
-          const now = playbackGraph.gain.context.currentTime
-          playbackGraph.gain.gain.cancelScheduledValues(now)
-          playbackGraph.gain.gain.setTargetAtTime(peerFactor, now, 0.015)
-          el.volume = global
+          el.muted = true
         } else {
           el.volume = Math.min(1, Math.max(0, global * peerFactor))
+          el.muted = shouldMuteRemoteAudioPlayback(kind, isDeafened)
         }
-        el.muted = shouldMuteRemoteAudioPlayback(kind, isDeafened)
       } catch {
         // ignore
       }
+    }
+    const mixerOutput = remoteAudioMixerOutputRef.current
+    if (mixerOutput) {
+      mixerOutput.volume = global
+      mixerOutput.muted = remotePlaybackGraphsRef.current.size === 0
     }
   }, [getPlaybackVolumeFactor, parseRemoteAudioPlaybackKey])
 
@@ -540,14 +597,16 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
     const audioContext = remoteAudioContextRef.current
     if (audioContext?.state === 'suspended') void audioContext.resume().catch(() => {})
+    if (remotePlaybackGraphsRef.current.size > 0) syncRemoteAudioMixerOutput()
     for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
+      if (remotePlaybackGraphsRef.current.has(playbackKey)) continue
       const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
       if (shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) continue
       const stream = element.srcObject
       if (!(stream instanceof MediaStream) || stream.getAudioTracks().length === 0) continue
       ensureRemoteAudioPlayback(playbackKey, element)
     }
-  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback, parseRemoteAudioPlaybackKey])
+  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback, parseRemoteAudioPlaybackKey, syncRemoteAudioMixerOutput])
 
   useEffect(() => {
     const recoverWhenVisible = () => {
@@ -707,11 +766,12 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         const prevTrackIds = el.__voxpery_trackIds
         if (currentTrackIds !== prevTrackIds) {
           attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, el)
-          void applyPreferredAudioOutputDevice(el)
         }
+        const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
         const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
-        el.muted = shouldMute
-        if (!shouldMute && currentTrackIds) {
+        el.muted = playbackGraph ? true : shouldMute
+        if (!playbackGraph) void applyPreferredAudioOutputDevice(el)
+        if (!playbackGraph && !shouldMute && currentTrackIds) {
           ensureRemoteAudioPlayback(playbackKey, el)
         }
       }
@@ -722,10 +782,17 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
     if (remotePlaybackGraphsRef.current.size === 0) {
       const context = remoteAudioContextRef.current
+      const mixerOutput = remoteAudioMixerOutputRef.current
+      if (mixerOutput) {
+        mixerOutput.muted = true
+        mixerOutput.srcObject = null
+      }
       if (context?.state === 'running') void context.suspend().catch(() => {})
+    } else {
+      syncRemoteAudioMixerOutput()
     }
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
-  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemotePlaybackGraph, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemotePlaybackGraph, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams, syncRemoteAudioMixerOutput])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -738,11 +805,41 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       for (const playbackKey of playbackGraphs.keys()) {
         disposeRemotePlaybackGraph(playbackKey)
       }
+      const mixer = remoteAudioMixerRef.current
+      remoteAudioMixerRef.current = null
+      remoteAudioMixerOutputRef.current = null
+      mixer?.masterGain.disconnect()
+      mixer?.destination.disconnect()
+      mixer?.destination.stream.getTracks().forEach((track) => track.stop())
       const context = remoteAudioContextRef.current
       remoteAudioContextRef.current = null
       if (context && context.state !== 'closed') void context.close().catch(() => {})
     }
   }, [disposeRemotePlaybackGraph])
+
+  const attachRemoteAudioMixerOutputElement = useCallback((element: HTMLAudioElement | null) => {
+    remoteAudioMixerOutputRef.current = element
+    if (!element) {
+      const timer = remoteAudioRetryTimerRef.current.get('remote-mixer-output')
+      if (timer != null) window.clearTimeout(timer)
+      remoteAudioRetryTimerRef.current.delete('remote-mixer-output')
+      return
+    }
+    syncRemoteAudioMixerOutput()
+  }, [syncRemoteAudioMixerOutput])
+
+  const renderRemoteAudioMixerOutput = useCallback(() => {
+    if (lightweightMobileVoice) return null
+    return (
+      <audio
+        key="remote-mixer-output"
+        data-remote-audio-output="mixed"
+        autoPlay
+        playsInline
+        ref={attachRemoteAudioMixerOutputElement}
+      />
+    )
+  }, [attachRemoteAudioMixerOutputElement, lightweightMobileVoice])
 
   const renderRemoteAudioElement = useCallback((
     peerId: string,
@@ -752,37 +849,44 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   ) => {
     const playbackKey = remoteAudioPlaybackKey(peerId, kind)
     return (
-      <audio key={playbackKey} autoPlay playsInline ref={(el) => {
-        if (el) {
-          const audioEl = el as VoxperyAudioElement
-          remoteAudioRefsRef.current.set(playbackKey, audioEl)
-          const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
-          const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
-          if (audioEl.__voxpery_trackIds !== currentTrackIds) {
-            attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
+      <audio
+        key={playbackKey}
+        data-peer-id={peerId}
+        data-remote-audio-kind={kind}
+        autoPlay
+        playsInline
+        ref={(el) => {
+          if (el) {
+            const audioEl = el as VoxperyAudioElement
+            remoteAudioRefsRef.current.set(playbackKey, audioEl)
+            const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
+            const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
+            if (audioEl.__voxpery_trackIds !== currentTrackIds) {
+              attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
+            }
+            const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
+            const peerFactor = getPlaybackVolumeFactor(peerId, kind)
+            const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
+            if (playbackGraph) {
+              playbackGraph.gain.gain.value = shouldMute ? 0 : peerFactor
+            }
+            const vol = playbackGraph
+              ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
+              : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
+            try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
+            audioEl.muted = playbackGraph ? true : shouldMute
+            if (!playbackGraph) void applyPreferredAudioOutputDevice(audioEl)
+            if (!playbackGraph && !shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
+          } else {
+            remoteAudioRefsRef.current.delete(playbackKey)
+            const timer = remoteAudioRetryTimerRef.current.get(playbackKey)
+            if (timer != null) {
+              window.clearTimeout(timer)
+              remoteAudioRetryTimerRef.current.delete(playbackKey)
+            }
           }
-          void applyPreferredAudioOutputDevice(audioEl)
-          const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
-          const peerFactor = getPlaybackVolumeFactor(peerId, kind)
-          const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
-          if (playbackGraph) {
-            playbackGraph.gain.gain.value = peerFactor
-          }
-          const vol = playbackGraph
-            ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
-            : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
-          try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
-          audioEl.muted = shouldMute
-          if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
-        } else {
-          remoteAudioRefsRef.current.delete(playbackKey)
-          const timer = remoteAudioRetryTimerRef.current.get(playbackKey)
-          if (timer != null) {
-            window.clearTimeout(timer)
-            remoteAudioRetryTimerRef.current.delete(playbackKey)
-          }
-        }
-      }} />
+        }}
+      />
     )
   }, [attachRemoteAudioPlaybackStream, ensureRemoteAudioPlayback, getPlaybackVolumeFactor, remoteAudioPlaybackKey])
 
@@ -1561,6 +1665,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               <RemoteAudioPlaybackLayer
                 remoteStreams={state.remoteStreams}
                 watchedScreenPeerIds={watchedRemoteScreenPeerIds}
+                renderMixerOutput={renderRemoteAudioMixerOutput}
                 renderAudioElement={renderRemoteAudioElement}
               />
               <div className="callbar-status">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed desktop remote-audio mixing so microphone and watched screen-share audio use one persistent output stream, preventing local speaking activity from ducking or interrupting shared audio.
+- Made deafen synchronously gate every remote microphone bus, including tracks that arrive during reconnect, without muting independently watched screen-share audio.
+
 ## [0.2.11] - 2026-08-22
 
 ### Fixed

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -25,6 +25,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] On a clean macOS install, the first voice join prompts for microphone access and Voxpery appears in Privacy & Security -> Microphone after the decision.
 - [ ] Rebinding or clearing the mute shortcut takes effect immediately; a conflicting desktop shortcut shows an error without losing the previous working binding.
 - [ ] Deafen stops remote microphone playback and restores it when disabled; watched screen-share audio continues at its independent stream volume.
+- [ ] While deafened, reconnect a participant and subscribe to a newly arriving microphone track; no voice leaks before or after the track appears, while watched screen-share audio continues.
 - [ ] On web and desktop, voice ping starts in the measuring state, uses a real backend WebSocket RTT while RTC settles, and switches to the selected ICE path only after stable samples; joining another channel or reconnecting never flashes a stale or implausible `1 ms` value.
 - [ ] User B leaves and User A hears a leave cue that is clearly different from the join cue.
 - [ ] Rejoining the same channel does not leave duplicate participants or stale voice controls.
@@ -60,6 +61,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] User B chooses `Watch stream`; both `ScreenShare` and `ScreenShareAudio` subscribe, while User A's microphone remains continuously audible.
 - [ ] While User B watches a stream, hiding/minimizing Voxpery pauses screen video but keeps screen-share audio continuous; restoring the app resumes video without an audio gap or replayed media cue.
 - [ ] Shared system, game, and music audio remains stereo and continuous without speech-style gating; diagnostics report `musicHighQualityStereo`, 128 kbps, `forceStereo: true`, `dtx: false`, and `red: true`.
+- [ ] While User B watches User A's shared-audio stream, User B repeatedly speaks and stops speaking; the stream and all remote microphones remain simultaneously audible without ducking, gaps, output-device changes, or playback restarts. Repeat with at least five participants on web and desktop.
 - [ ] Sharing a source/platform that provides no audio still publishes video without a misleading warning toast.
 - [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio sample rate/channel count/content hint/publication profile, simulcast, outbound video bitrate/FPS, actual screen-audio Opus bitrate/channels/packets, packet loss, and quality limitation reason are present without device identifiers.
 - [ ] Under constrained bandwidth, screen share remains watchable by stepping down to a lower simulcast layer instead of freezing on a single high-quality layer.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -183,16 +183,16 @@ Shared AudioContext (desktop) / direct media path (mobile)
     |
 Independent microphone and screen-share gain buses
     |
-<audio> element (global output volume)
+Single persistent mixed <audio> output (desktop)
     |
 Speaker
 ```
 
 - **Output volume**: Global 1-100%, per-peer microphone 0-200%, and per-screen-share audio 0-100%.
-- **Stable desktop mixing**: Remote microphone and screen-share audio use one long-lived `AudioContext` with independent gain buses. Speaking-state changes never rebuild, mute, or restart watched stream audio.
+- **Stable desktop mixing**: Remote microphone and screen-share audio use one long-lived `AudioContext` with independent gain buses feeding one persistent output stream. Local speaking/VAD updates never create competing output sessions or rebuild, mute, or restart watched stream audio.
 - **Source-aware dynamics**: Microphone amplification keeps its peak limiter, while screen-share audio bypasses voice compression so music and game dynamics are preserved. Mobile web keeps the lower-overhead direct media path.
 - **Deafen**: Mutes remote microphone playback while leaving watched screen-share audio under its independent stream volume/mute controls
-- **Immediate deafen**: The playback ref and every active remote microphone element are muted synchronously with the control click, closing the render/effect window where a new track could remain audible briefly.
+- **Immediate deafen**: Every active desktop microphone bus is set to zero synchronously with the control click, and newly subscribed microphone buses start at zero while deafened. Direct mobile microphone elements are muted in the same pass, closing reconnect and render/effect windows where voice could otherwise leak briefly.
 - **Deafened speaking feedback**: Self-deafen and server-deafen suppress remote speaking rings in both the channel sidebar and voice stage. The underlying speaking state remains intact, so indicators resume immediately after undeafen without waiting for a new speaking event.
 - **Watch screen share**: Screen-share video and shared audio remain unsubscribed until the viewer chooses `Watch stream`; `Stop watching` removes only those viewer subscriptions while the peer's normal microphone audio remains active.
 - **Pre-join media presence**: Server members can see a camera icon and `LIVE` screen-share badge beside voice participants before joining the channel. These indicators use the server-broadcast voice control state and do not subscribe the viewer to media.


### PR DESCRIPTION
## Summary

- route desktop remote voice and screen-share audio through one persistent mixer
- prevent local speaking activity from interrupting watched stream audio
- synchronously mute all remote microphone buses while deafened
- ensure reconnecting or newly subscribed microphone tracks start muted during deafen
- keep watched screen-share audio independent from deafen
- add multi-participant, reconnect, and deafen regression coverage
- update voice documentation and release smoke checks

## Validation

- Frontend lint passed
- 308 frontend tests passed
- Production build passed