### PR TITLE
fix: restore independent audio outputs for remote sources with fallba…

### DIFF
--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -100,17 +100,20 @@ type MockAudioContextInstance = {
 
 let restoreAudioContextMock: (() => void) | null = null
 
-function installAudioContextMock(): MockAudioContextInstance[] {
+function installAudioContextMock(options: { failMediaStreamSource?: boolean } = {}): MockAudioContextInstance[] {
   const original = Object.getOwnPropertyDescriptor(window, 'AudioContext')
   const instances: MockAudioContextInstance[] = []
 
   class MockAudioContext {
     state: AudioContextState = 'running'
     currentTime = 0
-    createMediaStreamSource = vi.fn(() => ({
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-    }))
+    createMediaStreamSource = vi.fn(() => {
+      if (options.failMediaStreamSource) throw new Error('Web Audio source unavailable')
+      return {
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      }
+    })
     createGain = vi.fn(() => ({
       context: this,
       connect: vi.fn(),
@@ -456,17 +459,17 @@ describe('ActiveCallBar regressions', () => {
 
     expect(audioContexts).toHaveLength(1)
     const gainNodes = audioContexts[0].createGain.mock.results.map((result) => result.value)
-    const microphoneBus = gainNodes[1]
-    const screenBus = gainNodes[2]
-    if (!microphoneBus || !screenBus) throw new Error('Remote mixer gain buses were not created.')
+    const microphoneBus = gainNodes[0]
+    const screenBus = gainNodes[1]
+    if (!microphoneBus || !screenBus) throw new Error('Remote playback gain buses were not created.')
 
     fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
 
     expect(microphoneBus.gain.setValueAtTime).toHaveBeenLastCalledWith(0, 0)
     expect(screenBus.gain.setValueAtTime).not.toHaveBeenCalled()
     expect(screenBus.gain.setTargetAtTime).toHaveBeenLastCalledWith(1, 0, 0.015)
-    const mixerOutput = container.querySelector('audio[data-remote-audio-output="mixed"]') as HTMLAudioElement | null
-    expect(mixerOutput?.muted).toBe(false)
+    const screenOutput = container.querySelector('audio[data-remote-audio-kind="screen"]') as HTMLAudioElement | null
+    expect(screenOutput?.muted).toBe(false)
   })
 
   it('starts microphone tracks that arrive while deafened at zero gain', () => {
@@ -490,7 +493,7 @@ describe('ActiveCallBar regressions', () => {
     )
 
     expect(audioContexts).toHaveLength(1)
-    const microphoneBus = audioContexts[0].createGain.mock.results[1]?.value
+    const microphoneBus = audioContexts[0].createGain.mock.results[0]?.value
     if (!microphoneBus) throw new Error('The reconnecting microphone bus was not created.')
     expect(microphoneBus.gain.value).toBe(0)
     const remoteMic = document.querySelector('audio[data-remote-audio-kind="mic"]') as HTMLAudioElement | null
@@ -567,19 +570,16 @@ describe('ActiveCallBar regressions', () => {
         remoteStreams: 5,
       },
     })
-    const mixerOutput = container.querySelector('audio[data-remote-audio-output="mixed"]') as HTMLAudioElement | null
-    if (!mixerOutput) throw new Error('The stable remote audio mixer output was not rendered.')
     expect(audioContexts).toHaveLength(1)
-    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledOnce()
+    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledTimes(6)
     expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledTimes(6)
-    expect(mixerOutput.srcObject).toBeInstanceOf(MediaStream)
-    const mixedSourceElements = Array.from(container.querySelectorAll<HTMLAudioElement>(
+    const sourceElements = Array.from(container.querySelectorAll<HTMLAudioElement>(
       'audio[data-remote-audio-kind="mic"], audio[data-peer-id="peer-1"][data-remote-audio-kind="screen"]',
     ))
-    expect(mixedSourceElements).toHaveLength(6)
-    expect(mixedSourceElements.every((element) => element.srcObject === null && element.muted)).toBe(true)
-    expect(play.mock.instances.every((element) => element === mixerOutput)).toBe(true)
-    const initialMixerStream = mixerOutput.srcObject
+    expect(sourceElements).toHaveLength(6)
+    expect(sourceElements.every((element) => element.srcObject instanceof MediaStream && !element.muted)).toBe(true)
+    expect(sourceElements.every((element) => play.mock.instances.includes(element))).toBe(true)
+    const initialOutputStreams = sourceElements.map((element) => element.srcObject)
     play.mockClear()
 
     act(() => useAppStore.getState().setVoiceSpeaking(['peer-2', 'peer-3'], false))
@@ -587,9 +587,33 @@ describe('ActiveCallBar regressions', () => {
     act(() => useAppStore.getState().setVoiceSpeaking([], false))
 
     expect(play).not.toHaveBeenCalled()
-    expect(mixerOutput.srcObject).toBe(initialMixerStream)
-    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledOnce()
+    expect(sourceElements.map((element) => element.srcObject)).toEqual(initialOutputStreams)
+    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledTimes(6)
     expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledTimes(6)
+  })
+
+  it('falls back to direct remote playback when Web Audio graph creation fails', () => {
+    const audioContexts = installAudioContextMock({ failMediaStreamSource: true })
+    const remoteMic = mediaTrack('audio', 'peer-mic')
+    markRemoteAudioTrackSource(remoteMic, 'voice')
+    const play = vi.mocked(HTMLMediaElement.prototype.play)
+
+    const { container } = renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', new MediaStream([remoteMic])]]),
+    })
+
+    const remoteMicOutput = container.querySelector(
+      'audio[data-peer-id="peer-1"][data-remote-audio-kind="mic"]',
+    ) as HTMLAudioElement | null
+    if (!remoteMicOutput) throw new Error('Remote microphone output was not rendered.')
+
+    expect(audioContexts).toHaveLength(1)
+    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledOnce()
+    expect(audioContexts[0].createMediaStreamDestination).not.toHaveBeenCalled()
+    expect(remoteMicOutput.srcObject).toBeInstanceOf(MediaStream)
+    expect((remoteMicOutput.srcObject as MediaStream).getAudioTracks()).toEqual([remoteMic])
+    expect(remoteMicOutput.muted).toBe(false)
+    expect(play.mock.instances).toContain(remoteMicOutput)
   })
 
   it('uses the configured shortcut while the web tab is focused', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -65,11 +65,6 @@ interface RemoteAudioPlaybackGraph {
   source: MediaStreamAudioSourceNode
   gain: GainNode
   limiter: DynamicsCompressorNode | null
-}
-
-interface RemoteAudioMixer {
-  context: AudioContext
-  masterGain: GainNode
   destination: MediaStreamAudioDestinationNode
 }
 
@@ -87,7 +82,6 @@ type RemoteMediaPlaceholder = {
 type RemoteAudioPlaybackLayerProps = {
   remoteStreams: Map<string, MediaStream>
   watchedScreenPeerIds: Set<string>
-  renderMixerOutput: () => ReactNode
   renderAudioElement: (
     peerId: string,
     stream: MediaStream,
@@ -132,12 +126,10 @@ function RemoteVideoTrack({ track }: { track: MediaStreamTrack }) {
 const RemoteAudioPlaybackLayer = memo(function RemoteAudioPlaybackLayer({
   remoteStreams,
   watchedScreenPeerIds,
-  renderMixerOutput,
   renderAudioElement,
 }: RemoteAudioPlaybackLayerProps) {
   return (
     <div style={{ display: 'none' }}>
-      {renderMixerOutput()}
       {Array.from(remoteStreams.entries()).flatMap(([peerId, stream]) => (
         (['mic', 'screen'] as RemoteAudioKind[]).map((kind) => (
           renderAudioElement(peerId, stream, kind, kind === 'mic' || watchedScreenPeerIds.has(peerId))
@@ -294,8 +286,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
   const remoteAudioContextRef = useRef<AudioContext | null>(null)
-  const remoteAudioMixerRef = useRef<RemoteAudioMixer | null>(null)
-  const remoteAudioMixerOutputRef = useRef<HTMLAudioElement | null>(null)
   const remotePlaybackGraphsRef = useRef<Map<string, RemoteAudioPlaybackGraph>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null)
@@ -388,6 +378,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     graph.source.disconnect()
     graph.gain.disconnect()
     graph.limiter?.disconnect()
+    graph.destination.disconnect()
+    graph.destination.stream.getTracks().forEach((track) => track.stop())
     remotePlaybackGraphsRef.current.delete(playbackKey)
   }, [])
 
@@ -406,24 +398,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   }, [])
 
-  const getRemoteAudioMixer = useCallback((): RemoteAudioMixer | null => {
-    const context = getRemoteAudioContext()
-    if (!context) return null
-    const current = remoteAudioMixerRef.current
-    if (current?.context === context) return current
-
-    try {
-      const masterGain = context.createGain()
-      const destination = context.createMediaStreamDestination()
-      masterGain.connect(destination)
-      const mixer = { context, masterGain, destination }
-      remoteAudioMixerRef.current = mixer
-      return mixer
-    } catch {
-      return null
-    }
-  }, [getRemoteAudioContext])
-
   const attachRemoteAudioPlaybackStream = useCallback((
     playbackKey: string,
     kind: RemoteAudioKind,
@@ -440,27 +414,28 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
     const current = remotePlaybackGraphsRef.current.get(playbackKey)
     if (current?.trackIds === trackIds) {
-      element.srcObject = null
-      element.muted = true
+      element.srcObject = current.destination.stream
+      element.muted = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
       element.__voxpery_trackIds = trackIds
       return
     }
 
     disposeRemotePlaybackGraph(playbackKey)
-    const mixer = getRemoteAudioMixer()
-    if (!mixer) {
+    const context = getRemoteAudioContext()
+    if (!context) {
       element.srcObject = playbackStream
       element.__voxpery_trackIds = trackIds
       return
     }
 
     try {
-      // All desktop remote sources feed one persistent output stream. This keeps
-      // local microphone/VAD activity from competing with a separate media
-      // element for every peer and screen-share track.
-      const source = mixer.context.createMediaStreamSource(playbackStream)
-      const gain = mixer.context.createGain()
-      const limiter = kind === 'mic' ? mixer.context.createDynamicsCompressor() : null
+      // Keep every remote source independently playable. If Web Audio cannot be
+      // created, the direct MediaStream fallback above remains audible instead
+      // of muting every participant behind one shared mixer output.
+      const source = context.createMediaStreamSource(playbackStream)
+      const gain = context.createGain()
+      const destination = context.createMediaStreamDestination()
+      const limiter = kind === 'mic' ? context.createDynamicsCompressor() : null
       const { peerId } = parseRemoteAudioPlaybackKey(playbackKey)
       gain.gain.value = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
         ? 0
@@ -473,21 +448,22 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         limiter.attack.value = 0.003
         limiter.release.value = 0.1
         gain.connect(limiter)
-        limiter.connect(mixer.masterGain)
+        limiter.connect(destination)
       } else {
-        gain.connect(mixer.masterGain)
+        gain.connect(destination)
       }
-      const graph = { trackIds, source, gain, limiter }
+      const graph = { trackIds, source, gain, limiter, destination }
       remotePlaybackGraphsRef.current.set(playbackKey, graph)
-      element.srcObject = null
-      element.muted = true
+      element.srcObject = destination.stream
+      element.muted = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
       element.__voxpery_trackIds = trackIds
-      if (mixer.context.state === 'suspended') void mixer.context.resume().catch(() => {})
+      if (context.state === 'suspended') void context.resume().catch(() => {})
     } catch {
       element.srcObject = playbackStream
+      element.muted = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
       element.__voxpery_trackIds = trackIds
     }
-  }, [disposeRemotePlaybackGraph, getPlaybackVolumeFactor, getRemoteAudioMixer, lightweightMobileVoice, parseRemoteAudioPlaybackKey])
+  }, [disposeRemotePlaybackGraph, getPlaybackVolumeFactor, getRemoteAudioContext, lightweightMobileVoice, parseRemoteAudioPlaybackKey])
 
   const ensureRemoteAudioPlayback = useCallback((playbackKey: string, el: HTMLAudioElement) => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -505,9 +481,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         clearRetry()
         return
       }
-      const isMixerOutput = playbackKey === 'remote-mixer-output'
       const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
-      if (el.muted || (!isMixerOutput && shouldMuteRemoteAudioPlayback(kind, deafenedRef.current))) {
+      if (el.muted || shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) {
         clearRetry()
         return
       }
@@ -538,20 +513,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     attempt()
   }, [parseRemoteAudioPlaybackKey])
 
-  const syncRemoteAudioMixerOutput = useCallback(() => {
-    const mixer = remoteAudioMixerRef.current
-    const element = remoteAudioMixerOutputRef.current
-    if (!mixer || !element || remotePlaybackGraphsRef.current.size === 0) return
-    if (element.srcObject !== mixer.destination.stream) element.srcObject = mixer.destination.stream
-    element.volume = Math.min(1, Math.max(0, outputVolumeRef.current / 100))
-    element.muted = false
-    void applyPreferredAudioOutputDevice(element)
-    ensureRemoteAudioPlayback('remote-mixer-output', element)
-  }, [ensureRemoteAudioPlayback])
-
   const applyOutputDeviceToElements = useCallback(() => {
-    const mixerOutput = remoteAudioMixerOutputRef.current
-    if (mixerOutput) void applyPreferredAudioOutputDevice(mixerOutput)
     for (const el of remoteAudioRefsRef.current.values()) {
       void applyPreferredAudioOutputDevice(el)
     }
@@ -575,7 +537,8 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         const peerFactor = getPlaybackVolumeFactor(peerId, kind)
         const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
         if (playbackGraph) {
-          el.muted = true
+          el.volume = global
+          el.muted = shouldMuteRemoteAudioPlayback(kind, isDeafened)
         } else {
           el.volume = Math.min(1, Math.max(0, global * peerFactor))
           el.muted = shouldMuteRemoteAudioPlayback(kind, isDeafened)
@@ -583,11 +546,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       } catch {
         // ignore
       }
-    }
-    const mixerOutput = remoteAudioMixerOutputRef.current
-    if (mixerOutput) {
-      mixerOutput.volume = global
-      mixerOutput.muted = remotePlaybackGraphsRef.current.size === 0
     }
   }, [getPlaybackVolumeFactor, parseRemoteAudioPlaybackKey])
 
@@ -597,16 +555,14 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
 
     const audioContext = remoteAudioContextRef.current
     if (audioContext?.state === 'suspended') void audioContext.resume().catch(() => {})
-    if (remotePlaybackGraphsRef.current.size > 0) syncRemoteAudioMixerOutput()
     for (const [playbackKey, element] of remoteAudioRefsRef.current.entries()) {
-      if (remotePlaybackGraphsRef.current.has(playbackKey)) continue
       const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
       if (shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) continue
       const stream = element.srcObject
       if (!(stream instanceof MediaStream) || stream.getAudioTracks().length === 0) continue
       ensureRemoteAudioPlayback(playbackKey, element)
     }
-  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback, parseRemoteAudioPlaybackKey, syncRemoteAudioMixerOutput])
+  }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback, parseRemoteAudioPlaybackKey])
 
   useEffect(() => {
     const recoverWhenVisible = () => {
@@ -769,9 +725,13 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         }
         const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
         const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
-        el.muted = playbackGraph ? true : shouldMute
-        if (!playbackGraph) void applyPreferredAudioOutputDevice(el)
-        if (!playbackGraph && !shouldMute && currentTrackIds) {
+        el.muted = shouldMute
+        if (playbackGraph) {
+          const { peerId: graphPeerId } = parseRemoteAudioPlaybackKey(playbackKey)
+          playbackGraph.gain.gain.value = shouldMute ? 0 : getPlaybackVolumeFactor(graphPeerId, kind)
+        }
+        void applyPreferredAudioOutputDevice(el)
+        if (!shouldMute && currentTrackIds) {
           ensureRemoteAudioPlayback(playbackKey, el)
         }
       }
@@ -782,17 +742,10 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
     if (remotePlaybackGraphsRef.current.size === 0) {
       const context = remoteAudioContextRef.current
-      const mixerOutput = remoteAudioMixerOutputRef.current
-      if (mixerOutput) {
-        mixerOutput.muted = true
-        mixerOutput.srcObject = null
-      }
       if (context?.state === 'running') void context.suspend().catch(() => {})
-    } else {
-      syncRemoteAudioMixerOutput()
     }
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
-  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemotePlaybackGraph, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams, syncRemoteAudioMixerOutput])
+  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemotePlaybackGraph, getPlaybackVolumeFactor, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
@@ -805,41 +758,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       for (const playbackKey of playbackGraphs.keys()) {
         disposeRemotePlaybackGraph(playbackKey)
       }
-      const mixer = remoteAudioMixerRef.current
-      remoteAudioMixerRef.current = null
-      remoteAudioMixerOutputRef.current = null
-      mixer?.masterGain.disconnect()
-      mixer?.destination.disconnect()
-      mixer?.destination.stream.getTracks().forEach((track) => track.stop())
       const context = remoteAudioContextRef.current
       remoteAudioContextRef.current = null
       if (context && context.state !== 'closed') void context.close().catch(() => {})
     }
   }, [disposeRemotePlaybackGraph])
-
-  const attachRemoteAudioMixerOutputElement = useCallback((element: HTMLAudioElement | null) => {
-    remoteAudioMixerOutputRef.current = element
-    if (!element) {
-      const timer = remoteAudioRetryTimerRef.current.get('remote-mixer-output')
-      if (timer != null) window.clearTimeout(timer)
-      remoteAudioRetryTimerRef.current.delete('remote-mixer-output')
-      return
-    }
-    syncRemoteAudioMixerOutput()
-  }, [syncRemoteAudioMixerOutput])
-
-  const renderRemoteAudioMixerOutput = useCallback(() => {
-    if (lightweightMobileVoice) return null
-    return (
-      <audio
-        key="remote-mixer-output"
-        data-remote-audio-output="mixed"
-        autoPlay
-        playsInline
-        ref={attachRemoteAudioMixerOutputElement}
-      />
-    )
-  }, [attachRemoteAudioMixerOutputElement, lightweightMobileVoice])
 
   const renderRemoteAudioElement = useCallback((
     peerId: string,
@@ -874,9 +797,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               ? Math.min(1, Math.max(0, outputVolumeRef.current / 100))
               : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
             try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
-            audioEl.muted = playbackGraph ? true : shouldMute
-            if (!playbackGraph) void applyPreferredAudioOutputDevice(audioEl)
-            if (!playbackGraph && !shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
+            audioEl.muted = shouldMute
+            void applyPreferredAudioOutputDevice(audioEl)
+            if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
           } else {
             remoteAudioRefsRef.current.delete(playbackKey)
             const timer = remoteAudioRetryTimerRef.current.get(playbackKey)
@@ -1665,7 +1588,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               <RemoteAudioPlaybackLayer
                 remoteStreams={state.remoteStreams}
                 watchedScreenPeerIds={watchedRemoteScreenPeerIds}
-                renderMixerOutput={renderRemoteAudioMixerOutput}
                 renderAudioElement={renderRemoteAudioElement}
               />
               <div className="callbar-status">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified that the self-service archive is a bounded convenience export rather than a complete formal privacy access response.
 
 ### Fixed
-- Fixed desktop remote-audio mixing so microphone and watched screen-share audio use one persistent output stream, preventing local speaking activity from ducking or interrupting shared audio.
+- Restored independent desktop playback outputs for every remote microphone and watched screen-share audio source, with direct `MediaStream` fallback so one Web Audio graph failure cannot silence the entire voice channel.
 - Made deafen synchronously gate every remote microphone bus, including tracks that arrive during reconnect, without muting independently watched screen-share audio.
 - Bound the complete Google OAuth state to its HttpOnly cookie so registration intent, legal versions, redirect metadata, and PKCE values cannot be changed before callback validation.
 

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -30,6 +30,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] User B leaves and User A hears a leave cue that is clearly different from the join cue.
 - [ ] Rejoining the same channel does not leave duplicate participants or stale voice controls.
 - [ ] With 3-5 members in one channel, every member can hear every other microphone; reconnecting one member restores all expected subscriptions without duplicate or missing audio.
+- [ ] If Web Audio processing is unavailable for one remote source, that participant remains audible through direct `MediaStream` playback and the other participants remain unaffected.
 
 ## 2. Reconnect and Revocation
 

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -181,15 +181,15 @@ MediaStream
     |
 Shared AudioContext (desktop) / direct media path (mobile)
     |
-Independent microphone and screen-share gain buses
+Independent per-source gain and destination graphs
     |
-Single persistent mixed <audio> output (desktop)
+Independent <audio> outputs with direct fallback
     |
 Speaker
 ```
 
 - **Output volume**: Global 1-100%, per-peer microphone 0-200%, and per-screen-share audio 0-100%.
-- **Stable desktop mixing**: Remote microphone and screen-share audio use one long-lived `AudioContext` with independent gain buses feeding one persistent output stream. Local speaking/VAD updates never create competing output sessions or rebuild, mute, or restart watched stream audio.
+- **Failure-isolated desktop playback**: Remote microphone and screen-share audio share one long-lived `AudioContext`, but each source owns its gain, destination, and media element. A graph-creation failure falls back to the source `MediaStream` directly, so one failed source cannot silence every participant. Local speaking/VAD updates do not rebuild or restart these outputs.
 - **Source-aware dynamics**: Microphone amplification keeps its peak limiter, while screen-share audio bypasses voice compression so music and game dynamics are preserved. Mobile web keeps the lower-overhead direct media path.
 - **Deafen**: Mutes remote microphone playback while leaving watched screen-share audio under its independent stream volume/mute controls
 - **Immediate deafen**: Every active desktop microphone bus is set to zero synchronously with the control click, and newly subscribed microphone buses start at zero while deafened. Direct mobile microphone elements are muted in the same pass, closing reconnect and render/effect windows where voice could otherwise leak briefly.


### PR DESCRIPTION
## Summary

- remove the shared remote-audio mixer that could silence every participant
- restore independent microphone and screen-share playback outputs
- fall back to direct MediaStream playback when Web Audio graph creation fails
- preserve immediate deafen behavior without muting watched screen audio
- add multi-participant and playback fallback regression coverage

## Validation

- npm run lint
- npm run test:run
- npm run build