### PR TITLE
feat: release version 0.2.13 with in-app theater view for screen shar…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16.15-alpine3.24
         env:
           POSTGRES_USER: voxpery_test
           POSTGRES_PASSWORD: postgres
@@ -82,7 +82,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       redis:
-        image: redis:7-alpine
+        image: redis:7.4.11-alpine
         ports:
           - 6379:6379
         options: >-

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
@@ -5389,7 +5389,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-desktop"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "image",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-desktop"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 description = "Voxpery Desktop - Tauri-based desktop app"
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Voxpery",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "identifier": "com.voxpery",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -3170,7 +3170,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxpery-server"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "argon2",
  "axum",

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxpery-server"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 description = "Voxpery - Privacy-first communication server"
 license = "AGPL-3.0-only"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "AGPL-3.0",
       "dependencies": {
         "@marsidev/react-turnstile": "^1.6.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.2.12",
+  "version": "0.2.13",
   "license": "AGPL-3.0",
   "type": "module",
   "engines": {

--- a/apps/web/scripts/dev-e2e.mjs
+++ b/apps/web/scripts/dev-e2e.mjs
@@ -1,8 +1,13 @@
-process.env.VITE_APP_VERSION ||= '0.2.0-test'
+const appVersion = process.env.VITE_APP_VERSION || '0.2.0-test'
 const port = Number.parseInt(process.env.PLAYWRIGHT_PORT ?? '5173', 10)
 
 const { createServer } = await import('vite')
-const server = await createServer({ server: { host: '127.0.0.1', port, strictPort: true } })
+const server = await createServer({
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
+  },
+  server: { host: '127.0.0.1', port, strictPort: true },
+})
 
 await server.listen()
 server.printUrls()

--- a/apps/web/src/components/ActiveCallBar.test.tsx
+++ b/apps/web/src/components/ActiveCallBar.test.tsx
@@ -283,6 +283,27 @@ describe('ActiveCallBar regressions', () => {
     expect(voice.leaveVoice).not.toHaveBeenCalled()
   })
 
+  it('focuses a watched screen share in the in-app theater view without changing its subscription', () => {
+    const screenTrack = mediaTrack('video', 'screen-track')
+    const remoteStream = new MediaStream([screenTrack])
+    const { container, voice } = renderActiveCallBar({
+      remoteStreams: new Map([['peer-1', remoteStream]]),
+      remoteScreenTrackIds: new Set(['screen-track']),
+      watchedRemoteScreenPeerIds: new Set(['peer-1']),
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Focus stream' }))
+
+    expect(container.querySelector('.screen-share-stage')).toHaveClass('screen-share-stage--theater')
+    expect(container.querySelector('.remote-screen-preview')).toHaveClass('is-theater-focused')
+    expect(voice.setRemoteMediaSubscribed).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exit focus view' }))
+
+    expect(container.querySelector('.screen-share-stage')).not.toHaveClass('screen-share-stage--theater')
+    expect(container.querySelector('.remote-screen-preview')).not.toHaveClass('is-theater-focused')
+  })
+
   it('keeps user volume and stream mute state independent', async () => {
     const micTrack = mediaTrack('audio', 'peer-mic')
     const screenAudioTrack = mediaTrack('audio', 'peer-screen-audio')

--- a/apps/web/src/components/ActiveCallBar.tsx
+++ b/apps/web/src/components/ActiveCallBar.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, PhoneOff, Mic, MicOff, Monitor, Volume2, VolumeX, Maximize2, Minimize2, SwitchCamera as SwitchCameraIcon, Users, Video, VideoOff, Wifi } from 'lucide-react'
+import { ChevronRight, Eye, EyeOff, PhoneOff, Mic, MicOff, Monitor, Volume2, VolumeX, Maximize2, Minimize2, LayoutGrid, PanelsTopLeft, SwitchCamera as SwitchCameraIcon, Users, Video, VideoOff, Wifi } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router'
@@ -198,9 +198,9 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     const ch = allKnownChannels.find((c) => c.id === id)
     if (!ch) return { full: 'Voice', display: 'Voice' }
     const serverName = servers.find((s) => s.id === ch.server_id)?.name ?? 'Server'
-    const full = `${serverName} / #${ch.name}`
+    const full = `${serverName} / ${ch.name}`
 
-    return { full, display: `#${shorten(ch.name, 24)}` }
+    return { full, display: shorten(ch.name, 24) }
   }, [state.joinedChannelId, selectedVoiceChannelId, allKnownChannels, servers])
   const goToVoiceChannel = () => {
     const id = state.joinedChannelId ?? selectedVoiceChannelId
@@ -276,6 +276,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     () => readRemotePlaybackVolumes(),
   )
   const [fullscreenTileKey, setFullscreenTileKey] = useState<string | null>(null)
+  const [theaterStreamKey, setTheaterStreamKey] = useState<string | null>(null)
   const [hiddenRemoteMediaKeys, setHiddenRemoteMediaKeys] = useState<Set<string>>(() => new Set())
   const [remoteMediaPlaceholders, setRemoteMediaPlaceholders] = useState<Map<string, RemoteMediaPlaceholder>>(() => new Map())
   const lastVoiceQualityWarningRef = useRef<string | null>(null)
@@ -686,6 +687,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
   useEffect(() => {
     setHiddenRemoteMediaKeys(new Set())
     setRemoteMediaPlaceholders(new Map())
+    setTheaterStreamKey(null)
   }, [currentVoiceChannelId])
 
   const getRemoteMediaKey = useCallback((peerId: string, kind: RemoteMediaKind) => {
@@ -758,6 +760,23 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
     }
     return entries
   }, [remoteEntries, state.remoteScreenTrackIds])
+  const activeTheaterStreamKeys = useMemo(() => {
+    const keys: string[] = []
+    if (state.isScreenSharing && state.screenStream) keys.push('local-screen')
+    for (const { peerId, track, kind } of remoteVideoTrackEntries) {
+      if (kind === 'screen' && state.watchedRemoteScreenPeerIds.has(peerId)) {
+        keys.push(`screen-${peerId}-${track.id}`)
+      }
+    }
+    return keys
+  }, [remoteVideoTrackEntries, state.isScreenSharing, state.screenStream, state.watchedRemoteScreenPeerIds])
+  const hasTheaterFocus = theaterStreamKey !== null && activeTheaterStreamKeys.includes(theaterStreamKey)
+
+  useEffect(() => {
+    if (theaterStreamKey && !activeTheaterStreamKeys.includes(theaterStreamKey)) {
+      setTheaterStreamKey(null)
+    }
+  }, [activeTheaterStreamKeys, theaterStreamKey])
   const activeRemoteMediaKeys = useMemo(() => {
     const keys = new Set<string>()
     for (const entry of remoteVideoTrackEntries) {
@@ -1467,10 +1486,11 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
         <>
           {showVoiceStage && (
             <div
-              className="screen-share-stage"
+              className={`screen-share-stage${hasTheaterFocus ? ' screen-share-stage--theater' : ''}`}
               data-stage-density={stageDensity}
               data-stage-columns={stageColumns}
-              style={{ gridTemplateColumns: `repeat(${stageColumns}, minmax(0, 1fr))` }}
+              data-theater-mode={hasTheaterFocus ? 'true' : undefined}
+              style={hasTheaterFocus ? undefined : { gridTemplateColumns: `repeat(${stageColumns}, minmax(0, 1fr))` }}
             >
               {channelParticipants.map((p) => {
                 const isLocal = p.user_id === user?.id
@@ -1536,12 +1556,21 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                 </div>
               )}
               {state.isScreenSharing && state.screenStream && (
-                <div className="screen-share-preview voice-stage-share-tile" data-fullscreen-key="screen" onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
+                <div className={`screen-share-preview voice-stage-share-tile${theaterStreamKey === 'local-screen' ? ' is-theater-focused' : ''}`} data-fullscreen-key="screen" onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
                   <video autoPlay muted playsInline ref={attachScreenPreviewElement} />
                   <div className="screen-share-info-overlay"><span className="screen-share-info-text">Screen share · You</span></div>
                   <div className="screen-share-controls-bar">
                     <div className="screen-share-controls-left" />
                     <div className="screen-share-controls-right">
+                      <button
+                        type="button"
+                        className="screen-share-controls-btn"
+                        title={theaterStreamKey === 'local-screen' ? 'Exit focus view' : 'Focus stream'}
+                        aria-label={theaterStreamKey === 'local-screen' ? 'Exit focus view' : 'Focus stream'}
+                        onClick={() => setTheaterStreamKey((current) => current === 'local-screen' ? null : 'local-screen')}
+                      >
+                        {theaterStreamKey === 'local-screen' ? <LayoutGrid size={16} /> : <PanelsTopLeft size={16} />}
+                      </button>
                       <button type="button" className="screen-share-controls-btn" title="Toggle fullscreen" onClick={(e) => {
                         const tile = (e.currentTarget as HTMLElement).closest('.screen-share-preview') as HTMLElement | null
                         if (!tile) return
@@ -1606,12 +1635,13 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   volumeKey,
                 )
                 const tileKey = `${peerId}-${track.id}`
+                const theaterKey = kind === 'screen' ? `screen-${tileKey}` : null
                 const owner = remoteShareOwner(peerId)
                 const isHidden = isRemoteMediaHidden(peerId, kind)
                 if (kind === 'screen' && !watchedRemoteScreenPeerIds.has(peerId)) return null
                 if (kind === 'camera' && isHidden) return null
                 return (
-                  <div key={tileKey} className="screen-share-preview remote-screen-preview voice-stage-share-tile" data-fullscreen-key={tileKey} onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
+                  <div key={tileKey} className={`screen-share-preview remote-screen-preview voice-stage-share-tile${theaterStreamKey === theaterKey ? ' is-theater-focused' : ''}`} data-fullscreen-key={tileKey} onMouseMove={handleTileMouseMove} onMouseLeave={handleTileMouseLeave}>
                     <RemoteVideoTrack track={track} />
                     <div className="screen-share-info-overlay"><span className="screen-share-info-text">{label} · {owner}</span></div>
                     <div className="screen-share-controls-bar">
@@ -1664,14 +1694,36 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                         >
                           <EyeOff size={16} />
                         </button>
-                        <button type="button" className="screen-share-controls-btn" title="Toggle fullscreen" onClick={(e) => {
-                          const tile = (e.currentTarget as HTMLElement).closest('.screen-share-preview') as HTMLElement | null
-                          if (!tile) return
-                          if (document.fullscreenElement) void document.exitFullscreen().catch(() => { })
-                          else void tile.requestFullscreen?.().catch(() => { })
-                        }}>
-                          {fullscreenTileKey === tileKey ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
-                        </button>
+                        {kind === 'screen' ? (
+                          <>
+                            <button
+                              type="button"
+                              className="screen-share-controls-btn"
+                              title={theaterStreamKey === theaterKey ? 'Exit focus view' : 'Focus stream'}
+                              aria-label={theaterStreamKey === theaterKey ? 'Exit focus view' : 'Focus stream'}
+                              onClick={() => setTheaterStreamKey((current) => current === theaterKey ? null : theaterKey)}
+                            >
+                              {theaterStreamKey === theaterKey ? <LayoutGrid size={16} /> : <PanelsTopLeft size={16} />}
+                            </button>
+                            <button type="button" className="screen-share-controls-btn" title="Toggle fullscreen" onClick={(e) => {
+                              const tile = (e.currentTarget as HTMLElement).closest('.screen-share-preview') as HTMLElement | null
+                              if (!tile) return
+                              if (document.fullscreenElement) void document.exitFullscreen().catch(() => { })
+                              else void tile.requestFullscreen?.().catch(() => { })
+                            }}>
+                              {fullscreenTileKey === tileKey ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+                            </button>
+                          </>
+                        ) : (
+                          <button type="button" className="screen-share-controls-btn" title="Toggle fullscreen" onClick={(e) => {
+                            const tile = (e.currentTarget as HTMLElement).closest('.screen-share-preview') as HTMLElement | null
+                            if (!tile) return
+                            if (document.fullscreenElement) void document.exitFullscreen().catch(() => { })
+                            else void tile.requestFullscreen?.().catch(() => { })
+                          }}>
+                            {fullscreenTileKey === tileKey ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+                          </button>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -1687,7 +1739,17 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                 renderAudioElement={renderRemoteAudioElement}
               />
               <div className="callbar-status">
-                <button type="button" className="active-call-title active-call-title-btn" onClick={goToVoiceChannel} title={voiceLocation.full}>{voiceLocation.display}</button>
+                <button
+                  type="button"
+                  className="active-call-title active-call-title-btn"
+                  onClick={goToVoiceChannel}
+                  title={`Return to ${voiceLocation.full}`}
+                  aria-label={`Return to ${voiceLocation.full}`}
+                >
+                  <Volume2 className="active-call-title-icon" size={14} aria-hidden="true" />
+                  <span className="active-call-title-label">{voiceLocation.display}</span>
+                  <ChevronRight size={14} aria-hidden="true" />
+                </button>
               </div>
               <div className="callbar-controls-center">
                 <button
@@ -1695,6 +1757,7 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   disabled={!state.joinedChannelId || !state.localStream || deafened}
                   className={`callbar-control-btn ${muted ? 'is-off' : (serverMuted || serverDeafened) ? 'is-server-off' : ''}`}
                   aria-label={micControlLabel}
+                  title={micControlLabel}
                 >
                   {(muted || serverMuted || serverDeafened) ? <MicOff size={16} /> : <Mic size={16} />}
                 </button>
@@ -1703,28 +1766,29 @@ export default function ActiveCallBar({ selectedVoiceChannelId, activeChannelId 
                   disabled={!state.joinedChannelId}
                   className={`callbar-control-btn ${deafened ? 'is-off' : serverDeafened ? 'is-server-off' : ''}`}
                   aria-label={deafenControlLabel}
+                  title={deafenControlLabel}
                 >
                   {(deafened || serverDeafened) ? <VolumeX size={16} /> : <Volume2 size={16} />}
                 </button>
-                <button onClick={handleCamera} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.cameraStream ? 'is-live' : ''}`} aria-label={cameraControlLabel}>
+                <button onClick={handleCamera} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.cameraStream ? 'is-live' : ''}`} aria-label={cameraControlLabel} title={cameraControlLabel}>
                   {state.cameraStream ? <Video size={16} /> : <VideoOff size={16} />}
                 </button>
                 {!isMobileViewport && (
-                  <button onClick={handleScreenShare} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.isScreenSharing ? 'is-live' : ''}`} aria-label={screenShareControlLabel}>
+                  <button onClick={handleScreenShare} disabled={!state.joinedChannelId} className={`callbar-control-btn media-control ${state.isScreenSharing ? 'is-live' : ''}`} aria-label={screenShareControlLabel} title={screenShareControlLabel}>
                     <Monitor size={16} />
                   </button>
                 )}
               </div>
               <div className="callbar-controls-right">
                 <span className="callbar-connection-inline">
-                  <span className={`callbar-ping-chip ${pingStateClass}`} role="status" aria-label={pingAriaLabel}>
+                  <span className={`callbar-ping-chip ${pingStateClass}`} role="status" aria-label={pingAriaLabel} title={pingAriaLabel}>
                     <span className="callbar-ping-inline-icon" aria-hidden="true">
                       <Wifi size={14} />
                     </span>
                     <span className="callbar-ping-value">{pingDisplay}</span>
                   </span>
                 </span>
-                <button onClick={handleJoinLeave} disabled={state.isJoining} className={`callbar-control-btn callbar-control-btn-disconnect danger ${isDisconnectVisualActive ? 'is-live is-disconnect-state' : ''} ${isDisconnectPendingVisual ? 'is-disconnect-pending' : ''}`} aria-label={disconnectControlLabel}>
+                <button onClick={handleJoinLeave} disabled={state.isJoining} className={`callbar-control-btn callbar-control-btn-disconnect danger ${isDisconnectVisualActive ? 'is-live is-disconnect-state' : ''} ${isDisconnectPendingVisual ? 'is-disconnect-pending' : ''}`} aria-label={disconnectControlLabel} title={disconnectControlLabel}>
                   <PhoneOff size={16} style={{ transform: isDisconnectVisualActive ? 'none' : 'rotate(135deg)' }} />
                 </button>
               </div>

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -230,4 +230,52 @@ describe('ChannelSidebar voice media presence', () => {
         expect(screen.queryByRole('button', { name: 'Create channels and categories' })).toBeNull()
         expect(screen.queryByRole('button', { name: 'Create channel in Voice' })).toBeNull()
     })
+
+    it('keeps channel and category context menus inside the viewport', () => {
+        const originalInnerWidth = window.innerWidth
+        const originalInnerHeight = window.innerHeight
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 320 })
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: 240 })
+
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel],
+            activeChannelId: null,
+        })
+
+        const { container } = render(
+            <ChannelSidebar
+                channelCategories={['Voice']}
+                canManageChannels
+                onRenameChannel={vi.fn()}
+                onRenameCategory={vi.fn()}
+            />,
+        )
+        const sidebar = container.querySelector('.channel-sidebar') as HTMLDivElement
+        vi.spyOn(sidebar, 'getBoundingClientRect').mockReturnValue({
+            bottom: 900,
+            height: 900,
+            left: 0,
+            right: 245,
+            top: 0,
+            width: 245,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        })
+
+        fireEvent.contextMenu(screen.getByText(voiceChannel.name), { clientX: 315, clientY: 235 })
+        let menu = container.querySelector('.channel-context-menu') as HTMLDivElement
+        expect(menu.style.left).toBe('29px')
+        expect(Number.parseInt(menu.style.top, 10)).toBeLessThan(235)
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: 'Voice' }), { clientX: 315, clientY: 235 })
+        menu = container.querySelector('.channel-context-menu') as HTMLDivElement
+        expect(menu.style.left).toBe('29px')
+        expect(Number.parseInt(menu.style.top, 10)).toBeLessThan(235)
+
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth })
+        Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight })
+    })
 })

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -132,7 +132,7 @@ export default function ChannelSidebar({
         }
     }
 
-    const clampParticipantMenuToSidebar = (x: number, y: number, width: number, height: number) => {
+    const clampSidebarMenuPosition = (x: number, y: number, width: number, height: number) => {
         const sidebarRect = sidebarRef.current?.getBoundingClientRect()
         if (!sidebarRect) return clampMenuPosition(x, y, width, height)
 
@@ -285,7 +285,7 @@ export default function ChannelSidebar({
                     const target = e.target as HTMLElement
                     if (target.closest('.channel-category-group, .channel-item')) return
                     e.preventDefault()
-                    const pos = clampMenuPosition(e.clientX, e.clientY, 190, 92)
+                    const pos = clampSidebarMenuPosition(e.clientX, e.clientY, 190, 92)
                     closeAllContextMenus()
                     setCreateMenu(pos)
                 }}
@@ -375,7 +375,7 @@ export default function ChannelSidebar({
                             onContextMenu={(e) => {
                                 if (!canManageChannels) return
                                 e.preventDefault()
-                                const pos = clampMenuPosition(e.clientX, e.clientY, 210, 100)
+                                const pos = clampSidebarMenuPosition(e.clientX, e.clientY, 210, 176)
                                 closeAllContextMenus()
                                 setCategoryMenu({ category, x: pos.x, y: pos.y })
                             }}
@@ -478,8 +478,12 @@ export default function ChannelSidebar({
                                         onContextMenu={(e) => {
                                             if (!canManageChannels && ch.channel_type !== 'text') return
                                             e.preventDefault()
+                                            const menuHeight = canManageChannels
+                                                ? (ch.channel_type === 'text' ? 116 : 80)
+                                                : 44
+                                            const pos = clampSidebarMenuPosition(e.clientX, e.clientY, 210, menuHeight)
                                             closeAllContextMenus()
-                                            setContextMenu({ channelId: ch.id, x: e.clientX, y: e.clientY })
+                                            setContextMenu({ channelId: ch.id, x: pos.x, y: pos.y })
                                         }}
                                         draggable={!!canManageChannels}
                                         onDragStart={(e) => {
@@ -585,7 +589,7 @@ export default function ChannelSidebar({
                                                             const estimatedHeight = 194 + (moderationActions > 0
                                                                 ? 54 + moderationActions * 32
                                                                 : 0)
-                                                            const pos = clampParticipantMenuToSidebar(e.clientX, e.clientY, estimatedWidth, estimatedHeight)
+                                                            const pos = clampSidebarMenuPosition(e.clientX, e.clientY, estimatedWidth, estimatedHeight)
                                                             closeAllContextMenus()
                                                             setParticipantMenu({ userId: vm.user_id, username: vm.username, channelId: ch.id, x: pos.x, y: pos.y })
                                                         }}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1294,6 +1294,8 @@ body {
 .server-context-menu {
   position: fixed;
   min-width: 160px;
+  max-width: calc(100vw - 16px);
+  box-sizing: border-box;
   background: var(--bg-surface);
   border: var(--border-subtle);
   border-radius: var(--border-radius-md);
@@ -1304,6 +1306,7 @@ body {
 
 .server-context-menu-item {
   width: 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1314,6 +1317,7 @@ body {
   font-size: 13px;
   cursor: pointer;
   text-align: left;
+  overflow-wrap: anywhere;
   transition: background var(--transition-fast);
 }
 
@@ -9707,8 +9711,40 @@ a.community-open-btn:hover {
   --voice-stage-tile-min: 132px;
 }
 
+/* Focus view keeps a selected screen share prominent without browser fullscreen. */
+.screen-share-stage--theater {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 12px;
+}
+
+.screen-share-stage--theater .screen-share-preview.is-theater-focused {
+  position: relative;
+  top: auto;
+  left: auto;
+  width: min(100%, 1280px);
+  height: min(100%, 720px);
+  min-height: 0;
+  aspect-ratio: 16 / 9;
+  margin: 0;
+  transform: none;
+}
+
+.screen-share-stage--theater .screen-share-preview.is-theater-focused video {
+  object-fit: cover;
+}
+
+.screen-share-stage--theater .voice-stage-tile,
+.screen-share-stage--theater .voice-stage-hidden-media-tile,
+.screen-share-stage--theater .screen-share-preview:not(.is-theater-focused) {
+  display: none;
+}
+
 .screen-share-preview {
   width: 100%;
+  /* Preserve the shared source aspect ratio without exposing the app theme in letterbox space. */
   background: #000 !important;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 10px;
@@ -9722,7 +9758,8 @@ a.community-open-btn:hover {
 .screen-share-preview video {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  /* Fill regular and focus tiles; browser fullscreen retains the complete source below. */
+  object-fit: cover;
   display: block;
   background: #000;
 }
@@ -10149,15 +10186,17 @@ a.community-open-btn:hover {
 }
 
 .active-call-title-btn {
-  display: block;
-  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex: 0 1 auto;
   width: auto;
   max-width: 100%;
   min-width: 0;
-  background: none;
-  border: 0;
-  border-radius: 0;
-  padding: 0 2px;
+  background: color-mix(in srgb, var(--text-link) 9%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-link) 34%, transparent);
+  border-radius: 6px;
+  padding: 4px 5px 4px 7px;
   cursor: pointer;
   text-align: left;
   font: inherit;
@@ -10166,11 +10205,18 @@ a.community-open-btn:hover {
   transition: all 0.15s ease;
   white-space: nowrap;
   overflow: hidden;
+}
+
+.active-call-title-label {
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .active-call-title-btn:hover {
   color: var(--text-primary);
+  background: color-mix(in srgb, var(--text-link) 16%, transparent);
+  border-color: color-mix(in srgb, var(--text-link) 58%, transparent);
 }
 
 .active-call-title-btn:focus-visible {
@@ -15217,6 +15263,16 @@ textarea {
     overflow-y: auto;
     overscroll-behavior: contain;
     padding: 0;
+  }
+
+  .screen-share-stage--theater {
+    padding: 0;
+  }
+
+  .screen-share-stage--theater .screen-share-preview.is-theater-focused {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
   }
 
   .voice-stage-tile {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-logging: &default-logging
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16.15-alpine3.24
     container_name: voxpery-db
     restart: unless-stopped
     environment:
@@ -29,7 +29,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.11-alpine
     container_name: voxpery-redis
     restart: unless-stopped
     ports:
@@ -44,7 +44,7 @@ services:
       retries: 10
 
   clamav:
-    image: clamav/clamav:1.4
+    image: clamav/clamav:1.4.6
     container_name: voxpery-clamav
     restart: unless-stopped
     profiles: ["security"]
@@ -52,7 +52,7 @@ services:
 
   # LiveKit runs on bridge networking for cross-platform Docker compatibility.
   livekit:
-    image: livekit/livekit-server:latest
+    image: livekit/livekit-server:v1.13.5
     container_name: voxpery-livekit
     restart: unless-stopped
     cpus: ${LIVEKIT_CPUS_LIMIT:-2.0}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-08-27
+
+### Added
+- Added an in-app theater view for local and watched screen shares so a stream can stay central and prominent without forcing browser fullscreen.
+
+### Changed
+- Pinned the production and CI PostgreSQL/Redis images, plus production LiveKit and ClamAV images, to explicit patch releases for repeatable deployments.
+- Made the active voice-channel return control easier to recognize and added state-aware hover labels to call controls.
+
 ### Fixed
 - Stabilized initial watched screen-share audio by coalescing output-device assignment and starting each unchanged remote track only once while subscription events settle.
 - Prevented supported browsers from recapturing Voxpery's own call playback into a shared-audio track.

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -20,6 +20,34 @@ SERVER_SERVICE=server
 WEB_SERVICE=web
 ```
 
+## Runtime Image Pins
+
+The production Compose stack uses explicit patch releases for its external
+services. This keeps a repeatable deployment base while allowing upgrades to
+be reviewed and smoke-tested deliberately:
+
+| Service | Pinned image |
+| --- | --- |
+| LiveKit | `livekit/livekit-server:v1.13.5` |
+| PostgreSQL | `postgres:16.15-alpine3.24` |
+| Redis | `redis:7.4.11-alpine` |
+| ClamAV | `clamav/clamav:1.4.6` |
+
+Before changing a pin, test the candidate with `docker compose config`, the
+local smoke flow, and the voice/screen-share regression checklist. Record the
+resolved image digest in the release or deployment record after the verified
+pull. Major PostgreSQL or Redis upgrades require a separate backup, restore,
+and compatibility plan.
+
+Verified Linux `amd64` digests for the current pins (2026-08-27):
+
+| Service | Digest |
+| --- | --- |
+| LiveKit | `sha256:d0d1cfdbe95617647bbe91630454526c2cdd88cec83f41114b3495b444918b9a` |
+| PostgreSQL | `sha256:075f7ba66bc9b3ce7d6b8b635208ff61cd7cf1a67d71ec530eec5d7ae0cbe571` |
+| Redis | `sha256:1db42ccef14898aa29bae778452d567534b59c107129cbc1163fb552de184d3c` |
+| ClamAV | `sha256:927f99699ed9b74869b77b3d2ba1a8f20b482c5775d65f2883fcf91e543a970a` |
+
 ## 1) Backup Automation (PostgreSQL)
 
 Backup script:


### PR DESCRIPTION
## Summary
- Bump Voxpery version metadata to `v0.2.13`.
- Add Focus View for local and watched screen shares, separate from browser fullscreen.
- Improve regular screen-share presentation while keeping browser fullscreen available for the uncropped source.
- Make the active voice-channel return action visually clear with a voice icon, channel label, arrow, and accessible hover label.
- Add state-aware hover labels for microphone, deafen, camera, screen share, connection quality, and leave-call controls.
- Keep server, channel, category, and participant context menus within the sidebar viewport.
- Pin LiveKit, PostgreSQL, Redis, and ClamAV to explicit patch versions in production and CI.
- Document runtime image pins and release changes.

## Validation
- `npm run lint`
- `npm run test:run -- src/components/ActiveCallBar.test.tsx`
- `npm run build`
- Local manual verification of Focus View, sidebar context menus, and active voice-channel return