### PR TITLE
Feature/social voice UI polish

### DIFF
--- a/apps/server/src/models/message.rs
+++ b/apps/server/src/models/message.rs
@@ -20,6 +20,13 @@ pub struct MessageReactionSummary {
     pub emoji: String,
     pub count: i64,
     pub reacted: bool,
+    #[serde(default)]
+    pub users: Vec<MessageReactionUser>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageReactionUser {
+    pub username: String,
 }
 
 /// Message with author info for API responses.

--- a/apps/server/src/routes/dm.rs
+++ b/apps/server/src/routes/dm.rs
@@ -12,7 +12,9 @@ use uuid::Uuid;
 use crate::{
     errors::AppError,
     middleware::auth::{require_auth, Claims},
-    models::{MessageAuthor, MessageQuery, MessageReactionSummary, MessageWithAuthor},
+    models::{
+        MessageAuthor, MessageQuery, MessageReactionSummary, MessageReactionUser, MessageWithAuthor,
+    },
     services::{
         idempotency::normalize_client_request_id,
         rate_limit::enforce_rate_limit,
@@ -150,6 +152,7 @@ struct DmMessageReactionRow {
     emoji: String,
     count: i64,
     reacted: bool,
+    usernames: Vec<String>,
 }
 
 fn normalize_reaction_emoji(raw: &str) -> Result<String, AppError> {
@@ -181,9 +184,11 @@ async fn attach_dm_message_reactions(
         r#"SELECT r.message_id,
                   r.emoji,
                   COUNT(*)::BIGINT AS count,
-                  BOOL_OR(r.user_id = $2) AS reacted
+                  BOOL_OR(r.user_id = $2) AS reacted,
+                  ARRAY_AGG(u.username ORDER BY r.created_at ASC) AS usernames
            FROM dm_message_reactions r
-           WHERE r.message_id = ANY($1)
+           INNER JOIN users u ON u.id = r.user_id
+          WHERE r.message_id = ANY($1)
            GROUP BY r.message_id, r.emoji
            ORDER BY r.message_id ASC, MIN(r.created_at) ASC"#,
     )
@@ -201,6 +206,11 @@ async fn attach_dm_message_reactions(
                 emoji: row.emoji,
                 count: row.count,
                 reacted: row.reacted,
+                users: row
+                    .usernames
+                    .into_iter()
+                    .map(|username| MessageReactionUser { username })
+                    .collect(),
             });
     }
 

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -13,7 +13,8 @@ use crate::{
     errors::AppError,
     middleware::auth::{require_auth, Claims},
     models::{
-        EditMessageRequest, MessageAuthor, MessageQuery, MessageReactionSummary, MessageWithAuthor,
+        EditMessageRequest, MessageAuthor, MessageQuery, MessageReactionSummary, MessageReactionUser,
+        MessageWithAuthor,
         SendMessageRequest,
     },
     services::{
@@ -237,6 +238,7 @@ struct MessageReactionRow {
     emoji: String,
     count: i64,
     reacted: bool,
+    usernames: Vec<String>,
 }
 
 fn normalize_reaction_emoji(raw: &str) -> Result<String, AppError> {
@@ -268,9 +270,11 @@ async fn attach_message_reactions(
         r#"SELECT mr.message_id,
                   mr.emoji,
                   COUNT(*)::BIGINT AS count,
-                  BOOL_OR(mr.user_id = $2) AS reacted
+                  BOOL_OR(mr.user_id = $2) AS reacted,
+                  ARRAY_AGG(u.username ORDER BY mr.created_at ASC) AS usernames
            FROM message_reactions mr
-           WHERE mr.message_id = ANY($1)
+           INNER JOIN users u ON u.id = mr.user_id
+          WHERE mr.message_id = ANY($1)
            GROUP BY mr.message_id, mr.emoji
            ORDER BY mr.message_id ASC, MIN(mr.created_at) ASC"#,
     )
@@ -288,6 +292,11 @@ async fn attach_message_reactions(
                 emoji: row.emoji,
                 count: row.count,
                 reacted: row.reacted,
+                users: row
+                    .usernames
+                    .into_iter()
+                    .map(|username| MessageReactionUser { username })
+                    .collect(),
             });
     }
 

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -1634,6 +1634,21 @@ async fn create_channel_list_channels_send_message_list_messages() {
     let msg: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let message_id = msg["id"].as_str().unwrap();
 
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/messages/item/{message_id}/reactions"))
+        .header("Authorization", &auth_header)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&json!({ "emoji": "👍" })).unwrap()))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, req).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "add reaction: {}",
+        String::from_utf8_lossy(&body)
+    );
+
     // List messages (with limit)
     let req = Request::builder()
         .uri(format!("/api/messages/{}?limit=10", channel_id))
@@ -1650,6 +1665,12 @@ async fn create_channel_list_channels_send_message_list_messages() {
     assert!(messages
         .iter()
         .any(|m| m["content"].as_str() == Some("Hello integration test")));
+    let listed_message = messages
+        .iter()
+        .find(|message| message["id"].as_str() == Some(message_id))
+        .expect("sent message should be listed");
+    assert_eq!(listed_message["reactions"][0]["emoji"], "👍");
+    assert_eq!(listed_message["reactions"][0]["users"][0]["username"], username);
 
     // List messages with before (pagination)
     let req = Request::builder()

--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -515,6 +515,27 @@ describe('ActiveCallBar regressions', () => {
     expect(remoteTile?.querySelector('.voice-stage-name')).toHaveClass('is-speaking')
   })
 
+  it('uses a stable scrollable grid for crowded voice stages', () => {
+    const crowdedMembers = Array.from({ length: 7 }, (_, index) => ({
+      user_id: index === 0 ? localUser.id : `peer-${index}`,
+      username: index === 0 ? localUser.username : `peer${index}`,
+      avatar_url: null,
+      role: 'member',
+      status: 'online',
+      role_color: null,
+    }))
+    useAppStore.setState({
+      members: crowdedMembers,
+      voiceStates: Object.fromEntries(crowdedMembers.map((member) => [member.user_id, voiceChannel.id])),
+    })
+
+    const { container } = renderActiveCallBar()
+    const stage = container.querySelector('.screen-share-stage')
+    expect(stage).toHaveAttribute('data-stage-density', 'crowded')
+    expect(stage).toHaveAttribute('data-stage-columns', '3')
+    expect(stage?.querySelectorAll('.voice-stage-tile')).toHaveLength(7)
+  })
+
   it('keeps five remote voices and watched screen audio stable across speaking changes', () => {
     const audioContexts = installAudioContextMock()
     const sharerMic = mediaTrack('audio', 'peer-1-mic')

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -1360,6 +1360,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     + remoteMediaPlaceholdersToRender.length
     + remoteScreenSharePlaceholders.length
   const stageColumns = getStageColumns(totalStageTiles)
+  const stageDensity = totalStageTiles > 9 ? 'dense' : totalStageTiles > 6 ? 'crowded' : 'standard'
   const roomState = state.livekit.roomState
   const roomConnected = roomState === 'connected'
   const roomReconnecting = roomState === 'reconnecting'
@@ -1465,7 +1466,12 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
       {showActiveCallBar && (
         <>
           {showVoiceStage && (
-            <div className="screen-share-stage" style={{ gridTemplateColumns: `repeat(${stageColumns}, minmax(0, 1fr))` }}>
+            <div
+              className="screen-share-stage"
+              data-stage-density={stageDensity}
+              data-stage-columns={stageColumns}
+              style={{ gridTemplateColumns: `repeat(${stageColumns}, minmax(0, 1fr))` }}
+            >
               {channelParticipants.map((p) => {
                 const isLocal = p.user_id === user?.id
                 const participantControl = voiceControls[p.user_id]

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -150,6 +150,31 @@ describe('ChannelSidebar voice media presence', () => {
         expect(getRemotePlaybackVolume(volumes, 'screen', remoteMember.user_id)).toBe(0)
     })
 
+    it('opens a direct message from a voice participant context menu', () => {
+        const onOpenDirectMessage = vi.fn()
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            members: [remoteMember],
+            voiceStates: { [remoteMember.user_id]: voiceChannel.id },
+            voiceStateServerIds: { [remoteMember.user_id]: server.id },
+        })
+
+        render(
+            <ChannelSidebar
+                channelCategories={['Voice']}
+                onOpenDirectMessage={onOpenDirectMessage}
+            />,
+        )
+
+        fireEvent.contextMenu(screen.getByText(remoteMember.username))
+        expect(screen.getByText('Member actions')).toBeInTheDocument()
+        expect(screen.getByText('Your playback')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Send direct message' }))
+        expect(onOpenDirectMessage).toHaveBeenCalledWith(remoteMember.user_id)
+    })
+
     it('offers compact, permission-aware channel creation controls', () => {
         const onOpenCreateChannel = vi.fn()
         const onOpenCreateCategory = vi.fn()

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -1,4 +1,4 @@
-import { Hash, Volume2, ChevronDown, Plus, MicOff, VolumeX, Video, Shield, Lock, Settings2, PhoneOff } from 'lucide-react'
+import { Hash, Volume2, ChevronDown, Plus, MicOff, VolumeX, Video, Shield, Lock, Settings2, PhoneOff, MessageCircle } from 'lucide-react'
 import { useEffect, useRef, useState, type DragEvent } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAuthStore } from '../stores/auth'
@@ -42,6 +42,7 @@ interface ChannelSidebarProps {
     onRenameChannel?: (channel: Channel) => void
     onDeleteChannel?: (channel: Channel) => void
     onReorderChannels?: (draggedChannelId: string, targetChannelId: string, position: 'before' | 'after') => void
+    onOpenDirectMessage?: (userId: string) => void
     loading?: boolean
 }
 
@@ -65,6 +66,7 @@ export default function ChannelSidebar({
     onRenameChannel,
     onDeleteChannel,
     onReorderChannels,
+    onOpenDirectMessage,
     loading = false,
 }: ChannelSidebarProps) {
     const channelTypeOrder = (type: Channel['channel_type']) => (type === 'text' ? 0 : 1)
@@ -575,14 +577,14 @@ export default function ChannelSidebar({
                                                                 setParticipantMenu(null)
                                                                 return
                                                             }
-                                                            const estimatedWidth = 192
+                                                            const estimatedWidth = 224
                                                             const moderationActions =
                                                                 (canMuteMembers ? 1 : 0)
                                                                 + (canDeafenMembers ? 1 : 0)
                                                                 + (canDisconnectMembers ? 1 : 0)
-                                                            const estimatedHeight = moderationActions > 0
-                                                                ? 154 + moderationActions * 46
-                                                                : 116
+                                                            const estimatedHeight = 194 + (moderationActions > 0
+                                                                ? 54 + moderationActions * 32
+                                                                : 0)
                                                             const pos = clampParticipantMenuToSidebar(e.clientX, e.clientY, estimatedWidth, estimatedHeight)
                                                             closeAllContextMenus()
                                                             setParticipantMenu({ userId: vm.user_id, username: vm.username, channelId: ch.id, x: pos.x, y: pos.y })
@@ -820,9 +822,29 @@ export default function ChannelSidebar({
                         <div className="server-context-menu-item member-volume-menu-username">
                             {participantMenu.username}
                         </div>
+                        {onOpenDirectMessage && (
+                            <>
+                                <div className="member-volume-menu-section-label member-volume-menu-section-label--personal">
+                                    <MessageCircle size={12} />
+                                    Member actions
+                                </div>
+                                <button
+                                    type="button"
+                                    className="server-context-menu-item member-volume-menu-action-with-icon"
+                                    onClick={() => {
+                                        onOpenDirectMessage(participantMenu.userId)
+                                        setParticipantMenu(null)
+                                    }}
+                                >
+                                    <MessageCircle size={14} />
+                                    Send direct message
+                                </button>
+                            </>
+                        )}
                         {!isSelf && (canMuteMembers || canDeafenMembers || canDisconnectMembers) && (
                             <>
-                                <div className="member-volume-menu-section-label">
+                                <div className="member-volume-menu-divider" />
+                                <div className="member-volume-menu-section-label member-volume-menu-section-label--moderation">
                                     <Shield size={12} />
                                     Server moderation
                                 </div>
@@ -891,9 +913,9 @@ export default function ChannelSidebar({
 
                         <div className="member-volume-menu-divider" />
                         <div className="server-context-menu-item member-volume-menu-control">
-                            <div className="member-volume-menu-section-label">
+                            <div className="member-volume-menu-section-label member-volume-menu-section-label--personal">
                                 <Volume2 size={12} />
-                                User Volume
+                                Your playback
                             </div>
                             <div className="member-volume-menu-section-hint">Only affects what you hear</div>
                             <div className="member-volume-menu-label">

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -567,6 +567,8 @@ export default function ChannelSidebar({
                                                     <div
                                                         key={vm.user_id}
                                                         className="voice-participant"
+                                                        tabIndex={0}
+                                                        aria-label={`${vm.username} in voice`}
                                                         onContextMenu={(e) => {
                                                             e.preventDefault()
                                                             if (user?.id === vm.user_id) {

--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -107,6 +107,7 @@ function mockDecodedImages() {
 describe('ChatArea regressions', () => {
   beforeEach(() => {
     vi.useRealTimers()
+    localStorage.clear()
     scrollToIndex.mockClear()
     measureVirtualElement.mockClear()
     measureVirtualizer.mockClear()
@@ -708,5 +709,74 @@ describe('ChatArea regressions', () => {
       'reaction-row-2',
       'reaction-row-3',
     ]))
+  })
+
+  it('enlarges emoji-only messages without changing regular message text', () => {
+    const { container } = renderChatArea({
+      messages: [
+        message('emoji-only', '😀', 0),
+        message('emoji-in-text', 'Hello 😀', 1),
+      ],
+    })
+
+    expect(container.querySelector('[data-message-id="emoji-only"] .message-text')).toHaveClass('message-text--emoji-only')
+    expect(container.querySelector('[data-message-id="emoji-in-text"] .message-text')).not.toHaveClass('message-text--emoji-only')
+  })
+
+  it('shows reaction authors on hover when the API provides them', () => {
+    renderChatArea({
+      messages: [{
+        ...message('reaction-authors', 'Thanks', 0),
+        reactions: [{
+          emoji: '👍',
+          count: 2,
+          reacted: false,
+          users: [{ username: 'alice' }, { username: 'bob' }],
+        }],
+      }],
+      onToggleReaction: vi.fn(),
+    })
+
+    fireEvent.pointerEnter(screen.getByRole('button', { name: /reaction from alice, bob/i }))
+    expect(screen.getByRole('tooltip')).toHaveTextContent('alice, bob')
+  })
+
+  it('opens a direct message action from another message author', () => {
+    const onOpenDirectMessage = vi.fn()
+    renderChatArea({
+      messages: [{
+        ...message('other-author', 'Hello', 0),
+        author: { user_id: 'friend-1', username: 'friend' },
+      }],
+      currentUserId: 'current-user',
+      onOpenDirectMessage,
+    })
+
+    fireEvent.contextMenu(screen.getByText('friend'))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Send direct message' }))
+    expect(onOpenDirectMessage).toHaveBeenCalledWith('friend-1', 'friend')
+  })
+
+  it('opens the message user menu from the keyboard', () => {
+    renderChatArea({
+      messages: [{
+        ...message('keyboard-author', 'Hello', 0),
+        author: { user_id: 'friend-2', username: 'keyboard friend' },
+      }],
+      currentUserId: 'current-user',
+      onOpenDirectMessage: vi.fn(),
+    })
+
+    fireEvent.keyDown(screen.getByText('keyboard friend'), { key: 'ContextMenu' })
+    expect(screen.getByRole('menuitem', { name: 'Send direct message' })).toBeVisible()
+  })
+
+  it('lets a shared GIF be saved to the same favorites store as the picker', () => {
+    renderChatArea({
+      messages: [message('shared-gif', '![gif](https://cdn.example.test/shared.gif)', 0)],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add GIF to favorites' }))
+    expect(screen.getByRole('button', { name: 'Remove GIF from favorites' })).toBeVisible()
   })
 })

--- a/apps/web/src/components/ChatArea.test.tsx
+++ b/apps/web/src/components/ChatArea.test.tsx
@@ -741,36 +741,6 @@ describe('ChatArea regressions', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent('alice, bob')
   })
 
-  it('opens a direct message action from another message author', () => {
-    const onOpenDirectMessage = vi.fn()
-    renderChatArea({
-      messages: [{
-        ...message('other-author', 'Hello', 0),
-        author: { user_id: 'friend-1', username: 'friend' },
-      }],
-      currentUserId: 'current-user',
-      onOpenDirectMessage,
-    })
-
-    fireEvent.contextMenu(screen.getByText('friend'))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Send direct message' }))
-    expect(onOpenDirectMessage).toHaveBeenCalledWith('friend-1', 'friend')
-  })
-
-  it('opens the message user menu from the keyboard', () => {
-    renderChatArea({
-      messages: [{
-        ...message('keyboard-author', 'Hello', 0),
-        author: { user_id: 'friend-2', username: 'keyboard friend' },
-      }],
-      currentUserId: 'current-user',
-      onOpenDirectMessage: vi.fn(),
-    })
-
-    fireEvent.keyDown(screen.getByText('keyboard friend'), { key: 'ContextMenu' })
-    expect(screen.getByRole('menuitem', { name: 'Send direct message' })).toBeVisible()
-  })
-
   it('lets a shared GIF be saved to the same favorites store as the picker', () => {
     renderChatArea({
       messages: [message('shared-gif', '![gif](https://cdn.example.test/shared.gif)', 0)],

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -695,7 +695,6 @@ interface ChatAreaProps {
     onPinMessage?: (messageId: string) => void
     onUnpinMessage?: (messageId: string) => void
     onToggleReaction?: (messageId: string, emoji: string, reacted: boolean) => void
-    onOpenDirectMessage?: (userId: string, username: string) => void
     canSendMessages?: boolean
     typingIndicatorLabel?: string | null
     seenMessageId?: string | null
@@ -748,7 +747,6 @@ export default function ChatArea({
     onPinMessage,
     onUnpinMessage,
     onToggleReaction,
-    onOpenDirectMessage,
     canSendMessages = true,
     typingIndicatorLabel = null,
     seenMessageId = null,
@@ -856,13 +854,6 @@ export default function ChatArea({
     const reactionPickerRef = useRef<HTMLDivElement | null>(null)
     const reactionPickerAnchorRef = useRef<HTMLButtonElement | null>(null)
     const [reactionPickerPosition, setReactionPickerPosition] = useState<{ top: number; left: number } | null>(null)
-    const [messageUserContextMenu, setMessageUserContextMenu] = useState<{
-        userId: string
-        username: string
-        x: number
-        y: number
-    } | null>(null)
-    const messageUserLongPressRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
     const [favoriteGifUrls, setFavoriteGifUrls] = useState(() => new Set(getFavoriteGifs().map((gif) => gif.url)))
 
     const pinnedMessageIds = useMemo(() => new Set(pinnedMessages.map((m) => m.id)), [pinnedMessages])
@@ -2041,86 +2032,9 @@ export default function ChatArea({
         onPickAttachments(dataTransfer.files)
     }
 
-    useEffect(() => {
-        if (!messageUserContextMenu) return
-        const close = () => setMessageUserContextMenu(null)
-        const closeOnEscape = (event: globalThis.KeyboardEvent) => {
-            if (event.key === 'Escape') close()
-        }
-        window.addEventListener('pointerdown', close)
-        window.addEventListener('keydown', closeOnEscape)
-        return () => {
-            window.removeEventListener('pointerdown', close)
-            window.removeEventListener('keydown', closeOnEscape)
-        }
-    }, [messageUserContextMenu])
-
-    useEffect(() => () => {
-        if (messageUserLongPressRef.current !== null) {
-            window.clearTimeout(messageUserLongPressRef.current)
-        }
-    }, [])
-
     const toggleGifFavorite = useCallback((url: string) => {
         const next = toggleFavoriteGif(savedGifOption(url))
         setFavoriteGifUrls(new Set(next.map((gif) => gif.url)))
-    }, [])
-
-    const showMessageUserContextMenu = useCallback((
-        author: UiMessage['author'],
-        clientX: number,
-        clientY: number,
-    ) => {
-        if (!onOpenDirectMessage || !author?.user_id || author.user_id === currentUserId) return
-        const menuWidth = 196
-        const menuHeight = 42
-        setMessageUserContextMenu({
-            userId: author.user_id,
-            username: author.username,
-            x: Math.max(8, Math.min(clientX, window.innerWidth - menuWidth - 8)),
-            y: Math.max(8, Math.min(clientY, window.innerHeight - menuHeight - 8)),
-        })
-    }, [currentUserId, onOpenDirectMessage])
-
-    const openMessageUserContextMenu = useCallback((
-        event: React.MouseEvent<HTMLElement>,
-        author: UiMessage['author'],
-    ) => {
-        event.preventDefault()
-        event.stopPropagation()
-        showMessageUserContextMenu(author, event.clientX, event.clientY)
-    }, [showMessageUserContextMenu])
-
-    const openMessageUserContextMenuFromKeyboard = useCallback((
-        event: KeyboardEvent<HTMLElement>,
-        author: UiMessage['author'],
-    ) => {
-        if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return
-        event.preventDefault()
-        const rect = event.currentTarget.getBoundingClientRect()
-        showMessageUserContextMenu(author, rect.left + rect.width / 2, rect.bottom)
-    }, [showMessageUserContextMenu])
-
-    const startMessageUserTouchMenu = useCallback((
-        event: PointerEvent<HTMLElement>,
-        author: UiMessage['author'],
-    ) => {
-        if (event.pointerType !== 'touch') return
-        if (messageUserLongPressRef.current !== null) {
-            window.clearTimeout(messageUserLongPressRef.current)
-        }
-        const { clientX, clientY } = event
-        messageUserLongPressRef.current = window.setTimeout(() => {
-            showMessageUserContextMenu(author, clientX, clientY)
-            messageUserLongPressRef.current = null
-        }, 500)
-    }, [showMessageUserContextMenu])
-
-    const cancelMessageUserTouchMenu = useCallback(() => {
-        if (messageUserLongPressRef.current !== null) {
-            window.clearTimeout(messageUserLongPressRef.current)
-            messageUserLongPressRef.current = null
-        }
     }, [])
 
     const renderMessageWithMentions = (content: string) => {
@@ -2613,10 +2527,6 @@ export default function ChatArea({
                                         <div
                                             className="message-avatar"
                                             aria-hidden={isGrouped ? 'true' : undefined}
-                                            onContextMenu={(event) => openMessageUserContextMenu(event, msg.author)}
-                                            onPointerDown={(event) => startMessageUserTouchMenu(event, msg.author)}
-                                            onPointerUp={cancelMessageUserTouchMenu}
-                                            onPointerCancel={cancelMessageUserTouchMenu}
                                         >
                                             {!isGrouped && (
                                                 getAuthorAvatarUrl(msg.author || {}) ? (
@@ -2633,13 +2543,6 @@ export default function ChatArea({
                                                     <span
                                                         className="message-author"
                                                         style={msg.author.role_color ? { color: msg.author.role_color } : undefined}
-                                                        tabIndex={0}
-                                                        role="button"
-                                                        onContextMenu={(event) => openMessageUserContextMenu(event, msg.author)}
-                                                        onKeyDown={(event) => openMessageUserContextMenuFromKeyboard(event, msg.author)}
-                                                        onPointerDown={(event) => startMessageUserTouchMenu(event, msg.author)}
-                                                        onPointerUp={cancelMessageUserTouchMenu}
-                                                        onPointerCancel={cancelMessageUserTouchMenu}
                                                     >
                                                         {msg.author.username}
                                                     </span>
@@ -2959,27 +2862,6 @@ export default function ChatArea({
                     />
                 </div>,
                 document.body
-            )}
-            {messageUserContextMenu && onOpenDirectMessage && createPortal(
-                <div
-                    className="chat-user-context-menu"
-                    role="menu"
-                    aria-label={`Actions for ${messageUserContextMenu.username}`}
-                    style={{ left: messageUserContextMenu.x, top: messageUserContextMenu.y }}
-                    onPointerDown={(event) => event.stopPropagation()}
-                >
-                    <button
-                        type="button"
-                        role="menuitem"
-                        onClick={() => {
-                            onOpenDirectMessage(messageUserContextMenu.userId, messageUserContextMenu.username)
-                            setMessageUserContextMenu(null)
-                        }}
-                    >
-                        Send direct message
-                    </button>
-                </div>,
-                document.body,
             )}
             {clickedLink && createPortal(
                 <div className="modal-overlay" onClick={() => setClickedLink(null)}>

--- a/apps/web/src/components/ChatArea.tsx
+++ b/apps/web/src/components/ChatArea.tsx
@@ -1,8 +1,9 @@
 import { useRef, useEffect, useMemo, useState, useCallback, useLayoutEffect, type FormEvent, type KeyboardEvent, type PointerEvent, type ReactNode, type TouchEvent, type WheelEvent } from 'react'
 import { createPortal } from 'react-dom'
-import { Hash, Volume2, Send, Paperclip, X, Save, Search, ChevronRight, Smile, Pin, PinOff, Users, ArrowDown, Sticker } from 'lucide-react'
+import { Hash, Volume2, Send, Paperclip, X, Save, Search, ChevronRight, Smile, Pin, PinOff, Users, ArrowDown, Sticker, Star } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import type { Attachment } from '../types'
+import type { Attachment, MessageReaction } from '../types'
+import type { GifOption } from '../emoji'
 import { resolveAttachmentUrl, resolveAvatarUrl, type MessageWithAuthor, type Channel } from '../api'
 import type { DraftAttachmentItem } from '../draftAttachments'
 import { openExternalUrl } from '../openExternalUrl'
@@ -11,6 +12,7 @@ import EmojiPicker from './EmojiPicker'
 import InlineMediaImage from './InlineMediaImage'
 import MessageInlineActions from './MessageInlineActions'
 import { useAuthStore } from '../stores/auth'
+import { getFavoriteGifs, toggleFavoriteGif } from '../expressionPreferences'
 
 type UiMessage = MessageWithAuthor & {
     clientId?: string
@@ -92,6 +94,98 @@ function extractEmbeddedMediaMarkdown(content: string): { text: string; gifUrls:
         })
         .trim()
     return { text, gifUrls, stickerUrls }
+}
+
+const EMOJI_ONLY_CONTENT = /^(?:\p{Extended_Pictographic}|\p{Regional_Indicator}|\uFE0F|\u200D|\u20E3|\s)+$/u
+const EMOJI_CODE_POINT = /\p{Extended_Pictographic}|\p{Regional_Indicator}/u
+
+function getEmojiOnlyCount(content: string): number {
+    const parsed = parseReplyContent(content)
+    if (parsed) return 0
+    const { text, gifUrls, stickerUrls } = extractEmbeddedMediaMarkdown(content)
+    const visibleText = text.trim()
+    if (!visibleText || gifUrls.length > 0 || stickerUrls.length > 0 || !EMOJI_ONLY_CONTENT.test(visibleText)) return 0
+    const count = Array.from(visibleText).filter((character) => EMOJI_CODE_POINT.test(character)).length
+    return count > 0 && count <= 4 ? count : 0
+}
+
+function savedGifOption(url: string): GifOption {
+    return {
+        id: url,
+        label: 'Saved GIF',
+        url,
+        previewUrl: url,
+        keywords: [],
+    }
+}
+
+function ReactionButton({
+    reaction,
+    disabled,
+    onToggle,
+}: {
+    reaction: MessageReaction
+    disabled: boolean
+    onToggle: () => void
+}) {
+    const [isDetailsOpen, setIsDetailsOpen] = useState(false)
+    const triggerRef = useRef<HTMLButtonElement | null>(null)
+    const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
+    const usernames = reaction.users?.map((user) => user.username).filter(Boolean) ?? []
+    const reactionLabel = usernames.length > 0
+        ? `${reaction.emoji} reaction from ${usernames.join(', ')}`
+        : `${reaction.emoji} reaction, ${reaction.count} total`
+
+    const syncPosition = useCallback(() => {
+        const rect = triggerRef.current?.getBoundingClientRect()
+        if (!rect) return
+        setPosition({
+            left: Math.max(8, Math.min(window.innerWidth - 8, rect.left + rect.width / 2)),
+            top: Math.max(8, rect.top - 8),
+        })
+    }, [])
+
+    useLayoutEffect(() => {
+        if (!isDetailsOpen || usernames.length === 0) return
+        syncPosition()
+        window.addEventListener('resize', syncPosition)
+        window.addEventListener('scroll', syncPosition, true)
+        return () => {
+            window.removeEventListener('resize', syncPosition)
+            window.removeEventListener('scroll', syncPosition, true)
+        }
+    }, [isDetailsOpen, syncPosition, usernames.length])
+
+    return (
+        <>
+            <button
+                ref={triggerRef}
+                type="button"
+                className={`message-reaction-btn ${reaction.reacted ? 'is-reacted' : ''}`}
+                disabled={disabled}
+                aria-label={reactionLabel}
+                onPointerEnter={() => setIsDetailsOpen(true)}
+                onPointerLeave={() => setIsDetailsOpen(false)}
+                onFocus={() => setIsDetailsOpen(true)}
+                onBlur={() => setIsDetailsOpen(false)}
+                onClick={onToggle}
+            >
+                <span>{reaction.emoji}</span>
+                <span>{reaction.count}</span>
+            </button>
+            {isDetailsOpen && usernames.length > 0 && position && typeof document !== 'undefined' && createPortal(
+                <div
+                    className="message-reaction-details"
+                    role="tooltip"
+                    style={{ left: position.left, top: position.top }}
+                >
+                    <strong>{reaction.emoji}</strong>
+                    <span>{usernames.join(', ')}</span>
+                </div>,
+                document.body,
+            )}
+        </>
+    )
 }
 
 function AttachmentImagePreviewModal({
@@ -601,6 +695,7 @@ interface ChatAreaProps {
     onPinMessage?: (messageId: string) => void
     onUnpinMessage?: (messageId: string) => void
     onToggleReaction?: (messageId: string, emoji: string, reacted: boolean) => void
+    onOpenDirectMessage?: (userId: string, username: string) => void
     canSendMessages?: boolean
     typingIndicatorLabel?: string | null
     seenMessageId?: string | null
@@ -653,6 +748,7 @@ export default function ChatArea({
     onPinMessage,
     onUnpinMessage,
     onToggleReaction,
+    onOpenDirectMessage,
     canSendMessages = true,
     typingIndicatorLabel = null,
     seenMessageId = null,
@@ -760,6 +856,14 @@ export default function ChatArea({
     const reactionPickerRef = useRef<HTMLDivElement | null>(null)
     const reactionPickerAnchorRef = useRef<HTMLButtonElement | null>(null)
     const [reactionPickerPosition, setReactionPickerPosition] = useState<{ top: number; left: number } | null>(null)
+    const [messageUserContextMenu, setMessageUserContextMenu] = useState<{
+        userId: string
+        username: string
+        x: number
+        y: number
+    } | null>(null)
+    const messageUserLongPressRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
+    const [favoriteGifUrls, setFavoriteGifUrls] = useState(() => new Set(getFavoriteGifs().map((gif) => gif.url)))
 
     const pinnedMessageIds = useMemo(() => new Set(pinnedMessages.map((m) => m.id)), [pinnedMessages])
     const mentionCandidates = useMemo(() => {
@@ -1937,6 +2041,88 @@ export default function ChatArea({
         onPickAttachments(dataTransfer.files)
     }
 
+    useEffect(() => {
+        if (!messageUserContextMenu) return
+        const close = () => setMessageUserContextMenu(null)
+        const closeOnEscape = (event: globalThis.KeyboardEvent) => {
+            if (event.key === 'Escape') close()
+        }
+        window.addEventListener('pointerdown', close)
+        window.addEventListener('keydown', closeOnEscape)
+        return () => {
+            window.removeEventListener('pointerdown', close)
+            window.removeEventListener('keydown', closeOnEscape)
+        }
+    }, [messageUserContextMenu])
+
+    useEffect(() => () => {
+        if (messageUserLongPressRef.current !== null) {
+            window.clearTimeout(messageUserLongPressRef.current)
+        }
+    }, [])
+
+    const toggleGifFavorite = useCallback((url: string) => {
+        const next = toggleFavoriteGif(savedGifOption(url))
+        setFavoriteGifUrls(new Set(next.map((gif) => gif.url)))
+    }, [])
+
+    const showMessageUserContextMenu = useCallback((
+        author: UiMessage['author'],
+        clientX: number,
+        clientY: number,
+    ) => {
+        if (!onOpenDirectMessage || !author?.user_id || author.user_id === currentUserId) return
+        const menuWidth = 196
+        const menuHeight = 42
+        setMessageUserContextMenu({
+            userId: author.user_id,
+            username: author.username,
+            x: Math.max(8, Math.min(clientX, window.innerWidth - menuWidth - 8)),
+            y: Math.max(8, Math.min(clientY, window.innerHeight - menuHeight - 8)),
+        })
+    }, [currentUserId, onOpenDirectMessage])
+
+    const openMessageUserContextMenu = useCallback((
+        event: React.MouseEvent<HTMLElement>,
+        author: UiMessage['author'],
+    ) => {
+        event.preventDefault()
+        event.stopPropagation()
+        showMessageUserContextMenu(author, event.clientX, event.clientY)
+    }, [showMessageUserContextMenu])
+
+    const openMessageUserContextMenuFromKeyboard = useCallback((
+        event: KeyboardEvent<HTMLElement>,
+        author: UiMessage['author'],
+    ) => {
+        if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return
+        event.preventDefault()
+        const rect = event.currentTarget.getBoundingClientRect()
+        showMessageUserContextMenu(author, rect.left + rect.width / 2, rect.bottom)
+    }, [showMessageUserContextMenu])
+
+    const startMessageUserTouchMenu = useCallback((
+        event: PointerEvent<HTMLElement>,
+        author: UiMessage['author'],
+    ) => {
+        if (event.pointerType !== 'touch') return
+        if (messageUserLongPressRef.current !== null) {
+            window.clearTimeout(messageUserLongPressRef.current)
+        }
+        const { clientX, clientY } = event
+        messageUserLongPressRef.current = window.setTimeout(() => {
+            showMessageUserContextMenu(author, clientX, clientY)
+            messageUserLongPressRef.current = null
+        }, 500)
+    }, [showMessageUserContextMenu])
+
+    const cancelMessageUserTouchMenu = useCallback(() => {
+        if (messageUserLongPressRef.current !== null) {
+            window.clearTimeout(messageUserLongPressRef.current)
+            messageUserLongPressRef.current = null
+        }
+    }, [])
+
     const renderMessageWithMentions = (content: string) => {
         const { text, gifUrls, stickerUrls } = extractEmbeddedMediaMarkdown(content)
         // Split by mentions OR direct http/https URLs
@@ -2006,12 +2192,21 @@ export default function ChatArea({
                                 <div
                                     key={`${url}-${index}`}
                                     className="chat-inline-gif-link"
-                                    onClickCapture={(event) => {
-                                        event.preventDefault()
-                                        event.stopPropagation()
-                                    }}
                                 >
                                     <InlineMediaImage src={url} alt="GIF preview" className="chat-inline-gif" />
+                                    <button
+                                        type="button"
+                                        className={`chat-inline-gif-favorite${favoriteGifUrls.has(url) ? ' is-favorited' : ''}`}
+                                        title={favoriteGifUrls.has(url) ? 'Remove GIF from favorites' : 'Add GIF to favorites'}
+                                        aria-label={favoriteGifUrls.has(url) ? 'Remove GIF from favorites' : 'Add GIF to favorites'}
+                                        onClick={(event) => {
+                                            event.preventDefault()
+                                            event.stopPropagation()
+                                            toggleGifFavorite(url)
+                                        }}
+                                    >
+                                        <Star size={14} fill={favoriteGifUrls.has(url) ? 'currentColor' : 'none'} />
+                                    </button>
                                 </div>
                             )
                         })}
@@ -2034,7 +2229,12 @@ export default function ChatArea({
                 </div>
             )
         }
-        return <div className="message-text">{renderMessageWithMentions(content)}</div>
+        const emojiOnlyCount = getEmojiOnlyCount(content)
+        return (
+            <div className={`message-text${emojiOnlyCount > 0 ? ` message-text--emoji-only message-text--emoji-count-${emojiOnlyCount}` : ''}`}>
+                {renderMessageWithMentions(content)}
+            </div>
+        )
     }
 
     if (!activeChannel) {
@@ -2410,7 +2610,14 @@ export default function ChatArea({
                                         </div>
                                     )}
                                     <div className={`message${isGrouped ? ' message-compact' : ''}${highlightedMessageId === msg.id ? ' message-highlight-jump' : ''}`}>
-                                        <div className="message-avatar" aria-hidden={isGrouped ? 'true' : undefined}>
+                                        <div
+                                            className="message-avatar"
+                                            aria-hidden={isGrouped ? 'true' : undefined}
+                                            onContextMenu={(event) => openMessageUserContextMenu(event, msg.author)}
+                                            onPointerDown={(event) => startMessageUserTouchMenu(event, msg.author)}
+                                            onPointerUp={cancelMessageUserTouchMenu}
+                                            onPointerCancel={cancelMessageUserTouchMenu}
+                                        >
                                             {!isGrouped && (
                                                 getAuthorAvatarUrl(msg.author || {}) ? (
                                                     <img src={getAuthorAvatarUrl(msg.author || {}) ?? ''} alt="" />
@@ -2426,6 +2633,13 @@ export default function ChatArea({
                                                     <span
                                                         className="message-author"
                                                         style={msg.author.role_color ? { color: msg.author.role_color } : undefined}
+                                                        tabIndex={0}
+                                                        role="button"
+                                                        onContextMenu={(event) => openMessageUserContextMenu(event, msg.author)}
+                                                        onKeyDown={(event) => openMessageUserContextMenuFromKeyboard(event, msg.author)}
+                                                        onPointerDown={(event) => startMessageUserTouchMenu(event, msg.author)}
+                                                        onPointerUp={cancelMessageUserTouchMenu}
+                                                        onPointerCancel={cancelMessageUserTouchMenu}
                                                     >
                                                         {msg.author.username}
                                                     </span>
@@ -2493,16 +2707,12 @@ export default function ChatArea({
                                             {Array.isArray(msg.reactions) && msg.reactions.length > 0 && (
                                                 <div className="message-reactions">
                                                     {msg.reactions.map((reaction) => (
-                                                        <button
+                                                        <ReactionButton
                                                             key={`${msg.id}-${reaction.emoji}`}
-                                                            type="button"
-                                                            className={`message-reaction-btn ${reaction.reacted ? 'is-reacted' : ''}`}
+                                                            reaction={reaction}
                                                             disabled={!onToggleReaction}
-                                                            onClick={() => toggleReactionPreservingBottomAnchor(msg.id, reaction.emoji, !!reaction.reacted)}
-                                                        >
-                                                            <span>{reaction.emoji}</span>
-                                                            <span>{reaction.count}</span>
-                                                        </button>
+                                                            onToggle={() => toggleReactionPreservingBottomAnchor(msg.id, reaction.emoji, !!reaction.reacted)}
+                                                        />
                                                     ))}
                                                 </div>
                                             )}
@@ -2749,6 +2959,27 @@ export default function ChatArea({
                     />
                 </div>,
                 document.body
+            )}
+            {messageUserContextMenu && onOpenDirectMessage && createPortal(
+                <div
+                    className="chat-user-context-menu"
+                    role="menu"
+                    aria-label={`Actions for ${messageUserContextMenu.username}`}
+                    style={{ left: messageUserContextMenu.x, top: messageUserContextMenu.y }}
+                    onPointerDown={(event) => event.stopPropagation()}
+                >
+                    <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => {
+                            onOpenDirectMessage(messageUserContextMenu.userId, messageUserContextMenu.username)
+                            setMessageUserContextMenu(null)
+                        }}
+                    >
+                        Send direct message
+                    </button>
+                </div>,
+                document.body,
             )}
             {clickedLink && createPortal(
                 <div className="modal-overlay" onClick={() => setClickedLink(null)}>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5260,16 +5260,6 @@ body {
   line-height: 20px;
 }
 
-.message-author[role="button"] {
-  cursor: context-menu;
-}
-
-.message-author[role="button"]:focus-visible {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
-  border-radius: 3px;
-}
-
 .message-author.owner {
   color: var(--accent-primary);
 }
@@ -6359,8 +6349,7 @@ body {
 }
 
 .chat-inline-gif-link:hover .chat-inline-gif-favorite,
-.chat-inline-gif-link:focus-within .chat-inline-gif-favorite,
-.chat-inline-gif-favorite.is-favorited {
+.chat-inline-gif-favorite:focus-visible {
   opacity: 1;
   transform: translateY(0);
 }
@@ -6374,36 +6363,6 @@ body {
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-.chat-user-context-menu {
-  position: fixed;
-  z-index: 10080;
-  min-width: 196px;
-  padding: 4px;
-  border: 1px solid rgba(var(--ui-contrast-rgb), 0.16);
-  border-radius: 8px;
-  background: var(--bg-elevated);
-  box-shadow: var(--shadow-medium);
-}
-
-.chat-user-context-menu button {
-  width: 100%;
-  min-height: 34px;
-  border: 0;
-  border-radius: 5px;
-  background: transparent;
-  color: var(--text-primary);
-  cursor: pointer;
-  font: inherit;
-  font-size: 13px;
-  text-align: left;
-  padding: 0 9px;
-}
-
-.chat-user-context-menu button:hover,
-.chat-user-context-menu button:focus-visible {
-  background: rgba(var(--ui-contrast-rgb), 0.08);
 }
 
 .chat-inline-gif {
@@ -6636,11 +6595,13 @@ body {
 }
 
 .member-volume-menu {
-  min-width: 176px;
+  width: min(224px, calc(100vw - 16px));
+  min-width: 0;
   max-width: calc(100vw - 16px);
   max-height: calc(100vh - 16px);
   padding: 3px 0;
   overflow: auto;
+  box-sizing: border-box;
 }
 
 .member-volume-menu .server-context-menu-item {
@@ -6661,6 +6622,14 @@ body {
   cursor: default;
 }
 
+.member-volume-menu-section-label--personal {
+  color: var(--accent-primary);
+}
+
+.member-volume-menu-section-label--moderation {
+  color: var(--text-warning);
+}
+
 .member-volume-menu-section-hint {
   padding: 0 10px 6px;
   color: var(--text-muted);
@@ -6679,11 +6648,14 @@ body {
   gap: 6px;
 }
 
-.member-volume-menu-username {
+.member-volume-menu .member-volume-menu-username {
+  padding: 7px 10px 5px;
+  margin: 0;
   cursor: default;
-  opacity: 0.92;
+  opacity: 1;
   font-weight: 700;
-  color: var(--text-primary);
+  color: var(--text-secondary);
+  font-size: 12px;
 }
 
 .member-volume-menu-control {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1792,13 +1792,26 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  min-height: 32px;
+  padding: 4px 6px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 13px;
   color: var(--text-secondary);
+  outline: none;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.voice-participant:hover,
+.voice-participant:focus-visible {
+  background: rgba(var(--ui-contrast-rgb), 0.07);
+  border-color: rgba(var(--ui-contrast-rgb), 0.11);
+  color: var(--text-primary);
 }
 
 .voice-participant-avatar {
-  width: 18px;
-  height: 18px;
+  width: 22px;
+  height: 22px;
   border-radius: 999px;
   background: var(--accent-gradient);
   display: flex;
@@ -1826,6 +1839,7 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 600;
   transition: color var(--transition-fast), text-shadow var(--transition-fast);
 }
 
@@ -5246,6 +5260,16 @@ body {
   line-height: 20px;
 }
 
+.message-author[role="button"] {
+  cursor: context-menu;
+}
+
+.message-author[role="button"]:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
 .message-author.owner {
   color: var(--accent-primary);
 }
@@ -5475,6 +5499,31 @@ body {
   color: var(--text-primary);
 }
 
+.message-reaction-details {
+  position: fixed;
+  z-index: 10080;
+  transform: translate(-50%, -100%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(280px, calc(100vw - 16px));
+  padding: 6px 8px;
+  border: 1px solid rgba(var(--ui-contrast-rgb), 0.16);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-medium);
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.25;
+  pointer-events: none;
+}
+
+.message-reaction-details span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .message-menu-btn {
   padding: 4px;
   border: none;
@@ -5539,6 +5588,23 @@ body {
   line-height: 20px;
   word-break: break-word;
   white-space: pre-wrap;
+}
+
+.message-text--emoji-only {
+  color: var(--text-primary);
+  font-size: 48px;
+  line-height: 1.2;
+  letter-spacing: 0;
+  word-break: normal;
+}
+
+.message-text--emoji-count-2 {
+  font-size: 42px;
+}
+
+.message-text--emoji-count-3,
+.message-text--emoji-count-4 {
+  font-size: 34px;
 }
 
 .message-send-state {
@@ -6270,6 +6336,74 @@ body {
   box-shadow: none;
   max-width: min(360px, 100%);
   cursor: default;
+  position: relative;
+}
+
+.chat-inline-gif-favorite {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  background: rgba(8, 12, 24, 0.72);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(-2px);
+  cursor: pointer;
+  transition: opacity var(--transition-fast), transform var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+}
+
+.chat-inline-gif-link:hover .chat-inline-gif-favorite,
+.chat-inline-gif-link:focus-within .chat-inline-gif-favorite,
+.chat-inline-gif-favorite.is-favorited {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.chat-inline-gif-favorite.is-favorited {
+  color: #f7c948;
+}
+
+@media (hover: none) {
+  .chat-inline-gif-favorite {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.chat-user-context-menu {
+  position: fixed;
+  z-index: 10080;
+  min-width: 196px;
+  padding: 4px;
+  border: 1px solid rgba(var(--ui-contrast-rgb), 0.16);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-medium);
+}
+
+.chat-user-context-menu button {
+  width: 100%;
+  min-height: 34px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  padding: 0 9px;
+}
+
+.chat-user-context-menu button:hover,
+.chat-user-context-menu button:focus-visible {
+  background: rgba(var(--ui-contrast-rgb), 0.08);
 }
 
 .chat-inline-gif {
@@ -9581,12 +9715,24 @@ a.community-open-btn:hover {
   z-index: 70;
   display: grid;
   grid-template-columns: repeat(1, minmax(0, 1fr));
-  grid-auto-rows: minmax(180px, 1fr);
+  --voice-stage-tile-min: 180px;
+  grid-auto-rows: minmax(var(--voice-stage-tile-min), 1fr);
   gap: 12px;
   align-content: stretch;
   align-items: stretch;
   justify-items: stretch;
-  pointer-events: none;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  pointer-events: auto;
+}
+
+.screen-share-stage[data-stage-density="crowded"] {
+  --voice-stage-tile-min: 156px;
+}
+
+.screen-share-stage[data-stage-density="dense"] {
+  --voice-stage-tile-min: 132px;
 }
 
 .screen-share-preview {
@@ -15092,10 +15238,11 @@ textarea {
     top: 120px;
     bottom: calc(var(--mobile-bottom-dock-height) + 12px + env(safe-area-inset-bottom, 0px));
     gap: 8px;
-    grid-auto-rows: minmax(0, 1fr);
+    --voice-stage-tile-min: 128px;
+    grid-auto-rows: minmax(var(--voice-stage-tile-min), 1fr);
     justify-items: stretch;
     align-content: stretch;
-    overflow: hidden;
+    overflow-y: auto;
     overscroll-behavior: contain;
     padding: 0;
   }
@@ -16054,9 +16201,10 @@ textarea {
     top: 112px;
     bottom: calc(var(--mobile-bottom-dock-height) + 12px + env(safe-area-inset-bottom, 0px));
     gap: 6px;
-    grid-auto-rows: minmax(0, 1fr);
+    --voice-stage-tile-min: 112px;
+    grid-auto-rows: minmax(var(--voice-stage-tile-min), 1fr);
     align-content: stretch;
-    overflow: hidden;
+    overflow-y: auto;
   }
 
   .voice-stage-tile {

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { Profiler, useEffect, useState, useRef, useCallback, useMemo, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router'
 import { useAuthStore } from '../stores/auth'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores/app'
@@ -46,6 +47,7 @@ import {
 import { shouldShowPushNotification, showPushNotification } from '../pushNotifications'
 import { createReplyContentSnippet } from '../replyPreview'
 import { createSecureId } from '../secureId'
+import { ROUTES } from '../routes'
 
 type UiMessage = MessageWithAuthor & {
     clientId?: string
@@ -296,6 +298,7 @@ function messageMentionsUser(content: string | undefined, username: string | und
 export default function AppLayout({ skipServerSidebar = false, isViewActive }: AppLayoutProps) {
     const MAX_IMAGE_BYTES = 2 * 1024 * 1024
     const { token, user } = useAuthStore()
+    const navigate = useNavigate()
     const {
         servers, serversLoading, activeServerId, activeChannelId, channels, members,
         setServers, setServersLoading, setActiveServer, setActiveChannel, setChannels, setMembers,
@@ -3052,6 +3055,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 onPinMessage={canManagePins ? handlePinChannelMessage : undefined}
                 onUnpinMessage={canManagePins ? handleUnpinChannelMessage : undefined}
                 onToggleReaction={canSendMessages ? handleToggleChannelReaction : undefined}
+                onOpenDirectMessage={(userId) => navigate(ROUTES.dm, { state: { openDmUserId: userId } })}
                 canSendMessages={canSendMessages}
                 showMemberSheetButton={isMobileViewport && !!activeServerId}
                 onOpenMemberSheet={() => setShowMobileMemberSheet(true)}

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -2999,6 +2999,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 onRenameChannel={openRenameChannelModal}
                 onDeleteChannel={(channel) => setDeleteChannelConfirm(channel)}
                 onReorderChannels={handleReorderChannels}
+                onOpenDirectMessage={(userId) => navigate(ROUTES.dm, { state: { openDmUserId: userId } })}
             />
             {mobileSidebarPanel === 'channels' && (
                 <button
@@ -3055,7 +3056,6 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 onPinMessage={canManagePins ? handlePinChannelMessage : undefined}
                 onUnpinMessage={canManagePins ? handleUnpinChannelMessage : undefined}
                 onToggleReaction={canSendMessages ? handleToggleChannelReaction : undefined}
-                onOpenDirectMessage={(userId) => navigate(ROUTES.dm, { state: { openDmUserId: userId } })}
                 canSendMessages={canSendMessages}
                 showMemberSheetButton={isMobileViewport && !!activeServerId}
                 onOpenMemberSheet={() => setShowMobileMemberSheet(true)}

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -159,6 +159,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const location = useLocation()
   const routeDmNotificationAnchor = readDmNotificationAnchor(location.state)
   const isUuid = (s: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(s)
+  const pushToast = useToastStore((s) => s.pushToast)
 
   const [view, setView] = useState<SocialView>('friends')
   const isDmConversationVisible = isMessagesView && location.pathname === ROUTES.dm && view === 'dm'
@@ -180,6 +181,31 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
   const dmChannels = storeDmChannels
   const showSocialBootstrapLoading = socialBootstrapLoading && !socialDataReady
 
+  const openDirectMessage = useCallback(async (peerId: string) => {
+    if (!user || peerId === user.id || openingDmPeerId) return
+    setOpeningDmPeerId(peerId)
+    try {
+      const channel = await dmApi.getOrCreateChannel(peerId, token)
+      const nextChannels = upsertDmChannel(useAppStore.getState().dmChannels, channel)
+      setStoreDmChannels(nextChannels)
+      setDmChannelIds(nextChannels.map((dmChannel) => dmChannel.id))
+      setActiveDmChannelId(channel.id)
+      clearDmUnread(channel.id)
+      setView('dm')
+      setPersistedSocialView('dm')
+      navigate(ROUTES.dm, { replace: true, state: {} })
+    } catch (err) {
+      pushToast({
+        level: 'error',
+        title: 'DM failed',
+        message: err instanceof Error ? err.message : 'Could not open direct message.',
+      })
+      navigate(ROUTES.home, { replace: true, state: {} })
+    } finally {
+      setOpeningDmPeerId(null)
+    }
+  }, [clearDmUnread, navigate, openingDmPeerId, pushToast, setActiveDmChannelId, setDmChannelIds, setStoreDmChannels, token, user])
+
   // Social paths (/social and /social/dm): restore last social tab and optional deep-linked DM.
   useEffect(() => {
     const isSocialRoute = location.pathname === ROUTES.home || location.pathname === ROUTES.dm
@@ -198,7 +224,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       return
     }
     const openDmUserId = (location.state as { openDmUserId?: string } | null)?.openDmUserId
-    if (openDmUserId && dmChannels.length > 0) {
+    if (openDmUserId) {
       const channel = isUuid(openDmUserId)
         ? dmChannels.find((c) => c.peer_id === openDmUserId)
         : dmChannels.find((c) => c.peer_username === decodeURIComponent(openDmUserId))
@@ -208,6 +234,10 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
         setPersistedSocialView('dm')
         clearDmUnread(channel.id)
         navigate(ROUTES.dm, { replace: true, state: {} })
+      } else if (isUuid(openDmUserId)) {
+        void openDirectMessage(openDmUserId)
+      } else {
+        navigate(ROUTES.home, { replace: true, state: {} })
       }
       return
     }
@@ -223,7 +253,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
       navigate(ROUTES.home, { replace: true })
     }
     setView('friends')
-  }, [location.pathname, location.state, routeDmNotificationAnchor, activeDmChannelId, dmChannels, setActiveDmChannelId, clearDmUnread, navigate])
+  }, [location.pathname, location.state, routeDmNotificationAnchor, activeDmChannelId, dmChannels, setActiveDmChannelId, clearDmUnread, navigate, openDirectMessage])
 
   const voxperyServer = useMemo(
     () => storeServers.find((s) => s.invite_code === 'voxpery' || s.name === 'Voxpery') ?? null,
@@ -257,7 +287,6 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     setDmInput(value)
     saveMessageDraft(userId, 'dm', activeDmChannelId, value)
   }, [activeDmChannelId, userId])
-  const pushToast = useToastStore((s) => s.pushToast)
   useEffect(() => { activeDmChannelIdRef.current = activeDmChannelId }, [activeDmChannelId])
   useEffect(() => { isDmConversationVisibleRef.current = isDmConversationVisible }, [isDmConversationVisible])
   useEffect(() => {
@@ -642,40 +671,7 @@ export default function HomePage({ isMessagesView = true }: { isMessagesView?: b
     return () => unsub()
   }, [isMessagesView, refreshFriendRequests, subscribe, userId])
 
-  const openMessageForFriend = useCallback(async (friendId: string) => {
-    if (!user || openingDmPeerId) return
-    setOpeningDmPeerId(friendId)
-    try {
-      const channel = await dmApi.getOrCreateChannel(friendId, token)
-      const nextChannels = upsertDmChannel(useAppStore.getState().dmChannels, channel)
-
-      setStoreDmChannels(nextChannels)
-      setDmChannelIds(nextChannels.map((dmChannel) => dmChannel.id))
-      setActiveDmChannelId(channel.id)
-      clearDmUnread(channel.id)
-      setView('dm')
-      setPersistedSocialView('dm')
-      navigate(ROUTES.dm)
-    } catch (err) {
-      pushToast({
-        level: 'error',
-        title: 'DM failed',
-        message: err instanceof Error ? err.message : 'Could not open direct message.',
-      })
-    } finally {
-      setOpeningDmPeerId(null)
-    }
-  }, [
-    clearDmUnread,
-    navigate,
-    openingDmPeerId,
-    pushToast,
-    setActiveDmChannelId,
-    setDmChannelIds,
-    setStoreDmChannels,
-    token,
-    user,
-  ])
+  const openMessageForFriend = openDirectMessage
 
   const sendFriendRequest = async () => {
     if (!user || !addFriendUsername.trim()) return

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -70,6 +70,9 @@ export interface MessageReaction {
     emoji: string;
     count: number;
     reacted: boolean;
+    users?: Array<{
+        username: string;
+    }>;
 }
 
 export interface SignalingMessage {


### PR DESCRIPTION
## Summary
- improve voice-stage layout for crowded participant, camera, and screen-share states
- add voice participant context actions with direct messaging and clearer moderation/playback grouping
- enlarge emoji-only messages and show reaction authors on hover
- allow GIF favorites directly from sent GIFs
- improve voice participant row hierarchy, hover, and keyboard focus states

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `PLAYWRIGHT_PORT=5174 npm run test:e2e:ui-smoke`