### PR TITLE
fix: restore legal page scrolling

### DIFF
--- a/apps/web/e2e/legal-pages.spec.ts
+++ b/apps/web/e2e/legal-pages.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test'
+
+const legalPages = [
+  { path: '/privacy', lastHeading: 'Changes and incidents' },
+  { path: '/terms', lastHeading: 'Contact' },
+  { path: '/kvkk', lastHeading: 'Saklama, mesaj gizliliği ve haklar' },
+]
+
+test.describe('hosted legal pages', () => {
+  for (const legalPage of legalPages) {
+    test(`keeps ${legalPage.path} scrollable at a desktop and Tauri-sized viewport`, async ({ page }) => {
+      await page.setViewportSize({ width: 1024, height: 640 })
+      await page.goto(legalPage.path)
+
+      const scrollRegion = page.locator('.legal-page')
+      await expect(scrollRegion).toBeVisible()
+      await expect.poll(async () => scrollRegion.evaluate((element) => (
+        element.scrollHeight > element.clientHeight
+      ))).toBe(true)
+
+      await scrollRegion.focus()
+      await page.keyboard.press('End')
+
+      await expect.poll(async () => scrollRegion.evaluate((element) => element.scrollTop > 0)).toBe(true)
+      await expect(page.getByRole('heading', { name: legalPage.lastHeading })).toBeInViewport()
+    })
+  }
+})

--- a/apps/web/e2e/mobile-web-smoke.spec.ts
+++ b/apps/web/e2e/mobile-web-smoke.spec.ts
@@ -11,6 +11,24 @@ import {
 } from './mock-core-api'
 
 test.describe('mocked mobile web smoke', () => {
+  test('keeps hosted legal pages touch-scrollable on a phone viewport', async ({ page }) => {
+    for (const path of ['/privacy', '/terms', '/kvkk']) {
+      await page.goto(path)
+
+      const scrollRegion = page.locator('.legal-page')
+      await expect(scrollRegion).toBeVisible()
+      await expectScrollable(scrollRegion)
+      await expect.poll(async () => scrollRegion.evaluate((element) => (
+        getComputedStyle(element).touchAction.includes('pan-y')
+      ))).toBe(true)
+
+      await scrollRegion.evaluate((element) => element.scrollTo({ top: element.scrollHeight }))
+      await expect.poll(async () => scrollRegion.evaluate((element) => (
+        element.scrollTop + element.clientHeight >= element.scrollHeight - 1
+      ))).toBe(true)
+    }
+  })
+
   test('keeps theme settings usable and persistent on a phone viewport', async ({ page }) => {
     const state = createMockCoreState({ friends: buildFriends(3) })
     await installMockCoreApi(page, state)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/release-settings-core-regressions.spec.ts e2e/social-friend-core-regressions.spec.ts e2e/server-settings-core-regressions.spec.ts e2e/invite-desktop-core-regressions.spec.ts --project=chromium",
+    "test:e2e:ui-smoke": "playwright test e2e/core-ui-smoke.spec.ts e2e/auth-core-regressions.spec.ts e2e/channel-permission-core-regressions.spec.ts e2e/legal-pages.spec.ts e2e/release-settings-core-regressions.spec.ts e2e/social-friend-core-regressions.spec.ts e2e/server-settings-core-regressions.spec.ts e2e/invite-desktop-core-regressions.spec.ts --project=chromium",
     "test:e2e:mobile-smoke": "playwright test e2e/mobile-web-smoke.spec.ts --project=mobile-chromium",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7518,10 +7518,29 @@ body {
 }
 
 .legal-page {
-  min-height: 100vh;
+  height: 100%;
+  min-height: 0;
+  max-height: 100vh;
+  overflow-x: hidden;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable;
   background: var(--bg-primary);
   color: var(--text-primary);
+}
+
+@supports (height: 100dvh) {
+  .legal-page {
+    height: 100dvh;
+    max-height: 100dvh;
+  }
+}
+
+.legal-page:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .legal-page-nav {
@@ -7574,6 +7593,33 @@ body {
 
 .legal-document a {
   color: var(--text-link);
+}
+
+@media (max-width: 700px) {
+  .legal-page {
+    scrollbar-gutter: auto;
+  }
+
+  .legal-page-nav {
+    min-height: 50px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 16px;
+  }
+
+  .legal-document {
+    width: min(100% - 28px, 820px);
+    padding: 28px 0 52px;
+  }
+
+  .legal-document h1 {
+    font-size: 26px;
+  }
+
+  .legal-document h2 {
+    margin-top: 26px;
+  }
 }
 
 .chat-loading-state--centered {

--- a/apps/web/src/pages/LegalPage.tsx
+++ b/apps/web/src/pages/LegalPage.tsx
@@ -76,7 +76,11 @@ export default function LegalPage() {
     : pathname === '/kvkk'
       ? <KvkkNotice />
       : <EnglishPrivacyNotice />
-  return <main className="legal-page">
+  return <main
+    className="legal-page"
+    tabIndex={0}
+    aria-label="Hosted service legal information"
+  >
     <div className="legal-page-nav"><Link to="/">Voxpery</Link><span>Hosted service legal information</span></div>
     <article className="legal-document">{content}</article>
   </main>


### PR DESCRIPTION
## Summary
- Restore scrolling for the hosted Privacy, Terms, and KVKK pages inside the fixed application shell.
- Add keyboard-accessible legal-page scrolling and mobile touch-scroll support.
- Add desktop/Tauri-sized and mobile UI regression coverage.

## Validation
- `npm run test:run`
- `npm run test:e2e:ui-smoke`
- `npm run test:e2e:mobile-smoke`
- `npm run lint`
- `npm run build`