### PR TITLE
fix: stabilize cross-browser voice playback

### DIFF
--- a/apps/web/src/audioCues.test.ts
+++ b/apps/web/src/audioCues.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { VOICE_CUE_TONES, type VoiceCueKind } from './audioCues'
+import {
+  getPreferredVoiceAudioContextOptions,
+  VOICE_AUDIO_SAMPLE_RATE,
+  VOICE_CUE_TONES,
+  type VoiceCueKind,
+} from './audioCues'
 
 const cueKinds = Object.keys(VOICE_CUE_TONES) as VoiceCueKind[]
 
@@ -14,6 +19,11 @@ function signature(kind: VoiceCueKind) {
 }
 
 describe('voice cue catalog', () => {
+  it('uses the 48 kHz sample rate required by the shared RNNoise pipeline', () => {
+    expect(VOICE_AUDIO_SAMPLE_RATE).toBe(48_000)
+    expect(getPreferredVoiceAudioContextOptions()).toEqual({ sampleRate: 48_000 })
+  })
+
   it('gives every voice and media event a distinct sound profile', () => {
     const signatures = cueKinds.map(signature)
     expect(new Set(signatures).size).toBe(cueKinds.length)

--- a/apps/web/src/audioCues.ts
+++ b/apps/web/src/audioCues.ts
@@ -67,10 +67,26 @@ export const VOICE_CUE_TONES: Readonly<Record<VoiceCueKind, readonly CueTone[]>>
 
 type AudioWindow = Window & { webkitAudioContext?: typeof AudioContext }
 
+export const VOICE_AUDIO_SAMPLE_RATE = 48_000
+
+export function getPreferredVoiceAudioContextOptions(): AudioContextOptions {
+  return { sampleRate: VOICE_AUDIO_SAMPLE_RATE }
+}
+
+function createVoiceAudioContext(AudioCtor: typeof AudioContext): AudioContext {
+  try {
+    return new AudioCtor(getPreferredVoiceAudioContextOptions())
+  } catch {
+    return new AudioCtor()
+  }
+}
+
 export function getOrCreateAudioContext(ref: { current: AudioContext | null }): AudioContext | null {
   const AudioCtor = window.AudioContext || (window as AudioWindow).webkitAudioContext
   if (!AudioCtor) return null
-  if (!ref.current) ref.current = new AudioCtor()
+  if (!ref.current || ref.current.state === 'closed') {
+    ref.current = createVoiceAudioContext(AudioCtor)
+  }
   const ctx = ref.current
   if (ctx.state === 'suspended') {
     void ctx.resume().catch(() => {})

--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -330,13 +330,16 @@ describe('ActiveCallBar regressions', () => {
     expect((preview.srcObject as MediaStream).getVideoTracks()).toEqual(localScreen.getVideoTracks())
   })
 
-  it('reasserts remote microphone playback after the macOS share picker returns', () => {
+  it('reasserts remote microphone playback after the macOS share picker returns', async () => {
     const remoteMic = mediaTrack('audio', 'peer-mic')
     const remoteStream = new MediaStream([remoteMic])
     const play = vi.mocked(HTMLMediaElement.prototype.play)
 
     renderActiveCallBar({
       remoteStreams: new Map([['peer-1', remoteStream]]),
+    })
+    await act(async () => {
+      await Promise.resolve()
     })
     play.mockClear()
 
@@ -445,7 +448,7 @@ describe('ActiveCallBar regressions', () => {
     expect(screenAudio.muted).toBe(false)
   })
 
-  it('immediately gates desktop microphone buses while keeping watched screen audio active', () => {
+  it('immediately mutes native microphone playback while keeping watched screen audio active', () => {
     const audioContexts = installAudioContextMock()
     const micTrack = mediaTrack('audio', 'peer-mic')
     const screenAudioTrack = mediaTrack('audio', 'peer-screen-audio')
@@ -457,18 +460,13 @@ describe('ActiveCallBar regressions', () => {
       watchedRemoteScreenPeerIds: new Set(['peer-1']),
     })
 
-    expect(audioContexts).toHaveLength(1)
-    const gainNodes = audioContexts[0].createGain.mock.results.map((result) => result.value)
-    const microphoneBus = gainNodes[0]
-    const screenBus = gainNodes[1]
-    if (!microphoneBus || !screenBus) throw new Error('Remote playback gain buses were not created.')
+    expect(audioContexts).toHaveLength(0)
 
     fireEvent.click(screen.getByRole('button', { name: 'Deafen' }))
 
-    expect(microphoneBus.gain.setValueAtTime).toHaveBeenLastCalledWith(0, 0)
-    expect(screenBus.gain.setValueAtTime).not.toHaveBeenCalled()
-    expect(screenBus.gain.setTargetAtTime).toHaveBeenLastCalledWith(1, 0, 0.015)
+    const microphoneOutput = container.querySelector('audio[data-remote-audio-kind="mic"]') as HTMLAudioElement | null
     const screenOutput = container.querySelector('audio[data-remote-audio-kind="screen"]') as HTMLAudioElement | null
+    expect(microphoneOutput?.muted).toBe(true)
     expect(screenOutput?.muted).toBe(false)
   })
 
@@ -492,10 +490,7 @@ describe('ActiveCallBar regressions', () => {
       </MemoryRouter>
     )
 
-    expect(audioContexts).toHaveLength(1)
-    const microphoneBus = audioContexts[0].createGain.mock.results[0]?.value
-    if (!microphoneBus) throw new Error('The reconnecting microphone bus was not created.')
-    expect(microphoneBus.gain.value).toBe(0)
+    expect(audioContexts).toHaveLength(0)
     const remoteMic = document.querySelector('audio[data-remote-audio-kind="mic"]') as HTMLAudioElement | null
     expect(remoteMic?.muted).toBe(true)
   })
@@ -570,9 +565,7 @@ describe('ActiveCallBar regressions', () => {
         remoteStreams: 5,
       },
     })
-    expect(audioContexts).toHaveLength(1)
-    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledTimes(6)
-    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledTimes(6)
+    expect(audioContexts).toHaveLength(0)
     const sourceElements = Array.from(container.querySelectorAll<HTMLAudioElement>(
       'audio[data-remote-audio-kind="mic"], audio[data-peer-id="peer-1"][data-remote-audio-kind="screen"]',
     ))
@@ -588,12 +581,103 @@ describe('ActiveCallBar regressions', () => {
 
     expect(play).not.toHaveBeenCalled()
     expect(sourceElements.map((element) => element.srcObject)).toEqual(initialOutputStreams)
-    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledTimes(6)
-    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledTimes(6)
   })
 
-  it('falls back to direct remote playback when Web Audio graph creation fails', () => {
-    const audioContexts = installAudioContextMock({ failMediaStreamSource: true })
+  it('starts newly watched screen audio only once while subscription state settles', async () => {
+    installAudioContextMock()
+    const screenAudio = mediaTrack('audio', 'peer-screen-audio')
+    markRemoteAudioTrackSource(screenAudio, 'screen')
+    const play = vi.mocked(HTMLMediaElement.prototype.play)
+    let resolvePlayback!: () => void
+    play.mockImplementation(() => new Promise<void>((resolve) => {
+      resolvePlayback = resolve
+    }))
+    const remoteStream = new MediaStream([screenAudio])
+
+    const { voice, rerender } = renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', remoteStream]]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+
+    expect(play).toHaveBeenCalledOnce()
+    for (let update = 0; update < 3; update += 1) {
+      voice.state = voiceState({
+        remoteStreams: new Map([['peer-1', new MediaStream([screenAudio])]]),
+        watchedRemoteScreenPeerIds: new Set(['peer-1']),
+      })
+      rerender(
+        <MemoryRouter>
+          <ActiveCallBar
+            selectedVoiceChannelId={voiceChannel.id}
+            activeChannelId={voiceChannel.id}
+          />
+        </MemoryRouter>
+      )
+    }
+
+    expect(play).toHaveBeenCalledOnce()
+    await act(async () => {
+      resolvePlayback()
+      await Promise.resolve()
+    })
+
+    voice.state = voiceState({
+      remoteStreams: new Map([['peer-1', new MediaStream([screenAudio])]]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+    rerender(
+      <MemoryRouter>
+        <ActiveCallBar
+          selectedVoiceChannelId={voiceChannel.id}
+          activeChannelId={voiceChannel.id}
+        />
+      </MemoryRouter>
+    )
+
+    expect(play).toHaveBeenCalledOnce()
+  })
+
+  it('starts screen audio again after the viewer stops and resumes watching', async () => {
+    installAudioContextMock()
+    const screenAudio = mediaTrack('audio', 'peer-screen-audio')
+    markRemoteAudioTrackSource(screenAudio, 'screen')
+    const remoteStream = new MediaStream([screenAudio])
+    const play = vi.mocked(HTMLMediaElement.prototype.play)
+    const { voice, rerender } = renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', remoteStream]]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(play).toHaveBeenCalledOnce()
+
+    voice.state = voiceState({
+      remoteStreams: new Map([['peer-1', remoteStream]]),
+      watchedRemoteScreenPeerIds: new Set(),
+    })
+    rerender(
+      <MemoryRouter>
+        <ActiveCallBar selectedVoiceChannelId={voiceChannel.id} activeChannelId={voiceChannel.id} />
+      </MemoryRouter>
+    )
+    expect(play).toHaveBeenCalledOnce()
+
+    voice.state = voiceState({
+      remoteStreams: new Map([['peer-1', remoteStream]]),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+    rerender(
+      <MemoryRouter>
+        <ActiveCallBar selectedVoiceChannelId={voiceChannel.id} activeChannelId={voiceChannel.id} />
+      </MemoryRouter>
+    )
+
+    expect(play).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses direct remote playback at normal voice volume without creating Web Audio', () => {
+    const audioContexts = installAudioContextMock()
     const remoteMic = mediaTrack('audio', 'peer-mic')
     markRemoteAudioTrackSource(remoteMic, 'voice')
     const play = vi.mocked(HTMLMediaElement.prototype.play)
@@ -607,13 +691,28 @@ describe('ActiveCallBar regressions', () => {
     ) as HTMLAudioElement | null
     if (!remoteMicOutput) throw new Error('Remote microphone output was not rendered.')
 
-    expect(audioContexts).toHaveLength(1)
-    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledOnce()
-    expect(audioContexts[0].createMediaStreamDestination).not.toHaveBeenCalled()
+    expect(audioContexts).toHaveLength(0)
     expect(remoteMicOutput.srcObject).toBeInstanceOf(MediaStream)
     expect((remoteMicOutput.srcObject as MediaStream).getAudioTracks()).toEqual([remoteMic])
     expect(remoteMicOutput.muted).toBe(false)
     expect(play.mock.instances).toContain(remoteMicOutput)
+  })
+
+  it('creates an isolated Web Audio gain graph only for voice amplification above 100 percent', () => {
+    const audioContexts = installAudioContextMock()
+    writeRemotePlaybackVolumes({ 'voice:peer-1': 150 })
+    const remoteMic = mediaTrack('audio', 'amplified-peer-mic')
+    markRemoteAudioTrackSource(remoteMic, 'voice')
+
+    renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', new MediaStream([remoteMic])]]),
+    })
+
+    expect(audioContexts).toHaveLength(1)
+    expect(audioContexts[0].createMediaStreamSource).toHaveBeenCalledOnce()
+    expect(audioContexts[0].createMediaStreamDestination).toHaveBeenCalledOnce()
+    const gain = audioContexts[0].createGain.mock.results[0]?.value
+    expect(gain?.gain.value).toBe(1.5)
   })
 
   it('uses direct remote playback in Tauri without creating a Web Audio destination', () => {

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -68,6 +68,14 @@ interface RemoteAudioPlaybackGraph {
   destination: MediaStreamAudioDestinationNode
 }
 
+type RemoteAudioPlaybackStatus = 'pending' | 'playing' | 'retrying'
+
+interface RemoteAudioPlaybackAttempt {
+  element: HTMLAudioElement
+  trackIds: string
+  status: RemoteAudioPlaybackStatus
+}
+
 interface VoxperyHTMLDivElement extends HTMLDivElement {
   _idleTimeout?: ReturnType<typeof setTimeout>
 }
@@ -286,6 +294,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   const micTestPrevMutedRef = useRef(false)
   const remoteAudioRefsRef = useRef<Map<string, HTMLAudioElement>>(new Map())
   const remoteAudioRetryTimerRef = useRef<Map<string, number>>(new Map())
+  const remoteAudioPlaybackAttemptsRef = useRef<Map<string, RemoteAudioPlaybackAttempt>>(new Map())
   const remoteAudioContextRef = useRef<AudioContext | null>(null)
   const remotePlaybackGraphsRef = useRef<Map<string, RemoteAudioPlaybackGraph>>(new Map())
   const localStreamRef = useRef<MediaStream | null>(null)
@@ -406,11 +415,22 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     trackIds: string,
     element: VoxperyAudioElement,
   ) => {
+    if (element.__voxpery_trackIds !== trackIds) {
+      remoteAudioPlaybackAttemptsRef.current.delete(playbackKey)
+      const retryTimer = remoteAudioRetryTimerRef.current.get(playbackKey)
+      if (retryTimer != null) {
+        window.clearTimeout(retryTimer)
+        remoteAudioRetryTimerRef.current.delete(playbackKey)
+      }
+    }
+    const { peerId } = parseRemoteAudioPlaybackKey(playbackKey)
+    const playbackVolumeFactor = getPlaybackVolumeFactor(peerId, kind)
     if (shouldUseDirectRemoteAudioPlayback(
       kind,
       lightweightMobileVoice,
       desktopRuntime,
       playbackStream.getAudioTracks().length,
+      playbackVolumeFactor,
     )) {
       disposeRemotePlaybackGraph(playbackKey)
       if (element.srcObject !== playbackStream) element.srcObject = playbackStream
@@ -443,10 +463,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       const gain = context.createGain()
       const destination = context.createMediaStreamDestination()
       const limiter = kind === 'mic' ? context.createDynamicsCompressor() : null
-      const { peerId } = parseRemoteAudioPlaybackKey(playbackKey)
       gain.gain.value = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
         ? 0
-        : getPlaybackVolumeFactor(peerId, kind)
+        : playbackVolumeFactor
       source.connect(gain)
       if (limiter) {
         limiter.threshold.value = -1
@@ -472,8 +491,13 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
   }, [desktopRuntime, disposeRemotePlaybackGraph, getPlaybackVolumeFactor, getRemoteAudioContext, lightweightMobileVoice, parseRemoteAudioPlaybackKey])
 
-  const ensureRemoteAudioPlayback = useCallback((playbackKey: string, el: HTMLAudioElement) => {
+  const ensureRemoteAudioPlayback = useCallback((
+    playbackKey: string,
+    el: VoxperyAudioElement,
+    force = false,
+  ) => {
     const retryTimers = remoteAudioRetryTimerRef.current
+    const playbackAttempts = remoteAudioPlaybackAttemptsRef.current
     const clearRetry = () => {
       const t = retryTimers.get(playbackKey)
       if (t != null) {
@@ -481,39 +505,73 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         retryTimers.delete(playbackKey)
       }
     }
+    const trackIds = el.__voxpery_trackIds ?? ''
+    if (!trackIds) {
+      clearRetry()
+      playbackAttempts.delete(playbackKey)
+      return
+    }
+    const current = playbackAttempts.get(playbackKey)
+    const samePlayback = current?.element === el && current.trackIds === trackIds
+    if (samePlayback && (current.status !== 'playing' || !force)) return
+
+    clearRetry()
+    const playbackAttempt: RemoteAudioPlaybackAttempt = {
+      element: el,
+      trackIds,
+      status: 'pending',
+    }
+    playbackAttempts.set(playbackKey, playbackAttempt)
+
     const attempt = () => {
+      if (playbackAttempts.get(playbackKey) !== playbackAttempt) return
       // Check if element is still available and not muted/deafened
       if (!el || !el.isConnected) {
         console.warn('[ensureRemoteAudioPlayback] Element not connected for playback', playbackKey)
         clearRetry()
+        playbackAttempts.delete(playbackKey)
         return
       }
       const { kind } = parseRemoteAudioPlaybackKey(playbackKey)
       if (el.muted || shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) {
         clearRetry()
+        playbackAttempts.delete(playbackKey)
         return
       }
       if (!el.srcObject) {
         console.warn('[ensureRemoteAudioPlayback] No srcObject for playback', playbackKey)
         clearRetry()
+        playbackAttempts.delete(playbackKey)
         return
       }
 
-      const p = el.play()
+      playbackAttempt.status = 'pending'
+      void applyPreferredAudioOutputDevice(el)
+      let p: Promise<void> | undefined
+      try {
+        p = el.play()
+      } catch {
+        p = Promise.reject(new Error('Remote audio playback failed'))
+      }
       if (!p || typeof p.catch !== 'function') {
         console.warn('[ensureRemoteAudioPlayback] play() did not return a promise for playback', playbackKey)
         clearRetry()
+        playbackAttempt.status = 'playing'
         return
       }
       p.then(() => {
+        if (playbackAttempts.get(playbackKey) !== playbackAttempt) return
         clearRetry()
+        playbackAttempt.status = 'playing'
       }).catch(() => {
+        if (playbackAttempts.get(playbackKey) !== playbackAttempt) return
         // Suppress expected "The play() request was interrupted by a new load request" warnings
         // Expected interruptions are retried below without surfacing a noisy console warning.
         clearRetry()
+        playbackAttempt.status = 'retrying'
         const retry = window.setTimeout(() => {
           attempt()
-        }, 500) // Increased delay to 500ms for more stable retry
+        }, 500)
         retryTimers.set(playbackKey, retry)
       })
     }
@@ -567,7 +625,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       if (shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)) continue
       const stream = element.srcObject
       if (!(stream instanceof MediaStream) || stream.getAudioTracks().length === 0) continue
-      ensureRemoteAudioPlayback(playbackKey, element)
+      ensureRemoteAudioPlayback(playbackKey, element as VoxperyAudioElement, true)
     }
   }, [applyOutputDeviceToElements, applyOutputVolumeToElements, ensureRemoteAudioPlayback, parseRemoteAudioPlaybackKey])
 
@@ -727,7 +785,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
         const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
         const prevTrackIds = el.__voxpery_trackIds
-        if (currentTrackIds !== prevTrackIds) {
+        const directPlaybackExpected = shouldUseDirectRemoteAudioPlayback(
+          kind,
+          lightweightMobileVoice,
+          desktopRuntime,
+          playbackStream.getAudioTracks().length,
+          getPlaybackVolumeFactor(peerId, kind),
+        )
+        const playbackModeChanged = remotePlaybackGraphsRef.current.has(playbackKey) === directPlaybackExpected
+        if (currentTrackIds !== prevTrackIds || playbackModeChanged) {
           attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, el)
         }
         const playbackGraph = remotePlaybackGraphsRef.current.get(playbackKey)
@@ -737,7 +803,6 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
           const { peerId: graphPeerId } = parseRemoteAudioPlaybackKey(playbackKey)
           playbackGraph.gain.gain.value = shouldMute ? 0 : getPlaybackVolumeFactor(graphPeerId, kind)
         }
-        void applyPreferredAudioOutputDevice(el)
         if (!shouldMute && currentTrackIds) {
           ensureRemoteAudioPlayback(playbackKey, el)
         }
@@ -752,16 +817,18 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       if (context?.state === 'running') void context.suspend().catch(() => {})
     }
     applyOutputVolumeToElements(outputVolumeRef.current / 100)
-  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, disposeRemotePlaybackGraph, getPlaybackVolumeFactor, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
+  }, [applyOutputVolumeToElements, attachRemoteAudioPlaybackStream, desktopRuntime, disposeRemotePlaybackGraph, getPlaybackVolumeFactor, lightweightMobileVoice, parseRemoteAudioPlaybackKey, watchedRemoteScreenPeerIds, remoteAudioPlaybackKey, stablePeerIds, remoteAudioTrackCount, ensureRemoteAudioPlayback, state.remoteStreams])
 
   useEffect(() => {
     const retryTimers = remoteAudioRetryTimerRef.current
+    const playbackAttempts = remoteAudioPlaybackAttemptsRef.current
     const playbackGraphs = remotePlaybackGraphsRef.current
     return () => {
       for (const t of retryTimers.values()) {
         window.clearTimeout(t)
       }
       retryTimers.clear()
+      playbackAttempts.clear()
       for (const playbackKey of playbackGraphs.keys()) {
         disposeRemotePlaybackGraph(playbackKey)
       }
@@ -791,7 +858,15 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
             remoteAudioRefsRef.current.set(playbackKey, audioEl)
             const playbackStream = include ? createRemoteAudioKindPlaybackStream(stream, kind) : new MediaStream()
             const currentTrackIds = playbackStream.getTracks().map(t => t.id).sort().join(',')
-            if (audioEl.__voxpery_trackIds !== currentTrackIds) {
+            const directPlaybackExpected = shouldUseDirectRemoteAudioPlayback(
+              kind,
+              lightweightMobileVoice,
+              desktopRuntime,
+              playbackStream.getAudioTracks().length,
+              getPlaybackVolumeFactor(peerId, kind),
+            )
+            const playbackModeChanged = remotePlaybackGraphsRef.current.has(playbackKey) === directPlaybackExpected
+            if (audioEl.__voxpery_trackIds !== currentTrackIds || playbackModeChanged) {
               attachRemoteAudioPlaybackStream(playbackKey, kind, playbackStream, currentTrackIds, audioEl)
             }
             const shouldMute = shouldMuteRemoteAudioPlayback(kind, deafenedRef.current)
@@ -805,20 +880,28 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
               : Math.min(1, Math.max(0, (outputVolumeRef.current / 100) * peerFactor))
             try { audioEl.volume = vol } catch (e) { console.warn('[ActiveCallBar] Failed to set volume:', e) }
             audioEl.muted = shouldMute
-            void applyPreferredAudioOutputDevice(audioEl)
             if (!shouldMute && currentTrackIds) ensureRemoteAudioPlayback(playbackKey, audioEl)
           } else {
-            remoteAudioRefsRef.current.delete(playbackKey)
-            const timer = remoteAudioRetryTimerRef.current.get(playbackKey)
-            if (timer != null) {
-              window.clearTimeout(timer)
-              remoteAudioRetryTimerRef.current.delete(playbackKey)
-            }
+            const detachedElement = remoteAudioRefsRef.current.get(playbackKey)
+            queueMicrotask(() => {
+              // React briefly invokes an old callback ref with null when the
+              // same keyed audio node receives a new ref callback. Only tear
+              // down playback state after a real DOM detach or replacement.
+              if (!detachedElement || detachedElement.isConnected) return
+              if (remoteAudioRefsRef.current.get(playbackKey) !== detachedElement) return
+              remoteAudioRefsRef.current.delete(playbackKey)
+              remoteAudioPlaybackAttemptsRef.current.delete(playbackKey)
+              const timer = remoteAudioRetryTimerRef.current.get(playbackKey)
+              if (timer != null) {
+                window.clearTimeout(timer)
+                remoteAudioRetryTimerRef.current.delete(playbackKey)
+              }
+            })
           }
         }}
       />
     )
-  }, [attachRemoteAudioPlaybackStream, ensureRemoteAudioPlayback, getPlaybackVolumeFactor, remoteAudioPlaybackKey])
+  }, [attachRemoteAudioPlaybackStream, desktopRuntime, ensureRemoteAudioPlayback, getPlaybackVolumeFactor, lightweightMobileVoice, remoteAudioPlaybackKey])
 
   const showActiveCallBar = !!(state.joinedChannelId || state.localStream || state.isJoining)
   const channelParticipants = useMemo(() => {

--- a/apps/web/src/components/UserBar.tsx
+++ b/apps/web/src/components/UserBar.tsx
@@ -24,10 +24,12 @@ import { ROUTES } from '../routes'
 import {
   DEFAULT_VOICE_INPUT_PROFILE,
   getStoredVoiceInputProfile,
+  getStoredVoiceMode,
   getVoiceInputProfileConfig,
   isVoiceInputProfile,
   type VoiceInputProfile,
   VOICE_INPUT_PROFILE_KEY,
+  VOICE_MODE_KEY,
 } from '../webrtc/voiceInputProfile'
 import {
   checkForUpdates,
@@ -92,7 +94,6 @@ const INPUT_VOL_KEY = 'voxpery-settings-input-volume'
 const OUTPUT_VOL_KEY = 'voxpery-settings-output-volume'
 const DEFAULT_INPUT_VOLUME = 80
 const DEFAULT_OUTPUT_VOLUME = 80
-const VOICE_MODE_KEY = 'voxpery-settings-voice-mode'
 const PTT_KEY_KEY = 'voxpery-settings-ptt-key'
 const NOISE_SUPPRESSION_KEY = 'voxpery-settings-noise-suppression'
 const SPEAKING_THRESHOLD_KEY = SENSITIVITY_THRESHOLD_KEY
@@ -553,7 +554,8 @@ export default function UserBar() {
     const sound = localStorage.getItem(SOUND_KEY)
     const input = localStorage.getItem(INPUT_VOL_KEY)
     const output = localStorage.getItem(OUTPUT_VOL_KEY)
-    const mode = localStorage.getItem(VOICE_MODE_KEY)
+    const storedMode = localStorage.getItem(VOICE_MODE_KEY)
+    const mode = getStoredVoiceMode()
     const ptt = localStorage.getItem(PTT_KEY_KEY)
     const ns = localStorage.getItem(NOISE_SUPPRESSION_KEY)
     const speaking = localStorage.getItem(SPEAKING_THRESHOLD_KEY)
@@ -566,7 +568,7 @@ export default function UserBar() {
     setPushNotificationPermission(getPushNotificationPermission())
     if (input != null) setInputVolume(Math.min(100, Math.max(1, Number(input) || DEFAULT_INPUT_VOLUME)))
     if (output != null) setOutputVolume(Math.min(100, Math.max(1, Number(output) || DEFAULT_OUTPUT_VOLUME)))
-    if (mode === 'push_to_talk' || mode === 'voice_activity') setVoiceMode(mode)
+    setVoiceMode(mode)
     if (ptt) setPttKey(ptt)
     if (ns != null) {
       setNoiseSuppressionEnabled(ns === '1')
@@ -622,9 +624,25 @@ export default function UserBar() {
     }
     if (isVoiceInputProfile(profileRaw)) {
       setVoiceInputProfile(profileRaw)
+      if (profileRaw !== 'custom') {
+        const defaults = getVoiceInputProfileConfig(profileRaw)
+        setVoiceMode(defaults.voiceMode)
+        setNoiseSuppressionEnabled(defaults.noiseSuppressionEnabled)
+        setSpeakingPreset(defaults.speakingPreset)
+        setSpeakingThreshold(defaults.speakingThreshold)
+        try {
+          localStorage.setItem(VOICE_MODE_KEY, defaults.voiceMode)
+          localStorage.setItem(NOISE_SUPPRESSION_KEY, defaults.noiseSuppressionEnabled ? '1' : '0')
+          localStorage.setItem(SPEAKING_PRESET_KEY, defaults.speakingPreset)
+          localStorage.setItem(SPEAKING_THRESHOLD_KEY, String(defaults.speakingThreshold))
+          window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
+        } catch {
+          // ignore storage errors
+        }
+      }
     } else {
       const hasExplicitLegacyVoiceSettings =
-        mode != null || ns != null || preset != null || speaking != null
+        storedMode != null || ns != null || preset != null || speaking != null
       const inferredProfile = hasExplicitLegacyVoiceSettings ? 'custom' : DEFAULT_VOICE_INPUT_PROFILE
       setVoiceInputProfile(inferredProfile)
       try {

--- a/apps/web/src/voiceDevices.test.ts
+++ b/apps/web/src/voiceDevices.test.ts
@@ -180,4 +180,32 @@ describe('voice device preferences', () => {
     expect(setSinkId).toHaveBeenCalledOnce()
     expect(localStorage.getItem(VOICE_OUTPUT_DEVICE_KEY)).toBe('custom-speaker')
   })
+
+  it('coalesces concurrent assignments to the same output device', async () => {
+    Object.defineProperty(HTMLMediaElement.prototype, 'setSinkId', {
+      configurable: true,
+      value: vi.fn(),
+    })
+    const element = document.createElement('audio') as HTMLAudioElement & {
+      sinkId?: string
+      setSinkId: (sinkId: string) => Promise<void>
+    }
+    let resolveAssignment: (() => void) | undefined
+    const setSinkId = vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+      resolveAssignment = resolve
+    }))
+    Object.defineProperty(element, 'setSinkId', {
+      configurable: true,
+      value: setSinkId,
+    })
+    localStorage.setItem(VOICE_OUTPUT_DEVICE_KEY, 'custom-speaker')
+
+    const first = applyPreferredAudioOutputDevice(element)
+    const second = applyPreferredAudioOutputDevice(element)
+
+    expect(setSinkId).toHaveBeenCalledOnce()
+    expect(setSinkId).toHaveBeenCalledWith('custom-speaker')
+    resolveAssignment?.()
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+  })
 })

--- a/apps/web/src/voiceDevices.ts
+++ b/apps/web/src/voiceDevices.ts
@@ -228,6 +228,13 @@ type SinkSelectableAudioElement = HTMLAudioElement & {
   setSinkId?: (sinkId: string) => Promise<void>
 }
 
+type OutputDeviceAssignment = {
+  targetId: string
+  promise: Promise<boolean>
+}
+
+const outputDeviceAssignments = new WeakMap<HTMLAudioElement, OutputDeviceAssignment>()
+
 export async function applyPreferredAudioOutputDevice(element: HTMLAudioElement): Promise<boolean> {
   if (!supportsAudioOutputSelection()) return false
   const sinkElement = element as SinkSelectableAudioElement
@@ -235,21 +242,38 @@ export async function applyPreferredAudioOutputDevice(element: HTMLAudioElement)
 
   const preferredSinkId = getStoredVoiceOutputDeviceId() || 'default'
 
-  try {
-    if (sinkElement.sinkId !== preferredSinkId) {
-      await sinkElement.setSinkId(preferredSinkId)
-    }
-    return true
-  } catch (error) {
-    if (preferredSinkId !== 'default' && isUnavailableDeviceError(error)) {
-      clearStoredDeviceId(VOICE_OUTPUT_DEVICE_KEY)
-      try {
-        await sinkElement.setSinkId('default')
-        return true
-      } catch {
-        // ignore fallback failures
+  const currentAssignment = outputDeviceAssignments.get(element)
+  if (currentAssignment?.targetId === preferredSinkId) return currentAssignment.promise
+
+  const assign = async (): Promise<boolean> => {
+    try {
+      if (sinkElement.sinkId !== preferredSinkId) {
+        await sinkElement.setSinkId(preferredSinkId)
       }
+      return true
+    } catch (error) {
+      if (preferredSinkId !== 'default' && isUnavailableDeviceError(error)) {
+        clearStoredDeviceId(VOICE_OUTPUT_DEVICE_KEY)
+        try {
+          await sinkElement.setSinkId('default')
+          return true
+        } catch {
+          // ignore fallback failures
+        }
+      }
+      return false
     }
-    return false
   }
+
+  const promise = currentAssignment
+    ? currentAssignment.promise.catch(() => false).then(assign)
+    : assign()
+  outputDeviceAssignments.set(element, { targetId: preferredSinkId, promise })
+  const clearAssignment = () => {
+    if (outputDeviceAssignments.get(element)?.promise === promise) {
+      outputDeviceAssignments.delete(element)
+    }
+  }
+  void promise.then(clearAssignment, clearAssignment)
+  return promise
 }

--- a/apps/web/src/webrtc/hooks/useAudioEngine.test.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { shouldUseLightweightMobileVoicePipeline } from './useAudioEngine'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  connectSilentVoicePipelineKeepAlive,
+  shouldUseLightweightMobileVoicePipeline,
+} from './useAudioEngine'
 
 describe('mobile voice pipeline selection', () => {
   it('uses the lightweight native-processing path on mobile runtimes', () => {
@@ -18,5 +21,25 @@ describe('mobile voice pipeline selection', () => {
       userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
       maxTouchPoints: 0,
     })).toBe(false)
+  })
+})
+
+describe('processed microphone pipeline keep-alive', () => {
+  it('keeps the shared graph rendering without playing the microphone locally', () => {
+    const destination = {} as AudioDestinationNode
+    const gain = {
+      gain: { value: 1 },
+      connect: vi.fn(),
+    } as unknown as GainNode
+    const ctx = {
+      destination,
+      createGain: vi.fn(() => gain),
+    } as unknown as AudioContext
+    const source = { connect: vi.fn() } as unknown as AudioNode
+
+    expect(connectSilentVoicePipelineKeepAlive(ctx, source)).toBe(gain)
+    expect(gain.gain.value).toBe(0)
+    expect(source.connect).toHaveBeenCalledWith(gain)
+    expect(gain.connect).toHaveBeenCalledWith(destination)
   })
 })

--- a/apps/web/src/webrtc/hooks/useAudioEngine.ts
+++ b/apps/web/src/webrtc/hooks/useAudioEngine.ts
@@ -33,6 +33,19 @@ export function shouldUseLightweightMobileVoicePipeline(
         || (userAgent.includes('macintosh') && navigatorTarget.maxTouchPoints > 1)
 }
 
+export type MicrophonePipelineSource = 'processed-webaudio' | 'browser-native'
+
+export function connectSilentVoicePipelineKeepAlive(
+    ctx: AudioContext,
+    source: AudioNode,
+): GainNode {
+    const keepAliveGain = ctx.createGain()
+    keepAliveGain.gain.value = 0
+    source.connect(keepAliveGain)
+    keepAliveGain.connect(ctx.destination)
+    return keepAliveGain
+}
+
 function dbToLinear(db: number): number {
     return Math.pow(10, db / 20)
 }
@@ -413,7 +426,12 @@ export function useAudioEngine() {
         rawMicTrackRef: React.MutableRefObject<MediaStreamTrack | null>,
         inputGainNodeRef: React.MutableRefObject<GainNode | null>,
         noiseSuppressionEnabled: boolean,
-    ): Promise<{ track: MediaStreamTrack; vadStream: MediaStream; cancelGate: () => void }> => {
+    ): Promise<{
+        track: MediaStreamTrack
+        vadStream: MediaStream
+        cancelGate: () => void
+        source: MicrophonePipelineSource
+    }> => {
         const rawTrack = sourceStream.getAudioTracks()[0]
         if (!rawTrack) throw new Error('No microphone track available')
 
@@ -421,7 +439,14 @@ export function useAudioEngine() {
         rawTrack.enabled = !muted
 
         const ctx = getAudioContext()
-        if (!ctx) return { track: rawTrack, vadStream: sourceStream, cancelGate: () => {} }
+        if (!ctx) {
+            return {
+                track: rawTrack,
+                vadStream: sourceStream,
+                cancelGate: () => {},
+                source: 'browser-native',
+            }
+        }
         if (ctx.state === 'suspended') {
             await ctx.resume()
         }
@@ -434,6 +459,7 @@ export function useAudioEngine() {
             rawMicTrackSettings: toVoiceTrackSettingsDiagnostics(rawTrack.getSettings?.()),
             audioContext: toVoiceAudioContextDiagnostics(ctx),
             inputVolume: roundVoiceDiagnosticNumber(volumeFactor, 2),
+            nativeMicrophonePipeline: false,
         })
 
         if (shouldUseLightweightMobileVoicePipeline()) {
@@ -446,11 +472,18 @@ export function useAudioEngine() {
             gain.gain.value = volumeFactor
             source.connect(gain)
             gain.connect(destination)
+            const keepAliveGain = connectSilentVoicePipelineKeepAlive(ctx, gain)
             const processedTrack = destination.stream.getAudioTracks()[0]
             if (!processedTrack) {
                 source.disconnect()
                 gain.disconnect()
-                return { track: rawTrack, vadStream: sourceStream, cancelGate: () => {} }
+                keepAliveGain.disconnect()
+                return {
+                    track: rawTrack,
+                    vadStream: sourceStream,
+                    cancelGate: () => {},
+                    source: 'browser-native',
+                }
             }
             inputGainNodeRef.current = gain
             updateVoiceDiagnostics({
@@ -463,7 +496,9 @@ export function useAudioEngine() {
                 cancelGate: () => {
                     try { source.disconnect() } catch { /* ignore */ }
                     try { gain.disconnect() } catch { /* ignore */ }
+                    try { keepAliveGain.disconnect() } catch { /* ignore */ }
                 },
+                source: 'processed-webaudio',
             }
         }
 
@@ -522,6 +557,7 @@ export function useAudioEngine() {
         noiseFloorGainNode.connect(vadDestination) // branch for VAD after final floor suppression
         noiseFloorGainNode.connect(volumeGainNode)
         volumeGainNode.connect(destination)
+        const keepAliveGain = connectSilentVoicePipelineKeepAlive(ctx, volumeGainNode)
 
         const liveSuppressionNodes = {
             ctx,
@@ -537,7 +573,14 @@ export function useAudioEngine() {
         liveSuppressionSignatureRef.current = `${noiseSuppressionEnabled}:${aggressiveIsolation}:${suppressionTuning}`
 
         const processedTrack = destination.stream.getAudioTracks()[0]
-        if (!processedTrack) return { track: rawTrack, vadStream: sourceStream, cancelGate: () => {} }
+        if (!processedTrack) {
+            return {
+                track: rawTrack,
+                vadStream: sourceStream,
+                cancelGate: () => {},
+                source: 'browser-native',
+            }
+        }
 
         updateVoiceDiagnostics({
             processedMicTrackSettings: toVoiceTrackSettingsDiagnostics(processedTrack.getSettings?.()),
@@ -643,6 +686,11 @@ export function useAudioEngine() {
             } catch {
                 // ignore
             }
+            try {
+                keepAliveGain.disconnect()
+            } catch {
+                // ignore
+            }
         }
 
         const tickNoiseFloor = () => {
@@ -710,7 +758,12 @@ export function useAudioEngine() {
 
         rafId = requestAnimationFrame(tickNoiseFloor)
 
-        return { track: processedTrack, vadStream: vadDestination.stream, cancelGate }
+        return {
+            track: processedTrack,
+            vadStream: vadDestination.stream,
+            cancelGate,
+            source: 'processed-webaudio',
+        }
     }, [getAudioContext])
 
     const updateMicProcessingSettings = useCallback((noiseSuppressionEnabled: boolean) => {

--- a/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.test.ts
@@ -73,6 +73,7 @@ describe('screen share quality profiles', () => {
       selfBrowserSurface: 'exclude',
       surfaceSwitching: 'include',
       audio: {
+        restrictOwnAudio: true,
         suppressLocalAudioPlayback: false,
       },
     })

--- a/apps/web/src/webrtc/hooks/useLocalMedia.ts
+++ b/apps/web/src/webrtc/hooks/useLocalMedia.ts
@@ -88,6 +88,7 @@ export function toScreenShareConstraintsForProfile(profile: ScreenShareProfile):
 }
 
 type DisplayAudioConstraints = MediaTrackConstraints & {
+    restrictOwnAudio: boolean
     suppressLocalAudioPlayback: boolean
 }
 
@@ -112,6 +113,9 @@ export function toScreenShareDisplayMediaOptions(
         selfBrowserSurface: 'exclude',
         surfaceSwitching: 'include',
         audio: {
+            // Do not feed Voxpery's own remote call playback back into the
+            // shared-audio track when the browser supports this constraint.
+            restrictOwnAudio: true,
             // Keep the active call audible while the native/macOS share picker changes focus.
             suppressLocalAudioPlayback: false,
         } as DisplayAudioConstraints,

--- a/apps/web/src/webrtc/hooks/useVoiceActivity.ts
+++ b/apps/web/src/webrtc/hooks/useVoiceActivity.ts
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppStore } from '../../stores/app'
 import { getThresholdsFromStorage } from '../sensitivityThreshold'
-import { getStoredVoiceInputProfile, shouldUseAggressiveVoiceIsolation } from '../voiceInputProfile'
+import {
+    getStoredVoiceInputProfile,
+    getStoredVoiceMode,
+    shouldUseAggressiveVoiceIsolation,
+} from '../voiceInputProfile'
 import { evaluateVoiceGateFrame } from '../voiceGate'
 import { linearToDbDiagnostic, updateVoiceDiagnostics } from '../voiceDiagnostics'
 
-const VOICE_MODE_KEY = 'voxpery-settings-voice-mode'
 const PTT_KEY_KEY = 'voxpery-settings-ptt-key'
 const SETTINGS_CHANGED_EVENT = 'voxpery-voice-settings-changed'
 const NOISE_SUPPRESSION_KEY = 'voxpery-settings-noise-suppression'
@@ -20,10 +23,7 @@ export function useVoiceActivity(options: {
     setLocalMicMuted: (muted: boolean) => Promise<void>
 }) {
     const { userId, joinedChannelId, localStream, getAudioContext, setLocalMicMuted } = options
-    const [voiceMode, setVoiceMode] = useState<VoiceMode>(() => {
-        const modeRaw = localStorage.getItem(VOICE_MODE_KEY)
-        return modeRaw === 'push_to_talk' ? 'push_to_talk' : 'voice_activity'
-    })
+    const [voiceMode, setVoiceMode] = useState<VoiceMode>(() => getStoredVoiceMode())
 
     const pttPressedRef = useRef(false)
     const voiceActivitySpeakingRef = useRef(false)
@@ -32,8 +32,7 @@ export function useVoiceActivity(options: {
     const monitorAnalyserRef = useRef<AnalyserNode | null>(null)
 
     const getVoiceModeSettings = useCallback((): { mode: VoiceMode; key: string } => {
-        const modeRaw = localStorage.getItem(VOICE_MODE_KEY)
-        const mode = modeRaw === 'push_to_talk' ? 'push_to_talk' : 'voice_activity'
+        const mode = getStoredVoiceMode()
         const keyRaw = localStorage.getItem(PTT_KEY_KEY)
         const key = keyRaw && keyRaw.trim().length > 0 ? keyRaw.trim() : 'V'
         return { mode, key }
@@ -208,8 +207,7 @@ export function useVoiceActivity(options: {
             applyPushToTalkGate()
         }
         const onSettingsChanged = () => {
-            const nextModeRaw = localStorage.getItem(VOICE_MODE_KEY)
-            const nextMode = nextModeRaw === 'push_to_talk' ? 'push_to_talk' : 'voice_activity'
+            const nextMode = getStoredVoiceMode()
             setVoiceMode(nextMode)
             pttPressedRef.current = false
             if (nextMode === 'push_to_talk') {

--- a/apps/web/src/webrtc/remoteMediaControls.test.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.test.ts
@@ -60,13 +60,14 @@ describe('remote media controls', () => {
     expect(shouldMuteRemoteAudioPlayback('screen', false)).toBe(false)
   })
 
-  it('uses direct playback in mobile and Tauri runtimes while keeping Web Audio for browsers', () => {
+  it('uses native playback by default and reserves Web Audio for browser voice amplification', () => {
     expect(shouldUseDirectRemoteAudioPlayback('mic', true, false, 1)).toBe(true)
     expect(shouldUseDirectRemoteAudioPlayback('screen', true, false, 1)).toBe(true)
     expect(shouldUseDirectRemoteAudioPlayback('mic', false, true, 1)).toBe(true)
     expect(shouldUseDirectRemoteAudioPlayback('screen', false, true, 1)).toBe(true)
-    expect(shouldUseDirectRemoteAudioPlayback('mic', false, false, 1)).toBe(false)
-    expect(shouldUseDirectRemoteAudioPlayback('screen', false, false, 1)).toBe(false)
+    expect(shouldUseDirectRemoteAudioPlayback('mic', false, false, 1)).toBe(true)
+    expect(shouldUseDirectRemoteAudioPlayback('screen', false, false, 1)).toBe(true)
     expect(shouldUseDirectRemoteAudioPlayback('screen', false, false, 0)).toBe(true)
+    expect(shouldUseDirectRemoteAudioPlayback('mic', false, false, 1, 1.01)).toBe(false)
   })
 })

--- a/apps/web/src/webrtc/remoteMediaControls.ts
+++ b/apps/web/src/webrtc/remoteMediaControls.ts
@@ -57,10 +57,15 @@ export function shouldMuteRemoteAudioPlayback(kind: RemoteAudioKind, voiceDeafen
 }
 
 export function shouldUseDirectRemoteAudioPlayback(
-  _kind: RemoteAudioKind,
+  kind: RemoteAudioKind,
   lightweightMobileVoice: boolean,
   desktopRuntime: boolean,
   audioTrackCount: number,
+  playbackVolumeFactor = 1,
 ): boolean {
-  return desktopRuntime || lightweightMobileVoice || audioTrackCount === 0
+  return kind === 'screen'
+    || desktopRuntime
+    || lightweightMobileVoice
+    || audioTrackCount === 0
+    || playbackVolumeFactor <= 1
 }

--- a/apps/web/src/webrtc/useLiveKitVoice.test.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.test.ts
@@ -7,6 +7,7 @@ import {
   getPreferredScreenShareCodec,
   getScreenShareAudioPublishOptions,
   getScreenSharePublishOptions,
+  LIVEKIT_AUTO_SUBSCRIBE,
   reconcileLiveKitVoicePresence,
   reconcileFinalMediaDisconnect,
   remoteMediaKindForSource,
@@ -41,6 +42,12 @@ describe('microphone publish options', () => {
       red: true,
       forceStereo: false,
     })
+  })
+})
+
+describe('initial remote subscription policy', () => {
+  it('hydrates existing microphone publications during room join', () => {
+    expect(LIVEKIT_AUTO_SUBSCRIBE).toBe(true)
   })
 })
 

--- a/apps/web/src/webrtc/useLiveKitVoice.ts
+++ b/apps/web/src/webrtc/useLiveKitVoice.ts
@@ -19,7 +19,10 @@ import { useAuthStore } from '../stores/auth'
 import { useAppStore } from '../stores/app'
 import { useSocketStore } from '../stores/socket'
 import { startAudioLevelMonitor } from './audioLevelMonitor'
-import { shouldUseLightweightMobileVoicePipeline, useAudioEngine } from './hooks/useAudioEngine'
+import {
+  shouldUseLightweightMobileVoicePipeline,
+  useAudioEngine,
+} from './hooks/useAudioEngine'
 import { useLocalMedia, type ScreenShareCaptureResult } from './hooks/useLocalMedia'
 import { useVoiceActivity } from './hooks/useVoiceActivity'
 import { useWebrtcDiagnostics } from './hooks/useWebrtcDiagnostics'
@@ -46,6 +49,8 @@ if (import.meta.env.PROD) {
 type PeerId = string
 type RemoteMediaStartCueKind = 'camera' | 'screen'
 type RemoteMediaCuePhase = 'start' | 'stop'
+
+export const LIVEKIT_AUTO_SUBSCRIBE = true
 
 type VoiceControlState = {
   muted?: boolean
@@ -909,7 +914,6 @@ export function useLiveKitVoice() {
       if (!rawMicTrack) throw new Error('No microphone track available')
 
       const audioContext = getAudioContext()
-      if (!audioContext && !mobileOptimizedVoice) throw new Error('Audio context required for voice processors')
       if (audioContext?.state === 'suspended') {
         await audioContext.resume()
       }
@@ -920,10 +924,15 @@ export function useLiveKitVoice() {
       // runs when enabled, and browser NS acts as a reliable fallback layer.
       await applyLocalMicSettings(rawMicTrack)
 
-      // Build the processed audio pipeline: mic → RNNoise (if enabled) → volume gain → publishTrack
+      // Build one processed publication source for desktop browsers and webviews.
       gateCancelRef.current?.()
       gateCancelRef.current = null
-      const { track: publishTrack, vadStream, cancelGate } = await buildMicSendTrack(
+      const {
+        track: publishTrack,
+        vadStream,
+        cancelGate,
+        source: microphoneSource,
+      } = await buildMicSendTrack(
         preflightStream,
         getInputVolumeFactor(),
         desiredMicMutedRef.current,
@@ -967,7 +976,7 @@ export function useLiveKitVoice() {
           adaptiveStream: true,
           dynacast: true,
           microphonePublished: false,
-          microphoneSource: 'processed-webaudio',
+          microphoneSource,
         },
       })
       roomRef.current = room
@@ -1136,7 +1145,10 @@ export function useLiveKitVoice() {
         })
 
       const connectPromise = room.connect(ws_url, lkToken, {
-        autoSubscribe: false,
+        // Hydrate existing microphone publications atomically with room join.
+        // Selective media rules immediately unsubscribe unwatched screen
+        // shares and hidden video without racing required voice audio.
+        autoSubscribe: LIVEKIT_AUTO_SUBSCRIBE,
         rtcConfig: { iceServers },
       })
       const timeoutPromise = new Promise<never>((_, reject) =>
@@ -1166,7 +1178,7 @@ export function useLiveKitVoice() {
           adaptiveStream: true,
           dynacast: true,
           microphonePublished: true,
-          microphoneSource: 'processed-webaudio',
+          microphoneSource,
           microphoneAudioPreset: mobileOptimizedVoice ? 'music' : 'musicHighQuality',
           microphoneDtx: true,
           microphoneRed: true,
@@ -1183,9 +1195,7 @@ export function useLiveKitVoice() {
       await setLocalMicMuted(desiredMicMutedRef.current)
 
       refreshLocalStreams()
-      // Feed the speaking monitor with the post-RNNoise signal so the
-      // indicator only lights up when actual voice passes through the
-      // denoiser — background noise (claps, keyboard, fan) won't trigger it.
+      // Monitor the exact source selected for publication.
       startLocalSpeakingMonitor(vadStreamRef.current)
 
       if (voiceMode === 'push_to_talk') {

--- a/apps/web/src/webrtc/voiceDiagnostics.ts
+++ b/apps/web/src/webrtc/voiceDiagnostics.ts
@@ -59,7 +59,7 @@ export interface VoiceLivekitDiagnostics {
   adaptiveStream?: boolean
   dynacast?: boolean
   microphonePublished?: boolean
-  microphoneSource?: 'processed-webaudio'
+  microphoneSource?: 'processed-webaudio' | 'browser-native'
   microphoneAudioPreset?: 'music' | 'musicHighQuality'
   microphoneDtx?: boolean
   microphoneRed?: boolean
@@ -123,6 +123,8 @@ export interface VoiceRuntimeDiagnostics {
   aggressiveIsolation?: boolean
   inputVolume?: number
   mobileOptimizedPipeline?: boolean
+  nativeMicrophonePipeline?: boolean
+  microphoneFallbackReason?: string
   captureConstraints?: VoiceProcessingConstraintsDiagnostics
   rawMicTrackSettings?: VoiceTrackSettingsDiagnostics
   processedMicTrackSettings?: VoiceTrackSettingsDiagnostics

--- a/apps/web/src/webrtc/voiceInputProfile.test.ts
+++ b/apps/web/src/webrtc/voiceInputProfile.test.ts
@@ -1,9 +1,36 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  getStoredVoiceMode,
   getVoiceSuppressionTuning,
   shouldRebuildSuppressionPipeline,
   shouldUseAggressiveVoiceIsolation,
+  VOICE_INPUT_PROFILE_KEY,
+  VOICE_MODE_KEY,
 } from './voiceInputProfile'
+
+describe('stored voice activation mode', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('uses voice activity for built-in profiles even when a stale PTT value remains', () => {
+    localStorage.setItem(VOICE_INPUT_PROFILE_KEY, 'isolation')
+    localStorage.setItem(VOICE_MODE_KEY, 'push_to_talk')
+
+    expect(getStoredVoiceMode()).toBe('voice_activity')
+  })
+
+  it('preserves an explicitly configured custom PTT mode', () => {
+    localStorage.setItem(VOICE_INPUT_PROFILE_KEY, 'custom')
+    localStorage.setItem(VOICE_MODE_KEY, 'push_to_talk')
+
+    expect(getStoredVoiceMode()).toBe('push_to_talk')
+  })
+
+  it('preserves legacy PTT settings until they are migrated to a custom profile', () => {
+    localStorage.setItem(VOICE_MODE_KEY, 'push_to_talk')
+
+    expect(getStoredVoiceMode()).toBe('push_to_talk')
+  })
+})
 
 describe('voiceInputProfile suppression tuning', () => {
   it('maps low thresholds to balanced cleanup and high thresholds to high cleanup', () => {

--- a/apps/web/src/webrtc/voiceInputProfile.ts
+++ b/apps/web/src/webrtc/voiceInputProfile.ts
@@ -5,6 +5,7 @@ import {
 } from './sensitivityThreshold'
 
 export const VOICE_INPUT_PROFILE_KEY = 'voxpery-settings-voice-input-profile'
+export const VOICE_MODE_KEY = 'voxpery-settings-voice-mode'
 
 export type VoiceInputProfile = 'isolation' | 'studio' | 'custom'
 export type VoiceSuppressionTuning = 'off' | 'balanced' | 'high'
@@ -64,6 +65,19 @@ export function getVoiceProfileSummary(profile: VoiceInputProfile): string {
   if (profile === 'studio') return 'Raw voice with minimal processing for maximum natural tone.'
   if (profile === 'custom') return 'Fine-tuned sensitivity and mode with noise isolation kept active when enabled.'
   return 'Default isolation profile optimized for keyboard and room-noise suppression.'
+}
+
+export function getStoredVoiceMode(): VoiceInputProfileConfig['voiceMode'] {
+  if (typeof localStorage === 'undefined') return 'voice_activity'
+
+  const profileRaw = localStorage.getItem(VOICE_INPUT_PROFILE_KEY)
+  if (profileRaw === 'isolation' || profileRaw === 'studio') {
+    return getVoiceInputProfileConfig(profileRaw).voiceMode
+  }
+
+  return localStorage.getItem(VOICE_MODE_KEY) === 'push_to_talk'
+    ? 'push_to_talk'
+    : 'voice_activity'
 }
 
 export function shouldUseAggressiveVoiceIsolation(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stabilized initial watched screen-share audio by coalescing output-device assignment and starting each unchanged remote track only once while subscription events settle.
+- Prevented supported browsers from recapturing Voxpery's own call playback into a shared-audio track.
+- Unified Firefox, Chromium, and desktop microphone publication behind one RNNoise/Web Audio engine, kept the processing graph alive without local monitor playback, and reconciled built-in voice profiles with stale activation-mode settings so a client cannot silently remain in push-to-talk.
+- Restored atomic LiveKit subscription hydration for participants already in a voice room, preventing join order from producing one-way audio while preserving selective camera and screen-share bandwidth controls.
+- Kept normal remote microphone and screen audio on native media-element playback across browsers, using an isolated Web Audio gain graph only when a user explicitly amplifies voice above 100%, so Firefox senders remain audible to Chromium receivers without coupling voice and stream volume.
+
 ## [0.2.12] - 2026-08-23
 
 ### Added

--- a/docs/VOICE_RELEASE_SMOKE_TEST.md
+++ b/docs/VOICE_RELEASE_SMOKE_TEST.md
@@ -15,6 +15,8 @@ The goal is to verify the real user path, not every implementation detail. Run t
 
 - [ ] User A joins a voice channel and User B sees A in the channel list.
 - [ ] User B joins the same voice channel and both users hear the join cue.
+- [ ] Repeat two-way microphone transmission with Firefox as the first participant and Chromium as the second, then reverse the join order and repeat with the desktop app. Every receiver hears every sender while the speaking indicator is active and RNNoise remains available on each browser.
+- [ ] At the default per-user voice level, Firefox-to-Chromium and Chromium-to-Firefox audio use stable native playback. Raising one user's voice above 100% enables amplification without changing screen-share volume or interrupting any other participant.
 - [ ] Mute/unmute changes local mic state and does not disconnect the room.
 - [ ] The configured mute shortcut toggles the microphone while the web tab is focused.
 - [ ] A new/default user joins with the operating system's current default microphone and speaker.
@@ -62,7 +64,7 @@ The goal is to verify the real user path, not every implementation detail. Run t
 - [ ] User B chooses `Watch stream`; both `ScreenShare` and `ScreenShareAudio` subscribe, while User A's microphone remains continuously audible.
 - [ ] While User B watches a stream, hiding/minimizing Voxpery pauses screen video but keeps screen-share audio continuous; restoring the app resumes video without an audio gap or replayed media cue.
 - [ ] Shared system, game, and music audio remains stereo and continuous without speech-style gating; diagnostics report `musicHighQualityStereo`, 128 kbps, `forceStereo: true`, `dtx: false`, and `red: true`.
-- [ ] On a freshly installed or updated Tauri build, two users hear each other immediately after joining, then while User B watches User A's shared-audio stream, User B repeatedly speaks and stops speaking; the stream and all remote microphones remain simultaneously audible without ducking, gaps, output-device changes, or playback restarts. Repeat with at least five participants on web and desktop.
+- [ ] On a freshly installed or updated Tauri build, two users hear each other immediately after joining, then while User B watches User A's shared-audio stream, User B speaks and stops at least five times immediately after playback begins; the stream and all remote microphones remain simultaneously audible without startup ducking, gaps, output-device changes, or playback restarts. Repeat with at least five participants on web and desktop.
 - [ ] Sharing a source/platform that provides no audio still publishes video without a misleading warning toast.
 - [ ] With opt-in diagnostics enabled, requested and actual capture resolution/FPS, audio sample rate/channel count/content hint/publication profile, simulcast, outbound video bitrate/FPS, actual screen-audio Opus bitrate/channels/packets, packet loss, and quality limitation reason are present without device identifiers.
 - [ ] Under constrained bandwidth, screen share remains watchable by stepping down to a lower simulcast layer instead of freezing on a single high-quality layer.

--- a/docs/VOICE_SYSTEM.md
+++ b/docs/VOICE_SYSTEM.md
@@ -13,7 +13,7 @@ Microphone -> getUserMedia -> AudioContext pipeline -> LiveKit Room -> SFU -> Re
                            Low-level noise taming
                            VAD analyser tap
                            Input gain
-                           VAD gate (optional)
+                           VAD monitoring (sender stays live)
                            Sensitivity threshold
 ```
 
@@ -78,7 +78,7 @@ VAD analyser tap (post-denoise + post-floor suppression, pre-volume)
     |
 GainNode (input volume)
     |
-VAD gate (optional, voice_activity mode)
+Published-track health monitor
     |
 LiveKit LocalAudioTrack (high-quality mono Opus with DTX + RED)
     |
@@ -125,7 +125,10 @@ Room.localParticipant.publishTrack
   - Spectral isolation and attack/recovery smoothing are profile-aware: `Balanced` recovers speech faster and attenuates it less, while `Noisy room` applies stronger isolation only to noise-dominant frames such as keyboard and fan fixtures.
   - Clean speech bypasses post-RNNoise floor and spectral attenuation in both presets. Quiet speech remains fully open in `Balanced`; `Noisy room` may apply bounded cleanup but must not mute or hard-gate it.
 - **Microphone publish quality**
-  - The processed microphone track is published with LiveKit's high-quality mono Opus preset.
+  - Firefox, Chromium, and desktop webviews use the same 48 kHz processing graph required by RNNoise. A zero-volume connection to the hardware destination keeps that graph rendering without playing the local microphone through the speakers.
+  - Browser identity never bypasses noise suppression. If Web Audio is unavailable before publication, Voxpery uses the browser-native capture track; it does not replace a healthy processed sender based on a browser-local analyser reading.
+  - Built-in input profiles are authoritative for activation mode and suppression, while explicit push-to-talk remains available through the custom profile.
+  - The selected microphone track is published with LiveKit's high-quality mono Opus preset.
   - Mobile web/PWA clients use the resilient 48 kbps mono Opus preset. Desktop clients keep the 96 kbps preset; both retain RED and DTX so unstable mobile uplinks do not have to carry the desktop bitrate.
   - DTX remains enabled to avoid sending unnecessary silence, and RED remains enabled for packet-loss resilience.
   - Stereo is forced off for microphone audio so bitrate stays focused on voice clarity rather than duplicate channels.
@@ -187,6 +190,7 @@ Speaker
 
 - **Output volume**: Global 1-100%, per-peer microphone 0-200%, and per-screen-share audio 0-100%.
 - **Desktop-safe playback**: Tauri plays each remote microphone and watched screen-share track through its own direct media element. This avoids routing incoming audio through a WebView-specific `MediaStreamAudioDestination` bridge while preserving source-level mute, volume, output-device, and playback recovery controls.
+- **Stable startup**: Output-device changes are serialized per media element, and an unchanged remote track has at most one pending playback start. Initial LiveKit subscription and mute-state events therefore cannot restart watched screen audio while the first playback promise settles.
 - **Source-aware browser dynamics**: Browser microphone amplification keeps its peak limiter, while screen-share audio bypasses voice compression so music and game dynamics are preserved. Tauri and mobile web keep the more resilient direct media path.
 - **Deafen**: Mutes remote microphone playback while leaving watched screen-share audio under its independent stream volume/mute controls
 - **Immediate deafen**: Every active browser microphone bus is set to zero synchronously with the control click. Direct Tauri and mobile microphone elements are muted in the same pass, and newly subscribed microphone outputs start muted while deafened, closing reconnect and render/effect windows where voice could otherwise leak briefly.
@@ -203,6 +207,7 @@ Speaker
 - Permission failures, devices that are temporarily busy, and output-selection policy failures do not overwrite a valid custom preference.
 - The same microphone fallback is used by call preflight, LiveKit capture, the microphone test, and the legacy WebRTC path.
 - Mobile browsers use their hardware/browser AEC and noise suppression with a lightweight Web Audio gain path. They skip the desktop RNNoise analyser/refinement loop and play remote microphone tracks through the browser's direct media path, so capture and multiple remote playbacks do not compete for the mobile main thread.
+- Desktop browsers also play remote microphone and watched screen audio directly at normal volume. The independent Web Audio voice gain path is created only for an explicit per-user voice level above 100%; screen audio remains direct and independently controlled from 0% to 100%.
 
 ## Screen Sharing
 
@@ -221,7 +226,10 @@ Speaker
 const stream = await navigator.mediaDevices.getDisplayMedia({
   video: { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 60, max: 60 } },
   systemAudio: 'include',
-  audio: { suppressLocalAudioPlayback: false }  // Shared audio without ducking the active call
+  audio: {
+    restrictOwnAudio: true,
+    suppressLocalAudioPlayback: false,
+  } // Exclude Voxpery's own call audio while keeping the call audible locally
 })
 await room.localParticipant.publishTrack(videoTrack, {
   source: Track.Source.ScreenShare,
@@ -254,7 +262,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - **Screen-share audio**: `contentHint = 'music'`, stereo 128 kbps Opus, continuous transmission (`dtx = false`), and RED packet-loss resilience preserve system, game, and music audio independently from the mono speech microphone profile.
 - **Camera video**: `contentHint = 'motion'` (optimizes for movement). On mobile devices with more than one camera, the local preview exposes a front/rear switch that restarts the existing published LiveKit video track in place. Devices with only one available camera do not show the control.
 - A share is not published without a live video track. A missing system/tab audio track is treated as an intentional silent share; capture or publication failures still surface as errors. System-audio availability is determined by the operating system, browser/runtime, selected share surface, and the picker audio option rather than the GPU vendor.
-- Display capture requests selected-window audio for window shares, exclude Voxpery's own browser surface, and let the native picker expose broader system-audio capture only for surfaces where the runtime supports it. Voxpery never substitutes whole-system audio when selected-window audio is unavailable.
+- Display capture requests selected-window audio for window shares, excludes Voxpery's own call playback and browser surface where supported, and lets the native picker expose broader system-audio capture only for surfaces where the runtime supports it. Voxpery never substitutes whole-system audio when selected-window audio is unavailable.
 - Publishing is rollback-safe: if any selected screen track fails to publish, already-published tracks from that attempt are unpublished and the local capture is stopped.
 - Opt-in voice diagnostics record requested and actual capture resolution/FPS, constraint application, screen-audio sample rate/channel count/content hint/publish profile, codec/scalability mode, simulcast state, outbound video resolution/FPS/bitrate/packet/quality-limitation samples, and actual screen-audio Opus bitrate/channel/packet samples without device identifiers.
 
@@ -269,7 +277,7 @@ Screen publishing uses VP9 SVC when supported and falls back to VP8 simulcast wi
 - Global output volume remains a top-level playback control for both sources without rewriting either per-source preference. Deafen suppresses remote microphone playback only; watched screen-share audio remains controlled by its independent stream volume and mute state.
 - When the Voxpery window is hidden or minimized, camera and watched screen video subscriptions pause while microphone and explicitly watched screen-share audio continue. Video resumes when the app becomes visible, without replaying media-start cues.
 - Returning from the native screen picker, restoring the app, or refocusing Voxpery reasserts the configured output device, volume, and remote playback without changing per-user volume settings.
-- Remote microphone publications remain subscribed in foreground and background. Failed subscriptions are retried, missing subscribed tracks are reconciled after LiveKit reconnect, ended tracks are removed immediately, and replacement tracks supersede stale tracks from the same logical source.
+- Existing remote microphone publications are hydrated by LiveKit as part of the room join, independent of participant join order, and remain subscribed in foreground and background. Selective rules then unsubscribe only unwatched screen shares and hidden video. Failed subscriptions are retried, missing subscribed tracks are reconciled after LiveKit reconnect, ended tracks are removed immediately, and replacement tracks supersede stale tracks from the same logical source.
 - Speaking indicators monitor microphone tracks only; screen-share audio cannot incorrectly keep a participant marked as speaking.
 
 ### Voice Event Cues


### PR DESCRIPTION
## Summary
- Stabilized Firefox, Chromium, and desktop microphone publishing through the shared RNNoise/Web Audio pipeline.
- Restored atomic LiveKit microphone subscription during room join to prevent join-order one-way audio.
- Kept normal remote voice and screen-share audio on native playback; Web Audio is now reserved for explicit voice amplification above 100%.
- Reduced initial screen-share playback restarts and prevented self-call audio from entering shared-audio capture.

## Validation
- `npm run test:run`
- `npm run lint`
- `npm run build`