### PR TITLE
fix: restore valid desktop dependency lock

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.13"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [


### PR DESCRIPTION
## Summary

- Restore `document-features` to the valid crates.io version `0.2.12`.
- Keep the Voxpery desktop application version at `0.2.13`.
- Fix desktop release builds on Windows, macOS, and Linux.

## Root cause

The v0.2.13 release bump accidentally changed the transitive
`document-features` lock entry from `0.2.12` to the nonexistent `0.2.13`
while retaining the `0.2.12` checksum.

## Validation

- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --locked`