### PR TITLE
feat: audit voice moderation actions

### DIFF
--- a/apps/server/migrations/048_voice_moderation_audit.sql
+++ b/apps/server/migrations/048_voice_moderation_audit.sql
@@ -1,0 +1,22 @@
+-- Add structured voice moderation context and a dedicated move-members permission.
+
+ALTER TABLE audit_log
+    ADD COLUMN channel_id UUID REFERENCES channels(id) ON DELETE SET NULL,
+    ADD COLUMN reason VARCHAR(500);
+
+CREATE INDEX idx_audit_log_server_action_at
+    ON audit_log(server_id, action, at DESC, id DESC);
+
+CREATE INDEX idx_audit_log_server_resource_at
+    ON audit_log(server_id, resource_id, at DESC, id DESC);
+
+CREATE INDEX idx_audit_log_server_channel_at
+    ON audit_log(server_id, channel_id, at DESC, id DESC);
+
+COMMENT ON COLUMN audit_log.channel_id IS
+    'Voice or text channel context for the audited action when one applies.';
+COMMENT ON COLUMN audit_log.reason IS
+    'Optional moderator-supplied reason, limited to 500 characters.';
+
+-- Bit 13 was previously used by the removed webhook feature and was cleared in migration 025.
+-- Existing custom roles are intentionally not granted this new moderation capability.

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -1210,6 +1210,7 @@ const PERM_MANAGE_PINS: i64 = 1 << 9;
 const PERM_CONNECT_VOICE: i64 = 1 << 10;
 const PERM_MUTE_MEMBERS: i64 = 1 << 11;
 const PERM_DEAFEN_MEMBERS: i64 = 1 << 12;
+const PERM_MOVE_MEMBERS: i64 = 1 << 13;
 const DEFAULT_COMMUNITY_ONBOARDING_TITLE: &str = "Welcome to the Voxpery Community";
 const DEFAULT_COMMUNITY_ONBOARDING_BODY: &str =
     "Start here, say hello, and jump into voice when you are ready.";
@@ -1368,6 +1369,7 @@ pub async fn ensure_default_server_join(db: &sqlx::PgPool, user_id: Uuid) -> Res
             | PERM_BAN_MEMBERS
             | PERM_MUTE_MEMBERS
             | PERM_DEAFEN_MEMBERS
+            | PERM_MOVE_MEMBERS
             | PERM_VIEW_AUDIT_LOG;
         sqlx::query(
             r#"INSERT INTO server_roles (id, server_id, name, color, position, permissions)

--- a/apps/server/src/routes/servers.rs
+++ b/apps/server/src/routes/servers.rs
@@ -6,6 +6,7 @@ use axum::{
     Extension, Json, Router,
 };
 use chrono::{Duration as ChronoDuration, Utc};
+use sqlx::{Postgres, QueryBuilder};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::{net::SocketAddr, time::Duration};
@@ -47,6 +48,7 @@ const PERM_MANAGE_PINS: i64 = 1 << 9;
 const PERM_CONNECT_VOICE: i64 = 1 << 10;
 const PERM_MUTE_MEMBERS: i64 = 1 << 11;
 const PERM_DEAFEN_MEMBERS: i64 = 1 << 12;
+const PERM_MOVE_MEMBERS: i64 = 1 << 13;
 const MAX_REORDER_ROLE_IDS: usize = 512;
 const MAX_ONBOARDING_CHANNELS: usize = 6;
 const MAX_ONBOARDING_TASKS: usize = 6;
@@ -66,11 +68,31 @@ struct AuditLogEntry {
     action: String,
     resource_type: String,
     resource_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    reason: Option<String>,
     details: Option<serde_json::Value>,
     /// Who performed the action (from users.username).
     actor_username: Option<String>,
     /// Target user display name when resource is a user (e.g. kicked member, role change target).
     resource_username: Option<String>,
+    /// Channel display name captured through the current channel relationship.
+    channel_name: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct AuditLogPage {
+    entries: Vec<AuditLogEntry>,
+    next_before: Option<Uuid>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct AuditLogQuery {
+    action: Option<String>,
+    actor_id: Option<Uuid>,
+    target_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    before: Option<Uuid>,
+    limit: Option<i64>,
 }
 
 #[derive(Debug, serde::Serialize, sqlx::FromRow)]
@@ -664,6 +686,7 @@ async fn create_server(
         | PERM_BAN_MEMBERS
         | PERM_MUTE_MEMBERS
         | PERM_DEAFEN_MEMBERS
+        | PERM_MOVE_MEMBERS
         | PERM_VIEW_AUDIT_LOG;
     sqlx::query(
         r#"INSERT INTO server_roles (id, server_id, name, color, position, permissions)
@@ -1144,7 +1167,8 @@ async fn get_audit_log(
     State(state): State<Arc<AppState>>,
     Extension(claims): Extension<Claims>,
     Path(server_id): Path<Uuid>,
-) -> Result<Json<Vec<AuditLogEntry>>, AppError> {
+    Query(query): Query<AuditLogQuery>,
+) -> Result<Json<AuditLogPage>, AppError> {
     // Require VIEW_AUDIT_LOG permission for audit log access.
     permissions::ensure_server_permission(
         &state.db,
@@ -1154,20 +1178,75 @@ async fn get_audit_log(
     )
     .await?;
 
-    let rows = sqlx::query_as::<_, AuditLogEntry>(
-        r#"SELECT a.id, a.at, a.actor_id, a.server_id, a.action, a.resource_type, a.resource_id, a.details,
+    let action = query
+        .action
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if action.is_some_and(|value| {
+        value.len() > 50
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
+    }) {
+        return Err(AppError::Validation("Invalid audit action filter".into()));
+    }
+
+    let limit = query.limit.unwrap_or(50).clamp(1, 100);
+    let mut builder = QueryBuilder::<Postgres>::new(
+        r#"SELECT a.id, a.at, a.actor_id, a.server_id, a.action, a.resource_type,
+                  a.resource_id, a.channel_id, a.reason, a.details,
                   u_actor.username AS actor_username,
-                  u_resource.username AS resource_username
+                  u_resource.username AS resource_username,
+                  c.name AS channel_name
            FROM audit_log a
            LEFT JOIN users u_actor ON u_actor.id = a.actor_id
            LEFT JOIN users u_resource ON u_resource.id = a.resource_id
-           WHERE a.server_id = $1 ORDER BY a.at DESC LIMIT 500"#,
-    )
-    .bind(server_id)
-    .fetch_all(&state.db)
-    .await?;
+           LEFT JOIN channels c ON c.id = a.channel_id
+           WHERE a.server_id = "#,
+    );
+    builder.push_bind(server_id);
 
-    Ok(Json(rows))
+    if let Some(action) = action {
+        builder.push(" AND a.action = ").push_bind(action);
+    }
+    if let Some(actor_id) = query.actor_id {
+        builder.push(" AND a.actor_id = ").push_bind(actor_id);
+    }
+    if let Some(target_id) = query.target_id {
+        builder.push(" AND a.resource_id = ").push_bind(target_id);
+    }
+    if let Some(channel_id) = query.channel_id {
+        builder.push(" AND a.channel_id = ").push_bind(channel_id);
+    }
+    if let Some(before) = query.before {
+        builder.push(
+            " AND (a.at, a.id) < (SELECT cursor.at, cursor.id FROM audit_log cursor WHERE cursor.id = ",
+        );
+        builder.push_bind(before);
+        builder.push(" AND cursor.server_id = ");
+        builder.push_bind(server_id);
+        builder.push(")");
+    }
+    builder.push(" ORDER BY a.at DESC, a.id DESC LIMIT ");
+    builder.push_bind(limit + 1);
+
+    let mut entries = builder
+        .build_query_as::<AuditLogEntry>()
+        .fetch_all(&state.db)
+        .await?;
+    let has_more = entries.len() > limit as usize;
+    entries.truncate(limit as usize);
+    let next_before = if has_more {
+        entries.last().map(|entry| entry.id)
+    } else {
+        None
+    };
+
+    Ok(Json(AuditLogPage {
+        entries,
+        next_before,
+    }))
 }
 
 /// POST /api/servers/join — join a server via invite code.

--- a/apps/server/src/services/audit.rs
+++ b/apps/server/src/services/audit.rs
@@ -3,6 +3,18 @@
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
+pub const VOICE_MEMBER_MUTE: &str = "voice_member_mute";
+pub const VOICE_MEMBER_UNMUTE: &str = "voice_member_unmute";
+pub const VOICE_MEMBER_DEAFEN: &str = "voice_member_deafen";
+pub const VOICE_MEMBER_UNDEAFEN: &str = "voice_member_undeafen";
+pub const VOICE_MEMBER_DISCONNECT: &str = "voice_member_disconnect";
+pub const VOICE_MEMBER_MOVE: &str = "voice_member_move";
+
+pub struct VoiceModerationAuditEntry {
+    pub action: &'static str,
+    pub details: serde_json::Value,
+}
+
 /// Insert an audit log entry. Caller must provide valid server_id where applicable.
 pub async fn log(
     db: &PgPool,
@@ -50,5 +62,36 @@ pub async fn log_in_transaction(
     .bind(details)
     .execute(&mut **tx)
     .await?;
+    Ok(())
+}
+
+/// Persist one server-enforced voice moderation action before changing runtime state.
+pub async fn log_voice_moderation(
+    db: &PgPool,
+    actor_id: Uuid,
+    server_id: Uuid,
+    target_user_id: Uuid,
+    channel_id: Uuid,
+    reason: Option<&str>,
+    entries: &[VoiceModerationAuditEntry],
+) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
+    for entry in entries {
+        sqlx::query(
+            r#"INSERT INTO audit_log
+               (actor_id, server_id, action, resource_type, resource_id, channel_id, reason, details)
+               VALUES ($1, $2, $3, 'member', $4, $5, $6, $7)"#,
+        )
+        .bind(actor_id)
+        .bind(server_id)
+        .bind(entry.action)
+        .bind(target_user_id)
+        .bind(channel_id)
+        .bind(reason)
+        .bind(&entry.details)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
     Ok(())
 }

--- a/apps/server/src/services/permissions.rs
+++ b/apps/server/src/services/permissions.rs
@@ -22,6 +22,7 @@ bitflags::bitflags! {
         const CONNECT_VOICE    = 1 << 10;
         const MUTE_MEMBERS     = 1 << 11;
         const DEAFEN_MEMBERS   = 1 << 12;
+        const MOVE_MEMBERS     = 1 << 13;
     }
 }
 
@@ -388,6 +389,7 @@ mod tests {
         assert!(p.contains(Permissions::VIEW_SERVER));
         assert!(p.contains(Permissions::MANAGE_SERVER));
         assert!(p.contains(Permissions::DEAFEN_MEMBERS));
+        assert!(p.contains(Permissions::MOVE_MEMBERS));
     }
 
     #[test]

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -18,7 +18,10 @@ use uuid::Uuid;
 use super::{WsClientMessage, WsEvent};
 use crate::middleware::auth::token_from_request;
 use crate::middleware::auth::{claims_match_current_token_version, Claims};
-use crate::services::permissions::{get_user_server_permissions, Permissions};
+use crate::services::audit::{self, VoiceModerationAuditEntry};
+use crate::services::permissions::{
+    get_user_highest_role_position, get_user_server_permissions, Permissions,
+};
 use crate::services::voice_revoke;
 use crate::ws::access::{can_join_voice_channel, can_subscribe_to_channel};
 use crate::AppState;
@@ -30,6 +33,54 @@ async fn server_id_for_channel(db: &sqlx::PgPool, channel_id: Uuid) -> Option<Uu
         .await
         .ok()
         .flatten()
+}
+
+async fn voice_channel_context(
+    db: &sqlx::PgPool,
+    channel_id: Uuid,
+) -> Option<(Uuid, String)> {
+    sqlx::query_as::<_, (Uuid, String)>(
+        "SELECT server_id, name FROM channels WHERE id = $1 AND channel_type = 'voice'",
+    )
+    .bind(channel_id)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten()
+}
+
+async fn can_moderate_voice_target(
+    db: &sqlx::PgPool,
+    server_id: Uuid,
+    actor_id: Uuid,
+    target_id: Uuid,
+) -> bool {
+    if actor_id == target_id {
+        return false;
+    }
+
+    let actor_position = get_user_highest_role_position(db, server_id, actor_id).await;
+    let target_position = get_user_highest_role_position(db, server_id, target_id).await;
+    match (actor_position, target_position) {
+        (Ok(actor_position), Ok(target_position)) => actor_position < target_position,
+        (actor_result, target_result) => {
+            tracing::warn!(
+                "Voice moderation hierarchy lookup failed: actor={:?}, target={:?}",
+                actor_result.err(),
+                target_result.err()
+            );
+            false
+        }
+    }
+}
+
+fn normalize_voice_moderation_reason(reason: Option<String>) -> Option<Option<String>> {
+    let reason = reason.map(|value| value.trim().to_string());
+    match reason {
+        Some(value) if value.chars().count() > 500 => None,
+        Some(value) if !value.is_empty() => Some(Some(value)),
+        _ => Some(None),
+    }
 }
 
 fn current_epoch_ms() -> u64 {
@@ -607,6 +658,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                 None => false,
                             }
                         }
+                        WsEvent::VoiceMemberMoveRequested { .. } => false,
                         WsEvent::Pong { .. } => false,
                         WsEvent::Signal { .. } => false,
                     };
@@ -981,15 +1033,21 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                     .await;
                                 }
                             }
-                            WsClientMessage::DisconnectVoiceMember { target_user_id } => {
+                            WsClientMessage::DisconnectVoiceMember {
+                                target_user_id,
+                                reason,
+                            } => {
+                                let Some(reason) = normalize_voice_moderation_reason(reason) else {
+                                    continue;
+                                };
                                 let target_channel =
                                     recv_state.voice_sessions.get(&target_user_id).map(|r| *r);
                                 let Some(target_channel_id) = target_channel else {
                                     continue;
                                 };
-                                let target_server_id =
-                                    server_id_for_channel(&recv_state.db, target_channel_id).await;
-                                let Some(target_server_id) = target_server_id else {
+                                let Some((target_server_id, target_channel_name)) =
+                                    voice_channel_context(&recv_state.db, target_channel_id).await
+                                else {
                                     continue;
                                 };
 
@@ -1017,6 +1075,41 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                     continue;
                                 }
 
+                                if !can_moderate_voice_target(
+                                    &recv_state.db,
+                                    target_server_id,
+                                    user_id,
+                                    target_user_id,
+                                )
+                                .await
+                                {
+                                    continue;
+                                }
+
+                                let audit_entries = [VoiceModerationAuditEntry {
+                                    action: audit::VOICE_MEMBER_DISCONNECT,
+                                    details: serde_json::json!({
+                                        "channel_name": target_channel_name,
+                                    }),
+                                }];
+                                if let Err(e) = audit::log_voice_moderation(
+                                    &recv_state.db,
+                                    user_id,
+                                    target_server_id,
+                                    target_user_id,
+                                    target_channel_id,
+                                    reason.as_deref(),
+                                    &audit_entries,
+                                )
+                                .await
+                                {
+                                    tracing::error!(
+                                        "DisconnectVoiceMember audit log failed: {}",
+                                        e
+                                    );
+                                    continue;
+                                }
+
                                 if let Err(e) = voice_revoke::revoke_active_voice_session(
                                     &recv_state,
                                     target_user_id,
@@ -1030,25 +1123,142 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                     );
                                 }
                             }
+                            WsClientMessage::MoveVoiceMember {
+                                target_user_id,
+                                channel_id,
+                                reason,
+                            } => {
+                                let Some(reason) = normalize_voice_moderation_reason(reason) else {
+                                    continue;
+                                };
+                                let Some(source_channel_id) = recv_state
+                                    .voice_sessions
+                                    .get(&target_user_id)
+                                    .map(|entry| *entry)
+                                else {
+                                    continue;
+                                };
+                                if source_channel_id == channel_id {
+                                    continue;
+                                }
+
+                                let Some((source_server_id, source_channel_name)) =
+                                    voice_channel_context(&recv_state.db, source_channel_id).await
+                                else {
+                                    continue;
+                                };
+                                let Some((destination_server_id, destination_channel_name)) =
+                                    voice_channel_context(&recv_state.db, channel_id).await
+                                else {
+                                    continue;
+                                };
+                                if source_server_id != destination_server_id {
+                                    continue;
+                                }
+
+                                let perms = match get_user_server_permissions(
+                                    &recv_state.db,
+                                    source_server_id,
+                                    user_id,
+                                )
+                                .await
+                                {
+                                    Ok(perms) => perms,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "MoveVoiceMember permission lookup failed: {}",
+                                            e
+                                        );
+                                        continue;
+                                    }
+                                };
+                                if !perms.contains(Permissions::MOVE_MEMBERS)
+                                    && !perms.contains(Permissions::MANAGE_SERVER)
+                                {
+                                    continue;
+                                }
+                                if !can_moderate_voice_target(
+                                    &recv_state.db,
+                                    source_server_id,
+                                    user_id,
+                                    target_user_id,
+                                )
+                                .await
+                                {
+                                    continue;
+                                }
+                                if !matches!(
+                                    can_join_voice_channel(
+                                        &recv_state.db,
+                                        target_user_id,
+                                        channel_id,
+                                    )
+                                    .await,
+                                    Ok(true)
+                                ) {
+                                    continue;
+                                }
+
+                                let audit_entries = [VoiceModerationAuditEntry {
+                                    action: audit::VOICE_MEMBER_MOVE,
+                                    details: serde_json::json!({
+                                        "source_channel_id": source_channel_id,
+                                        "source_channel_name": source_channel_name,
+                                        "destination_channel_id": channel_id,
+                                        "destination_channel_name": destination_channel_name,
+                                    }),
+                                }];
+                                if let Err(e) = audit::log_voice_moderation(
+                                    &recv_state.db,
+                                    user_id,
+                                    source_server_id,
+                                    target_user_id,
+                                    channel_id,
+                                    reason.as_deref(),
+                                    &audit_entries,
+                                )
+                                .await
+                                {
+                                    tracing::error!("MoveVoiceMember audit log failed: {}", e);
+                                    continue;
+                                }
+
+                                super::publish_user_event(
+                                    &recv_state,
+                                    target_user_id,
+                                    WsEvent::VoiceMemberMoveRequested {
+                                        source_channel_id,
+                                        channel_id,
+                                        server_id: source_server_id,
+                                        actor_id: user_id,
+                                    },
+                                )
+                                .await;
+                            }
                             WsClientMessage::SetVoiceControl {
                                 target_user_id,
                                 muted,
                                 deafened,
                                 screen_sharing,
                                 camera_on,
+                                reason,
                             } => {
                                 let target_id = target_user_id.unwrap_or(user_id);
 
                                 if target_id != user_id {
+                                    let Some(reason) = normalize_voice_moderation_reason(reason)
+                                    else {
+                                        continue;
+                                    };
                                     let target_channel =
                                         recv_state.voice_sessions.get(&target_id).map(|r| *r);
                                     let Some(target_channel_id) = target_channel else {
                                         continue;
                                     };
-                                    let target_server_id =
-                                        server_id_for_channel(&recv_state.db, target_channel_id)
-                                            .await;
-                                    let Some(target_server_id) = target_server_id else {
+                                    let Some((target_server_id, target_channel_name)) =
+                                        voice_channel_context(&recv_state.db, target_channel_id)
+                                            .await
+                                    else {
                                         continue;
                                     };
 
@@ -1082,6 +1292,63 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, claims: Claims, 
                                         continue;
                                     }
                                     if deafened != current.3 && !can_deafen {
+                                        continue;
+                                    }
+                                    if !can_moderate_voice_target(
+                                        &recv_state.db,
+                                        target_server_id,
+                                        user_id,
+                                        target_id,
+                                    )
+                                    .await
+                                    {
+                                        continue;
+                                    }
+
+                                    let mut audit_entries = Vec::with_capacity(2);
+                                    if muted != current.2 {
+                                        audit_entries.push(VoiceModerationAuditEntry {
+                                            action: if muted {
+                                                audit::VOICE_MEMBER_MUTE
+                                            } else {
+                                                audit::VOICE_MEMBER_UNMUTE
+                                            },
+                                            details: serde_json::json!({
+                                                "channel_name": target_channel_name,
+                                                "previous_server_muted": current.2,
+                                                "server_muted": muted,
+                                            }),
+                                        });
+                                    }
+                                    if deafened != current.3 {
+                                        audit_entries.push(VoiceModerationAuditEntry {
+                                            action: if deafened {
+                                                audit::VOICE_MEMBER_DEAFEN
+                                            } else {
+                                                audit::VOICE_MEMBER_UNDEAFEN
+                                            },
+                                            details: serde_json::json!({
+                                                "channel_name": target_channel_name,
+                                                "previous_server_deafened": current.3,
+                                                "server_deafened": deafened,
+                                            }),
+                                        });
+                                    }
+                                    if audit_entries.is_empty() {
+                                        continue;
+                                    }
+                                    if let Err(e) = audit::log_voice_moderation(
+                                        &recv_state.db,
+                                        user_id,
+                                        target_server_id,
+                                        target_id,
+                                        target_channel_id,
+                                        reason.as_deref(),
+                                        &audit_entries,
+                                    )
+                                    .await
+                                    {
+                                        tracing::error!("SetVoiceControl audit log failed: {}", e);
                                         continue;
                                     }
 

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -79,6 +79,13 @@ pub enum WsEvent {
         screen_sharing: bool,
         camera_on: bool,
     },
+    /// A moderator requested that the current user join another voice channel.
+    VoiceMemberMoveRequested {
+        source_channel_id: Uuid,
+        channel_id: Uuid,
+        server_id: Uuid,
+        actor_id: Uuid,
+    },
     /// A voice participant started or stopped watching another participant's active screen share.
     ScreenShareViewerUpdate {
         viewer_id: Uuid,
@@ -162,6 +169,52 @@ mod tests {
             } if publisher_user_id == publisher_id
         ));
     }
+
+    #[test]
+    fn parses_voice_member_move_request_with_reason() {
+        let target_user_id = Uuid::new_v4();
+        let channel_id = Uuid::new_v4();
+        let payload = format!(
+            r#"{{"type":"MoveVoiceMember","data":{{"target_user_id":"{target_user_id}","channel_id":"{channel_id}","reason":"Requested support"}}}}"#,
+        );
+
+        let message = serde_json::from_str::<WsClientMessage>(&payload)
+            .expect("voice member move request parses");
+        assert!(matches!(
+            message,
+            WsClientMessage::MoveVoiceMember {
+                target_user_id: parsed_target,
+                channel_id: parsed_channel,
+                reason: Some(reason),
+            } if parsed_target == target_user_id
+                && parsed_channel == channel_id
+                && reason == "Requested support"
+        ));
+    }
+
+    #[test]
+    fn serializes_targeted_voice_member_move_event() {
+        let source_channel_id = Uuid::new_v4();
+        let channel_id = Uuid::new_v4();
+        let server_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let event = WsEvent::VoiceMemberMoveRequested {
+            source_channel_id,
+            channel_id,
+            server_id,
+            actor_id,
+        };
+
+        let json = serde_json::to_value(event).expect("voice member move event serializes");
+        assert_eq!(json["type"], "VoiceMemberMoveRequested");
+        assert_eq!(
+            json["data"]["source_channel_id"],
+            source_channel_id.to_string()
+        );
+        assert_eq!(json["data"]["channel_id"], channel_id.to_string());
+        assert_eq!(json["data"]["server_id"], server_id.to_string());
+        assert_eq!(json["data"]["actor_id"], actor_id.to_string());
+    }
 }
 
 /// Client-to-server WebSocket messages.
@@ -183,7 +236,18 @@ pub enum WsClientMessage {
     /// Leave voice channel.
     LeaveVoice,
     /// Disconnect another member from voice (server moderation).
-    DisconnectVoiceMember { target_user_id: Uuid },
+    DisconnectVoiceMember {
+        target_user_id: Uuid,
+        #[serde(default)]
+        reason: Option<String>,
+    },
+    /// Move another member to a voice channel in the same server.
+    MoveVoiceMember {
+        target_user_id: Uuid,
+        channel_id: Uuid,
+        #[serde(default)]
+        reason: Option<String>,
+    },
     /// Update voice controls.
     SetVoiceControl {
         #[serde(default)]
@@ -192,6 +256,8 @@ pub enum WsClientMessage {
         deafened: bool,
         screen_sharing: bool,
         camera_on: bool,
+        #[serde(default)]
+        reason: Option<String>,
     },
     /// Opt in or out of receiving an active participant's screen share.
     SetScreenShareWatching {

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -9,6 +9,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use dashmap::DashMap;
+use futures::SinkExt;
 use http_body_util::BodyExt;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -22,6 +23,7 @@ use tokio::sync::broadcast;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tower::ServiceExt;
 use uuid::Uuid;
 use voxpery_server::{
@@ -979,7 +981,7 @@ async fn default_voxpery_server_has_moderator_role_after_register() {
     .expect("moderator permissions query should succeed");
 
     assert_eq!(
-        moderator_permissions, 7024,
+        moderator_permissions, 15216,
         "default Voxpery Moderator role should use recommended default permissions"
     );
 
@@ -1467,7 +1469,7 @@ async fn create_server_seeds_recommended_moderator_permissions() {
     .expect("moderator role should exist for newly created server");
 
     assert_eq!(
-        moderator_permissions, 7024,
+        moderator_permissions, 15216,
         "new server Moderator role should use recommended default permissions"
     );
 
@@ -3885,6 +3887,164 @@ async fn websocket_rejects_query_token_but_accepts_protocol_token() {
         .await
         .expect("protocol token websocket must connect");
     assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn voice_moderation_is_audited_and_queryable_with_permission_and_pagination() {
+    let Some(_) = test_db_url() else {
+        eprintln!("SKIP: DATABASE_URL not set");
+        return;
+    };
+    let (mut app, state) = setup_app().await;
+
+    let owner_suffix = Uuid::new_v4();
+    let (owner_token, _) = register_user(
+        &mut app,
+        &format!("voice-audit-owner-{owner_suffix}@example.com"),
+        &format!("voice_audit_owner_{}", owner_suffix.as_u128() % 1_000_000),
+        test_credential("owner"),
+    )
+    .await;
+    let owner_auth = format!("Bearer {owner_token}");
+    let (server_id, _, invite_code) = create_server_with_default_text_channel(
+        &mut app,
+        &state,
+        &owner_auth,
+        "Voice Audit Server",
+    )
+    .await;
+
+    let target_suffix = Uuid::new_v4();
+    let (target_token, target_user_id) = register_user(
+        &mut app,
+        &format!("voice-audit-target-{target_suffix}@example.com"),
+        &format!("voice_audit_target_{}", target_suffix.as_u128() % 1_000_000),
+        test_credential("target"),
+    )
+    .await;
+    let target_auth = format!("Bearer {target_token}");
+    let join_request = Request::builder()
+        .method("POST")
+        .uri("/api/servers/join")
+        .header("Authorization", &target_auth)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "invite_code": invite_code })).unwrap(),
+        ))
+        .unwrap();
+    let (status, body) = oneshot(&mut app, join_request).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "target join failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let voice_channel_id: Uuid = sqlx::query_scalar(
+        "SELECT id FROM channels WHERE server_id = $1 AND channel_type = 'voice' LIMIT 1",
+    )
+    .bind(server_id)
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    state
+        .voice_sessions
+        .insert(target_user_id, voice_channel_id);
+
+    let ws_app = build_app(state.clone(), vec!["http://localhost:5173".to_string()]);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server_handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, ws_app).await;
+    });
+
+    let mut ws_request = format!("ws://{addr}/ws")
+        .into_client_request()
+        .unwrap();
+    ws_request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        HeaderValue::from_str(&format!("voxpery.auth,{owner_token}")).unwrap(),
+    );
+    ws_request
+        .headers_mut()
+        .insert("Origin", HeaderValue::from_static("http://localhost:5173"));
+    let (mut ws_stream, _) = connect_async(ws_request)
+        .await
+        .expect("owner websocket must connect");
+    ws_stream
+        .send(WsMessage::Text(
+            json!({
+                "type": "SetVoiceControl",
+                "data": {
+                    "target_user_id": target_user_id,
+                    "muted": true,
+                    "deafened": true,
+                    "screen_sharing": false,
+                    "camera_on": false,
+                    "reason": "Repeated voice disruption"
+                }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+    let mut audit_count = 0_i64;
+    for _ in 0..40 {
+        audit_count = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM audit_log WHERE server_id = $1 AND resource_id = $2 AND action LIKE 'voice_member_%'",
+        )
+        .bind(server_id)
+        .bind(target_user_id)
+        .fetch_one(&state.db)
+        .await
+        .unwrap();
+        if audit_count == 2 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert_eq!(audit_count, 2, "mute and deafen must both be audited");
+
+    let unauthorized_request = Request::builder()
+        .uri(format!("/api/servers/{server_id}/audit-log"))
+        .header("Authorization", &target_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = oneshot(&mut app, unauthorized_request).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let filtered_request = Request::builder()
+        .uri(format!(
+            "/api/servers/{server_id}/audit-log?action=voice_member_mute&target_id={target_user_id}&channel_id={voice_channel_id}&limit=1"
+        ))
+        .header("Authorization", &owner_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, filtered_request).await;
+    assert_eq!(status, StatusCode::OK);
+    let page: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(page["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(page["entries"][0]["action"], "voice_member_mute");
+    assert_eq!(page["entries"][0]["resource_id"], target_user_id.to_string());
+    assert_eq!(page["entries"][0]["channel_id"], voice_channel_id.to_string());
+    assert_eq!(page["entries"][0]["reason"], "Repeated voice disruption");
+
+    let paged_request = Request::builder()
+        .uri(format!(
+            "/api/servers/{server_id}/audit-log?target_id={target_user_id}&limit=1"
+        ))
+        .header("Authorization", &owner_auth)
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = oneshot(&mut app, paged_request).await;
+    assert_eq!(status, StatusCode::OK);
+    let page: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(page["entries"].as_array().unwrap().len(), 1);
+    assert!(page["next_before"].as_str().is_some());
 
     server_handle.abort();
 }

--- a/apps/web/e2e/mock-core-api.ts
+++ b/apps/web/e2e/mock-core-api.ts
@@ -242,9 +242,12 @@ export function buildCoreAuditLog(serverId = 'server-core'): AuditLogEntry[] {
       action: 'server_update',
       resource_type: 'server',
       resource_id: serverId,
+      channel_id: null,
+      reason: null,
       details: { name: 'Core Guild' },
       actor_username: 'localuser',
       resource_username: null,
+      channel_name: null,
     },
   ]
 }
@@ -903,7 +906,12 @@ async function handleMockApiRoute(route: Route, state: MockCoreState) {
 
   const auditMatch = pathname.match(/^\/api\/servers\/([^/]+)\/audit-log$/)
   if (auditMatch && method === 'GET') {
-    await json(route, state.auditLogByServerId[auditMatch[1]] ?? buildCoreAuditLog(auditMatch[1]))
+    const action = url.searchParams.get('action')
+    const limit = Math.max(1, Math.min(100, Number(url.searchParams.get('limit') ?? 50)))
+    const entries = (state.auditLogByServerId[auditMatch[1]] ?? buildCoreAuditLog(auditMatch[1]))
+      .filter((entry) => !action || entry.action === action)
+      .slice(0, limit)
+    await json(route, { entries, next_before: null })
     return
   }
 

--- a/apps/web/e2e/server-settings-core-regressions.spec.ts
+++ b/apps/web/e2e/server-settings-core-regressions.spec.ts
@@ -132,6 +132,24 @@ test.describe('mocked server settings UI regressions', () => {
 
   test('keeps community, audit, and safety settings tabs wired to data', async ({ page }) => {
     const state = createServerSettingsState()
+    state.auditLogByServerId[server.id].unshift({
+      id: 'audit-voice-move',
+      at: new Date(Date.UTC(2026, 0, 5, 10)).toISOString(),
+      actor_id: 'user-local',
+      server_id: server.id,
+      action: 'voice_member_move',
+      resource_type: 'member',
+      resource_id: 'friend-01',
+      channel_id: `${server.id}-voice-support`,
+      reason: 'Moved after a warning',
+      details: {
+        source_channel_name: 'General',
+        destination_channel_name: 'Support',
+      },
+      actor_username: 'localuser',
+      resource_username: 'Friend 01',
+      channel_name: 'Support',
+    })
     await installMockCoreApi(page, state)
 
     await openServerSettings(page)
@@ -151,6 +169,13 @@ test.describe('mocked server settings UI regressions', () => {
     expect(state.serverRulesByServerId[server.id].some((rule) => rule.rule_text === 'Keep channels readable.')).toBe(true)
 
     await page.getByRole('button', { name: 'Audit Log' }).click()
+    await expect(page.getByText('Updated server settings')).toBeVisible()
+    await expect(page.getByText('from General to Support')).toBeVisible()
+    await expect(page.getByText('Moved after a warning')).toBeVisible()
+    await page.getByLabel('Filter audit log by action').selectOption('voice_member_move')
+    await expect(page.getByText('Updated server settings')).toBeHidden()
+    await expect(page.getByText('from General to Support')).toBeVisible()
+    await page.getByLabel('Filter audit log by action').selectOption('')
     await expect(page.getByText('Updated server settings')).toBeVisible()
 
     await page.getByRole('button', { name: 'Safety' }).click()

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,7 @@
 export type {
     AuditLogEntry,
+    AuditLogPage,
+    AuditLogQuery,
     AutoModRule,
     AutoModTriggerType,
     AuthResponse,

--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -10,9 +10,26 @@ export interface AuditLogEntry {
     action: string
     resource_type: string
     resource_id: string | null
+    channel_id: string | null
+    reason: string | null
     details: unknown | null
     actor_username: string | null
     resource_username: string | null
+    channel_name: string | null
+}
+
+export interface AuditLogPage {
+    entries: AuditLogEntry[]
+    next_before: string | null
+}
+
+export interface AuditLogQuery {
+    action?: string
+    actorId?: string
+    targetId?: string
+    channelId?: string
+    before?: string
+    limit?: number
 }
 
 // Re-export User as UserPublic for compat

--- a/apps/web/src/api/servers.ts
+++ b/apps/web/src/api/servers.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client'
-import type { AuditLogEntry, AuthToken, AutoModRule, AutoModTriggerType, Channel, MemberInfo, RaidEventEntry, Server, ServerBanEntry, ServerDetail, ServerInvitePreview, ServerOnboardingGuide, ServerReportEntry, ServerRole, ServerRule, ServerTimeoutEntry, UpdateServerOnboardingGuideRequest } from './contracts'
+import type { AuditLogPage, AuditLogQuery, AuthToken, AutoModRule, AutoModTriggerType, Channel, MemberInfo, RaidEventEntry, Server, ServerBanEntry, ServerDetail, ServerInvitePreview, ServerOnboardingGuide, ServerReportEntry, ServerRole, ServerRule, ServerTimeoutEntry, UpdateServerOnboardingGuideRequest } from './contracts'
 
 export const serverApi = {
     getInvitePreview: (inviteCode: string) =>
@@ -39,8 +39,17 @@ export const serverApi = {
     delete: (serverId: string, token: AuthToken) =>
         apiFetch<void>(`/api/servers/${serverId}`, { method: 'DELETE', token }),
 
-    auditLog: (serverId: string, token: AuthToken) =>
-        apiFetch<AuditLogEntry[]>(`/api/servers/${serverId}/audit-log`, { token }),
+    auditLog: (serverId: string, token: AuthToken, query: AuditLogQuery = {}) => {
+        const params = new URLSearchParams()
+        if (query.action) params.set('action', query.action)
+        if (query.actorId) params.set('actor_id', query.actorId)
+        if (query.targetId) params.set('target_id', query.targetId)
+        if (query.channelId) params.set('channel_id', query.channelId)
+        if (query.before) params.set('before', query.before)
+        if (query.limit) params.set('limit', String(query.limit))
+        const suffix = params.size > 0 ? `?${params.toString()}` : ''
+        return apiFetch<AuditLogPage>(`/api/servers/${serverId}/audit-log${suffix}`, { token })
+    },
 
     listBans: (serverId: string, token: AuthToken) =>
         apiFetch<ServerBanEntry[]>(`/api/servers/${serverId}/bans`, { token }),

--- a/apps/web/src/components/ChannelSettingsModal.tsx
+++ b/apps/web/src/components/ChannelSettingsModal.tsx
@@ -262,6 +262,7 @@ export default function ChannelSettingsModal({
         { label: 'Connect to Voice', bit: 1 << 10 }, // PERM_CONNECT_VOICE
         { label: 'Mute Members', bit: 1 << 11 }, // PERM_MUTE_MEMBERS
         { label: 'Deafen Members', bit: 1 << 12 }, // PERM_DEAFEN_MEMBERS
+        { label: 'Move Members', bit: 1 << 13 }, // PERM_MOVE_MEMBERS
     ]
 
     return (

--- a/apps/web/src/components/ChannelSidebar.test.tsx
+++ b/apps/web/src/components/ChannelSidebar.test.tsx
@@ -24,6 +24,13 @@ const voiceChannel: Channel = {
     my_permissions: 1 << 10,
 }
 
+const supportVoiceChannel: Channel = {
+    ...voiceChannel,
+    id: 'voice-2',
+    name: 'Support',
+    position: 1,
+}
+
 const remoteMember: MemberInfo = {
     user_id: 'remote-1',
     username: 'a-very-long-remote-username',
@@ -206,6 +213,37 @@ describe('ChannelSidebar voice media presence', () => {
         expect(screen.getByText('Your playback')).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: 'Send direct message' }))
         expect(onOpenDirectMessage).toHaveBeenCalledWith(remoteMember.user_id)
+    })
+
+    it('moves a voice participant through the permission-gated channel picker', () => {
+        const send = vi.fn()
+        useSocketStore.setState({ send })
+        useAppStore.setState({
+            servers: [server],
+            activeServerId: server.id,
+            channels: [voiceChannel, supportVoiceChannel],
+            members: [remoteMember],
+            voiceStates: { [remoteMember.user_id]: voiceChannel.id },
+            voiceStateServerIds: { [remoteMember.user_id]: server.id },
+        })
+
+        render(
+            <ChannelSidebar
+                channelCategories={['Voice']}
+                canMoveMembers
+            />,
+        )
+
+        fireEvent.contextMenu(screen.getByText(remoteMember.username))
+        fireEvent.change(
+            screen.getByLabelText(`Move ${remoteMember.username} to voice channel`),
+            { target: { value: supportVoiceChannel.id } },
+        )
+
+        expect(send).toHaveBeenCalledWith('MoveVoiceMember', {
+            target_user_id: remoteMember.user_id,
+            channel_id: supportVoiceChannel.id,
+        })
     })
 
     it('opens the shared profile dialog and its member actions from a voice participant context menu', () => {

--- a/apps/web/src/components/ChannelSidebar.tsx
+++ b/apps/web/src/components/ChannelSidebar.tsx
@@ -1,4 +1,4 @@
-import { Hash, Volume2, ChevronDown, Plus, MicOff, VolumeX, Video, Shield, Lock, Settings2, PhoneOff, MessageCircle, UserRound } from 'lucide-react'
+import { Hash, Volume2, ChevronDown, Plus, MicOff, VolumeX, Video, Shield, Lock, Settings2, PhoneOff, MessageCircle, UserRound, MoveRight } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState, type DragEvent } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAuthStore } from '../stores/auth'
@@ -36,6 +36,7 @@ interface ChannelSidebarProps {
     canManageChannels?: boolean
     canMuteMembers?: boolean
     canDeafenMembers?: boolean
+    canMoveMembers?: boolean
     canDisconnectMembers?: boolean
     unreadByChannel?: Record<string, number>
     mentionByChannel?: Record<string, number>
@@ -60,6 +61,7 @@ export default function ChannelSidebar({
     canManageChannels,
     canMuteMembers = false,
     canDeafenMembers = false,
+    canMoveMembers = false,
     canDisconnectMembers = false,
     unreadByChannel = {},
     mentionByChannel = {},
@@ -865,6 +867,10 @@ export default function ChannelSidebar({
                     screenSharing: false,
                     cameraOn: false,
                 }
+                const moveDestinationChannels = channels.filter(
+                    (channel) => channel.channel_type === 'voice' && channel.id !== participantMenu.channelId,
+                )
+                const canMoveTarget = canMoveMembers && moveDestinationChannels.length > 0
                 if (isSelf) return null
                 return (
                     <div
@@ -905,7 +911,7 @@ export default function ChannelSidebar({
                                 </button>
                             </>
                         )}
-                        {!isSelf && (canMuteMembers || canDeafenMembers || canDisconnectMembers) && (
+                        {!isSelf && (canMuteMembers || canDeafenMembers || canMoveTarget || canDisconnectMembers) && (
                             <>
                                 <div className="member-volume-menu-divider" />
                                 <div className="member-volume-menu-section-label member-volume-menu-section-label--moderation">
@@ -956,6 +962,31 @@ export default function ChannelSidebar({
                                     {(targetVoice.serverDeafened ?? false) ? 'Undeafen member (server)' : 'Deafen member (server)'}
                                 </span>
                             </button>
+                        )}
+                        {!isSelf && canMoveTarget && (
+                            <label className="server-context-menu-item member-volume-menu-move">
+                                <span className="member-volume-menu-action-with-icon">
+                                    <MoveRight size={12} />
+                                    Move to voice channel
+                                </span>
+                                <select
+                                    aria-label={`Move ${participantMenu.username} to voice channel`}
+                                    defaultValue=""
+                                    onChange={(event) => {
+                                        if (!event.target.value) return
+                                        sendWs('MoveVoiceMember', {
+                                            target_user_id: participantMenu.userId,
+                                            channel_id: event.target.value,
+                                        })
+                                        setParticipantMenu(null)
+                                    }}
+                                >
+                                    <option value="" disabled>Select channel</option>
+                                    {moveDestinationChannels.map((channel) => (
+                                        <option key={channel.id} value={channel.id}>{channel.name}</option>
+                                    ))}
+                                </select>
+                            </label>
                         )}
                         {!isSelf && canDisconnectMembers && (
                             <button

--- a/apps/web/src/components/ServerRoleEditor.tsx
+++ b/apps/web/src/components/ServerRoleEditor.tsx
@@ -7,6 +7,7 @@ type PermissionBits = {
     managePins: number
     muteMembers: number
     deafenMembers: number
+    moveMembers: number
     kickMembers: number
     banMembers: number
 }
@@ -66,6 +67,7 @@ export default function ServerRoleEditor({
             perms: [
                 { label: 'Mute members', bit: bits.muteMembers },
                 { label: 'Deafen members', bit: bits.deafenMembers },
+                { label: 'Move members', bit: bits.moveMembers },
             ],
         },
         {

--- a/apps/web/src/components/ServerSettingsAuditLog.test.tsx
+++ b/apps/web/src/components/ServerSettingsAuditLog.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AuditLogEntry } from '../api'
+import ServerSettingsAuditLog from './ServerSettingsAuditLog'
+
+const moveEntry: AuditLogEntry = {
+    id: 'audit-1',
+    at: '2026-08-30T10:00:00.000Z',
+    actor_id: 'moderator-1',
+    server_id: 'server-1',
+    action: 'voice_member_move',
+    resource_type: 'member',
+    resource_id: 'member-1',
+    channel_id: 'voice-2',
+    reason: 'Moved after a moderation warning',
+    details: {
+        source_channel_name: 'General',
+        destination_channel_name: 'Support',
+    },
+    actor_username: 'moderator',
+    resource_username: 'member',
+    channel_name: 'Support',
+}
+
+describe('ServerSettingsAuditLog', () => {
+    it('explains structured voice moderation context and reason', () => {
+        render(
+            <ServerSettingsAuditLog
+                entries={[moveEntry]}
+                memberUsernameById={new Map()}
+                actionFilter=""
+                onActionFilterChange={vi.fn()}
+                hasMore={false}
+                loadingMore={false}
+                onLoadMore={vi.fn()}
+            />,
+        )
+
+        expect(screen.getByText('moderator')).toBeVisible()
+        expect(screen.getByText('Moved')).toBeVisible()
+        expect(screen.getByText('member')).toBeVisible()
+        expect(screen.getByText('from General to Support')).toBeVisible()
+        expect(screen.getByText('Moved after a moderation warning')).toBeVisible()
+    })
+
+    it('reports filter changes and requests the next server page', () => {
+        const onActionFilterChange = vi.fn()
+        const onLoadMore = vi.fn()
+        render(
+            <ServerSettingsAuditLog
+                entries={[moveEntry]}
+                memberUsernameById={new Map()}
+                actionFilter=""
+                onActionFilterChange={onActionFilterChange}
+                hasMore
+                loadingMore={false}
+                onLoadMore={onLoadMore}
+            />,
+        )
+
+        fireEvent.change(screen.getByLabelText('Filter audit log by action'), {
+            target: { value: 'voice_member_disconnect' },
+        })
+        expect(onActionFilterChange).toHaveBeenCalledWith('voice_member_disconnect')
+
+        fireEvent.click(screen.getByRole('button', { name: 'Load older entries' }))
+        expect(onLoadMore).toHaveBeenCalledTimes(1)
+    })
+})

--- a/apps/web/src/components/ServerSettingsAuditLog.tsx
+++ b/apps/web/src/components/ServerSettingsAuditLog.tsx
@@ -1,99 +1,184 @@
-import { useMemo, useState } from 'react'
 import type { AuditLogEntry } from '../api'
 
 type ServerSettingsAuditLogProps = {
     entries: AuditLogEntry[]
     memberUsernameById: Map<string, string>
+    actionFilter: string
+    onActionFilterChange: (action: string) => void
+    hasMore: boolean
+    loadingMore: boolean
+    onLoadMore: () => void
 }
 
-const INITIAL_VISIBLE = 50
-const PAGE_SIZE = 50
+const ACTION_OPTIONS = [
+    { value: '', label: 'All actions' },
+    { value: 'voice_member_mute', label: 'Voice: server mute' },
+    { value: 'voice_member_unmute', label: 'Voice: server unmute' },
+    { value: 'voice_member_deafen', label: 'Voice: server deafen' },
+    { value: 'voice_member_undeafen', label: 'Voice: server undeafen' },
+    { value: 'voice_member_disconnect', label: 'Voice: disconnect' },
+    { value: 'voice_member_move', label: 'Voice: move' },
+]
 
-function toAuditText(entry: AuditLogEntry, targetName: string | null, details: Record<string, unknown> | null | undefined) {
+function textDetail(details: Record<string, unknown> | null | undefined, key: string) {
+    const value = details?.[key]
+    return typeof value === 'string' && value.trim() ? value : null
+}
+
+function toAuditText(
+    entry: AuditLogEntry,
+    targetName: string | null,
+    details: Record<string, unknown> | null | undefined,
+) {
     let actionText = entry.action
     let targetDesc = targetName
+    const channelName = entry.channel_name ?? textDetail(details, 'channel_name')
+    let contextText = channelName ? `in ${channelName}` : null
 
     switch (entry.action) {
         case 'channel_create':
             actionText = 'Created channel'
-            targetDesc = details?.name ? `#${details.name}` : 'Unknown Channel'
+            targetDesc = textDetail(details, 'name') ? `#${textDetail(details, 'name')}` : 'Unknown Channel'
+            contextText = null
             break
         case 'channel_delete':
             actionText = 'Deleted channel'
-            targetDesc = details?.name ? `#${details.name}` : 'Unknown Channel'
+            targetDesc = textDetail(details, 'name') ? `#${textDetail(details, 'name')}` : 'Unknown Channel'
+            contextText = null
             break
-        case 'channel_rename':
+        case 'channel_rename': {
             actionText = 'Renamed channel'
-            targetDesc = details?.old_name && details?.new_name ? `#${details.old_name} → #${details.new_name}` : 'Unknown Channel'
+            const oldName = textDetail(details, 'old_name')
+            const newName = textDetail(details, 'new_name')
+            targetDesc = oldName && newName ? `#${oldName} to #${newName}` : 'Unknown Channel'
+            contextText = null
             break
+        }
         case 'server_update':
             actionText = 'Updated server settings'
             targetDesc = null
+            contextText = null
             break
         case 'member_kick':
-            actionText = 'Kicked member'
+            actionText = 'Kicked'
             break
         case 'member_role_change':
-            actionText = 'Updated member roles'
+            actionText = 'Updated roles for'
             break
         case 'message_pin':
             actionText = 'Pinned a message'
-            targetDesc = details?.channel_id ? 'in a channel' : null
+            targetDesc = null
             break
         case 'message_unpin':
             actionText = 'Unpinned a message'
-            targetDesc = details?.channel_id ? 'in a channel' : null
+            targetDesc = null
             break
+        case 'voice_member_mute':
+            actionText = 'Server muted'
+            break
+        case 'voice_member_unmute':
+            actionText = 'Removed server mute from'
+            break
+        case 'voice_member_deafen':
+            actionText = 'Server deafened'
+            break
+        case 'voice_member_undeafen':
+            actionText = 'Removed server deafen from'
+            break
+        case 'voice_member_disconnect':
+            actionText = 'Disconnected'
+            break
+        case 'voice_member_move': {
+            actionText = 'Moved'
+            const source = textDetail(details, 'source_channel_name') ?? 'Unknown channel'
+            const destination = textDetail(details, 'destination_channel_name')
+                ?? entry.channel_name
+                ?? 'Unknown channel'
+            contextText = `from ${source} to ${destination}`
+            break
+        }
     }
 
-    return { actionText, targetDesc }
+    return { actionText, targetDesc, contextText }
 }
 
-export default function ServerSettingsAuditLog({ entries, memberUsernameById }: ServerSettingsAuditLogProps) {
-    const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE)
-
-    const visibleEntries = useMemo(
-        () => entries.slice(0, Math.min(visibleCount, entries.length)),
-        [entries, visibleCount]
-    )
-
-    const hasMore = visibleEntries.length < entries.length
-
+export default function ServerSettingsAuditLog({
+    entries,
+    memberUsernameById,
+    actionFilter,
+    onActionFilterChange,
+    hasMore,
+    loadingMore,
+    onLoadMore,
+}: ServerSettingsAuditLogProps) {
     return (
         <>
-            <div className="server-settings-audit-list">
-                {visibleEntries.map((entry) => {
-                    const actorName = entry.actor_username ?? memberUsernameById.get(entry.actor_id) ?? 'Unknown User'
-                    const targetName = entry.resource_username ?? (entry.resource_id ? memberUsernameById.get(entry.resource_id) ?? null : null)
-                    const details = entry.details as Record<string, unknown> | null | undefined
-                    const { actionText, targetDesc } = toAuditText(entry, targetName, details)
-
-                    return (
-                        <div key={entry.id} className="server-settings-audit-row">
-                            <div className="server-settings-audit-row__top">
-                                <div className="server-settings-audit-row__summary">
-                                    <strong className="server-settings-audit-row__actor">{actorName}</strong>
-                                    <span className="server-settings-audit-row__action">{actionText}</span>
-                                    {targetDesc && (
-                                        <strong className="server-settings-audit-row__target">{targetDesc}</strong>
-                                    )}
-                                </div>
-                                <span className="server-settings-audit-row__time">
-                                    {new Date(entry.at).toLocaleString()}
-                                </span>
-                            </div>
-                        </div>
-                    )
-                })}
+            <div className="server-settings-audit-toolbar">
+                <label>
+                    <span>Action</span>
+                    <select
+                        aria-label="Filter audit log by action"
+                        value={actionFilter}
+                        onChange={(event) => onActionFilterChange(event.target.value)}
+                    >
+                        {ACTION_OPTIONS.map((option) => (
+                            <option key={option.value || 'all'} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
             </div>
+
+            {entries.length === 0 ? (
+                <div className="server-settings-empty-state">No audit entries match this filter.</div>
+            ) : (
+                <div className="server-settings-audit-list">
+                    {entries.map((entry) => {
+                        const actorName = entry.actor_username ?? memberUsernameById.get(entry.actor_id) ?? 'Unknown User'
+                        const targetName = entry.resource_username
+                            ?? (entry.resource_id ? memberUsernameById.get(entry.resource_id) ?? null : null)
+                        const details = entry.details as Record<string, unknown> | null | undefined
+                        const { actionText, targetDesc, contextText } = toAuditText(entry, targetName, details)
+
+                        return (
+                            <div key={entry.id} className="server-settings-audit-row">
+                                <div className="server-settings-audit-row__top">
+                                    <div className="server-settings-audit-row__summary">
+                                        <strong className="server-settings-audit-row__actor">{actorName}</strong>
+                                        <span className="server-settings-audit-row__action">{actionText}</span>
+                                        {targetDesc && (
+                                            <strong className="server-settings-audit-row__target">{targetDesc}</strong>
+                                        )}
+                                        {contextText && (
+                                            <span className="server-settings-audit-row__context">{contextText}</span>
+                                        )}
+                                    </div>
+                                    <time className="server-settings-audit-row__time" dateTime={entry.at}>
+                                        {new Date(entry.at).toLocaleString()}
+                                    </time>
+                                </div>
+                                {entry.reason && (
+                                    <div className="server-settings-audit-row__reason">
+                                        <span>Reason</span>
+                                        <p>{entry.reason}</p>
+                                    </div>
+                                )}
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+
             {hasMore && (
                 <div className="server-settings-audit-actions">
                     <button
                         type="button"
                         className="btn btn-secondary btn-sm"
-                        onClick={() => setVisibleCount((prev) => prev + PAGE_SIZE)}
+                        onClick={onLoadMore}
+                        disabled={loadingMore}
                     >
-                        Load older entries
+                        {loadingMore ? 'Loading…' : 'Load older entries'}
                     </button>
                 </div>
             )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6732,6 +6732,29 @@ body {
   gap: 6px;
 }
 
+.member-volume-menu-move {
+  display: grid;
+  gap: 6px;
+  cursor: default;
+}
+
+.member-volume-menu-move select {
+  width: 100%;
+  min-width: 0;
+  height: 28px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0 8px;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  font: inherit;
+}
+
+.member-volume-menu-move select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
 .member-volume-menu .member-volume-menu-username {
   padding: 7px 10px 5px;
   margin: 0;
@@ -12104,6 +12127,37 @@ a.community-open-btn:hover {
   background: rgba(0, 0, 0, 0.1);
 }
 
+.server-settings-audit-toolbar {
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.server-settings-audit-toolbar label {
+  display: grid;
+  gap: 4px;
+  min-width: min(220px, 100%);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.server-settings-audit-toolbar select {
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0 10px;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  font: inherit;
+}
+
+.server-settings-audit-toolbar select:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 .server-settings-audit-row {
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-color);
@@ -12133,13 +12187,33 @@ a.community-open-btn:hover {
 }
 
 .server-settings-audit-row__action,
-.server-settings-audit-row__time {
+.server-settings-audit-row__time,
+.server-settings-audit-row__context {
   color: var(--text-muted);
 }
 
 .server-settings-audit-row__time {
   font-size: 11px;
   white-space: nowrap;
+}
+
+.server-settings-audit-row__reason {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  align-items: baseline;
+  color: var(--text-secondary);
+}
+
+.server-settings-audit-row__reason span {
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.server-settings-audit-row__reason p {
+  margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .server-settings-audit-row:last-child {

--- a/apps/web/src/pages/AppLayout.tsx
+++ b/apps/web/src/pages/AppLayout.tsx
@@ -134,6 +134,7 @@ const PERM_MANAGE_PINS = 1 << 9
 const PERM_CONNECT_VOICE = 1 << 10
 const PERM_MUTE_MEMBERS = 1 << 11
 const PERM_DEAFEN_MEMBERS = 1 << 12
+const PERM_MOVE_MEMBERS = 1 << 13
 
 const LAST_CHANNELS_STORAGE_KEY = 'voxpery-last-channel-ids'
 
@@ -474,7 +475,11 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     const [onboardingError, setOnboardingError] = useState<string | null>(null)
     const [auditLogEntries, setAuditLogEntries] = useState<AuditLogEntry[] | null>(null)
     const [auditLogLoading, setAuditLogLoading] = useState(false)
+    const [auditLogLoadingMore, setAuditLogLoadingMore] = useState(false)
     const [auditLogError, setAuditLogError] = useState<string | null>(null)
+    const [auditLogActionFilter, setAuditLogActionFilter] = useState('')
+    const [auditLogNextBefore, setAuditLogNextBefore] = useState<string | null>(null)
+    const auditLogRequestSequence = useRef(0)
     const [reportEntries, setReportEntries] = useState<ServerReportEntry[] | null>(null)
     const [reportEntriesLoading, setReportEntriesLoading] = useState(false)
     const [reportEntriesError, setReportEntriesError] = useState<string | null>(null)
@@ -1258,11 +1263,30 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                     store.setVoiceCamera(user_id, !!camera_on)
                     break
                 }
+                case 'VoiceMemberMoveRequested': {
+                    const sourceChannelId = d.source_channel_id as string | undefined
+                    const channelId = d.channel_id as string | undefined
+                    if (!sourceChannelId || !channelId) break
+                    if (useAppStore.getState().joinedVoiceChannelId !== sourceChannelId) break
+                    const joinVoice = (window as Window & {
+                        __voxperyJoinVoice?: (targetChannelId: string) => void
+                    }).__voxperyJoinVoice
+                    if (joinVoice) {
+                        joinVoice(channelId)
+                    } else {
+                        pushToast({
+                            level: 'error',
+                            title: 'Voice move failed',
+                            message: 'The voice client is not ready to change channels.',
+                        })
+                    }
+                    break
+                }
             }
         } catch (err) {
             console.error('AppLayout WS handler error:', err)
         }
-    }, [channels, channelsByServerId, incrementServerMention, incrementServerUnread, isViewActive, mutedChannelIds, mutedServerIds, setActiveChannel, setActiveServer, setChannels, user?.id, user?.status, user?.username])
+    }, [channels, channelsByServerId, incrementServerMention, incrementServerUnread, isViewActive, mutedChannelIds, mutedServerIds, pushToast, setActiveChannel, setActiveServer, setChannels, user?.id, user?.status, user?.username])
 
     // Subscribe to WebSocket events (connection is managed globally by AppShell)
     useEffect(() => {
@@ -1686,6 +1710,8 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
         hasManageServer || (activePerms & PERM_MUTE_MEMBERS) === PERM_MUTE_MEMBERS
     const canDeafenMembers =
         hasManageServer || (activePerms & PERM_DEAFEN_MEMBERS) === PERM_DEAFEN_MEMBERS
+    const canMoveMembers =
+        hasManageServer || (activePerms & PERM_MOVE_MEMBERS) === PERM_MOVE_MEMBERS
     const canDisconnectMembers = hasManageServer || canMuteMembers || canDeafenMembers
     const canBanMembers = (activePerms & PERM_BAN_MEMBERS) === PERM_BAN_MEMBERS
     const canManageBans = canBanMembers
@@ -1918,22 +1944,63 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
     useEffect(() => {
         if (!showServerSettings || serverSettingsTab !== 'audit') return
         if (!isLoggedIn || !settingsServerId) return
+        const requestSequence = ++auditLogRequestSequence.current
         const load = async () => {
             setAuditLogLoading(true)
+            setAuditLogLoadingMore(false)
             setAuditLogError(null)
+            setAuditLogEntries(null)
+            setAuditLogNextBefore(null)
             try {
-                const entries = await serverApi.auditLog(settingsServerId, token)
-                setAuditLogEntries(entries)
+                const page = await serverApi.auditLog(settingsServerId, token, {
+                    action: auditLogActionFilter || undefined,
+                    limit: 50,
+                })
+                if (auditLogRequestSequence.current !== requestSequence) return
+                setAuditLogEntries(page.entries)
+                setAuditLogNextBefore(page.next_before)
             } catch (err) {
+                if (auditLogRequestSequence.current !== requestSequence) return
                 const message =
                     err instanceof Error ? err.message : 'Failed to load audit log.'
                 setAuditLogError(message)
             } finally {
-                setAuditLogLoading(false)
+                if (auditLogRequestSequence.current === requestSequence) {
+                    setAuditLogLoading(false)
+                }
             }
         }
         void load()
-    }, [showServerSettings, serverSettingsTab, isLoggedIn, settingsServerId, token])
+        return () => {
+            if (auditLogRequestSequence.current === requestSequence) {
+                auditLogRequestSequence.current += 1
+            }
+        }
+    }, [showServerSettings, serverSettingsTab, isLoggedIn, settingsServerId, token, auditLogActionFilter])
+
+    const loadOlderAuditLog = useCallback(async () => {
+        if (!settingsServerId || !auditLogNextBefore || auditLogLoadingMore) return
+        const requestSequence = auditLogRequestSequence.current
+        setAuditLogLoadingMore(true)
+        setAuditLogError(null)
+        try {
+            const page = await serverApi.auditLog(settingsServerId, token, {
+                action: auditLogActionFilter || undefined,
+                before: auditLogNextBefore,
+                limit: 50,
+            })
+            if (auditLogRequestSequence.current !== requestSequence) return
+            setAuditLogEntries((current) => [...(current ?? []), ...page.entries])
+            setAuditLogNextBefore(page.next_before)
+        } catch (err) {
+            if (auditLogRequestSequence.current !== requestSequence) return
+            setAuditLogError(err instanceof Error ? err.message : 'Failed to load older audit entries.')
+        } finally {
+            if (auditLogRequestSequence.current === requestSequence) {
+                setAuditLogLoadingMore(false)
+            }
+        }
+    }, [auditLogActionFilter, auditLogLoadingMore, auditLogNextBefore, settingsServerId, token])
 
     useEffect(() => {
         if (!showServerSettings || serverSettingsTab !== 'safety' || safetySettingsTab !== 'reports' || !canViewReports) return
@@ -2077,7 +2144,8 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
             PERM_MANAGE_PINS |
             PERM_CONNECT_VOICE |
             PERM_MUTE_MEMBERS |
-            PERM_DEAFEN_MEMBERS
+            PERM_DEAFEN_MEMBERS |
+            PERM_MOVE_MEMBERS
 
         if (isFullAdmin) {
             if (checked) {
@@ -2992,6 +3060,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                 canManageChannels={canManageChannels}
                 canMuteMembers={canMuteMembers}
                 canDeafenMembers={canDeafenMembers}
+                canMoveMembers={canMoveMembers}
                 canDisconnectMembers={canDisconnectMembers}
                 unreadByChannel={serverUnreadByChannel}
                 mentionByChannel={serverMentionsByChannel}
@@ -3701,16 +3770,15 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                             Loading audit log…
                                                         </div>
                                                     )}
-                                                    {!auditLogLoading && auditLogEntries && auditLogEntries.length === 0 && (
-                                                        <div className="server-settings-empty-state">
-                                                            No audit entries yet.
-                                                        </div>
-                                                    )}
-                                                    {!auditLogLoading && auditLogEntries && auditLogEntries.length > 0 && (
+                                                    {!auditLogLoading && auditLogEntries && (
                                                         <ServerSettingsAuditLog
-                                                            key={auditLogEntries[0]?.id ?? 'empty-audit'}
                                                             entries={auditLogEntries}
                                                             memberUsernameById={memberUsernameById}
+                                                            actionFilter={auditLogActionFilter}
+                                                            onActionFilterChange={setAuditLogActionFilter}
+                                                            hasMore={auditLogNextBefore !== null}
+                                                            loadingMore={auditLogLoadingMore}
+                                                            onLoadMore={() => void loadOlderAuditLog()}
                                                         />
                                                     )}
                                                 </section>
@@ -3794,6 +3862,7 @@ export default function AppLayout({ skipServerSidebar = false, isViewActive }: A
                                                                     managePins: PERM_MANAGE_PINS,
                                                                     muteMembers: PERM_MUTE_MEMBERS,
                                                                     deafenMembers: PERM_DEAFEN_MEMBERS,
+                                                                    moveMembers: PERM_MOVE_MEMBERS,
                                                                     kickMembers: PERM_KICK_MEMBERS,
                                                                     banMembers: PERM_BAN_MEMBERS,
                                                                 }}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -87,6 +87,6 @@ export interface SignalingMessage {
 }
 
 export interface WsEvent {
-    type: 'NewMessage' | 'DmRead' | 'MessageDeleted' | 'MessageUpdated' | 'Typing' | 'PresenceUpdate' | 'FriendUpdate' | 'MemberJoined' | 'MemberLeft' | 'MemberRoleUpdated' | 'ServerRolesUpdated' | 'ServerChannelsUpdated' | 'VoiceStateUpdate' | 'VoiceControlUpdate' | 'ScreenShareViewerUpdate' | 'Signal' | 'Pong';
+    type: 'NewMessage' | 'DmRead' | 'MessageDeleted' | 'MessageUpdated' | 'Typing' | 'PresenceUpdate' | 'FriendUpdate' | 'MemberJoined' | 'MemberLeft' | 'MemberRoleUpdated' | 'ServerRolesUpdated' | 'ServerChannelsUpdated' | 'VoiceStateUpdate' | 'VoiceControlUpdate' | 'VoiceMemberMoveRequested' | 'ScreenShareViewerUpdate' | 'Signal' | 'Pong';
     data: unknown;
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -34,6 +34,7 @@ Role/permission system is bitmask-based (`apps/server/src/services/permissions.r
 - `1 << 10` `CONNECT_VOICE`
 - `1 << 11` `MUTE_MEMBERS`
 - `1 << 12` `DEAFEN_MEMBERS`
+- `1 << 13` `MOVE_MEMBERS`
 
 Important behavior:
 
@@ -150,6 +151,10 @@ Notes:
 - `GET /api/servers/:server_id/bans` (requires `BAN_MEMBERS`)
 - `DELETE /api/servers/:server_id/bans/:user_id` (requires `BAN_MEMBERS`)
 - `GET /api/servers/:server_id/audit-log` (requires `VIEW_AUDIT_LOG`)
+  - Optional exact filters: `action`, `actor_id`, `target_id`, and `channel_id`.
+  - Cursor pagination uses `before=<audit-entry-id>` and `limit` from 1 to 100 (default 50).
+  - Returns `{ entries, next_before }`, newest first. Pass `next_before` as the next request's `before` value.
+  - Voice moderation entries identify the actor, target member, channel, action, and optional reason.
 - `GET /api/servers/:server_id/automod-rules` (requires `MANAGE_MESSAGES`)
 - `POST /api/servers/:server_id/automod-rules` (requires `MANAGE_MESSAGES`)
 - `PATCH /api/servers/:server_id/automod-rules/:rule_id` (requires `MANAGE_MESSAGES`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added permission-gated voice member moves and structured moderation audit entries for server mute, deafen, disconnect, and move actions, including target, channel, optional reason, filters, and cursor pagination.
+
 ### Fixed
 - Kept remote microphone tracks locally suppressed when a sender unmutes, republishes, or reconnects after the listener has deafened, without muting independently watched screen-share audio.
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -157,7 +157,8 @@ Uniqueness (case-insensitive):
 
 ### `audit_log`
 
-- `id`, `at`, `actor_id`, `server_id`, `action`, `resource_type`, `resource_id`, `details`
+- `id`, `at`, `actor_id`, `server_id`, `action`, `resource_type`, `resource_id`, `channel_id`, `reason`, `details`
+- Voice moderation rows use `resource_id` for the target member and `channel_id` for the affected or destination voice channel. Move details preserve both source and destination channel names/IDs.
 
 ### `server_bans`
 
@@ -279,6 +280,7 @@ All migrations currently present:
 - `045_privacy_compliance.sql`
 - `046_user_profile_fields.sql`
 - `047_versioned_legal_consent.sql`
+- `048_voice_moderation_audit.sql`
 
 ### Privacy audit log
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -378,7 +378,7 @@ CI validates the nginx and Tauri policy files statically. Release smoke validate
 
 ## Audit Logging
 
-Audit logging is implemented for core moderation/server actions (for example role updates, kick, ban, and server settings updates) and exposed via server audit endpoints.
+Audit logging is implemented for core moderation/server actions (for example role updates, kick, ban, server settings updates, and server-enforced voice mute/deafen/disconnect/move) and exposed via permission-gated server audit endpoints. Voice moderation changes are rejected when their audit record cannot be persisted, and records include the actor, target member, channel context, and optional bounded reason.
 
 Critical role replacement and channel deletion flows lock their server-scoped database state, re-check authorization on the transaction connection, and commit the mutation with its audit record. External WebSocket and voice reconciliation side effects run after commit so delivery failures do not create ambiguous rollback responses for already-persisted changes.
 

--- a/docs/WEBSOCKET_EVENTS.md
+++ b/docs/WEBSOCKET_EVENTS.md
@@ -99,7 +99,8 @@ Authorization:
     "muted": false,
     "deafened": false,
     "screen_sharing": false,
-    "camera_on": false
+    "camera_on": false,
+    "reason": "optional moderator reason"
   }
 }
 ```
@@ -107,7 +108,37 @@ Authorization:
 Behavior:
 
 - Without `target_user_id`, updates self voice controls.
-- With `target_user_id`, server moderation controls apply (`MUTE_MEMBERS` / `DEAFEN_MEMBERS`) and only when both users are in the same voice channel.
+- With `target_user_id`, server moderation controls apply (`MUTE_MEMBERS` / `DEAFEN_MEMBERS`). The target must be active in voice and lower in the server role hierarchy.
+- A moderator reason is optional and limited to 500 characters. Server mute/deafen state is not changed unless the corresponding audit entry is persisted.
+
+### `DisconnectVoiceMember`
+
+```json
+{
+  "type": "DisconnectVoiceMember",
+  "data": {
+    "target_user_id": "uuid",
+    "reason": "optional moderator reason"
+  }
+}
+```
+
+Requires `MUTE_MEMBERS`, `DEAFEN_MEMBERS`, or `MANAGE_SERVER`. The target must be active in voice and lower in the role hierarchy. The affected channel and optional reason are recorded before the voice session is revoked.
+
+### `MoveVoiceMember`
+
+```json
+{
+  "type": "MoveVoiceMember",
+  "data": {
+    "target_user_id": "uuid",
+    "channel_id": "destination-voice-channel-uuid",
+    "reason": "optional moderator reason"
+  }
+}
+```
+
+Requires `MOVE_MEMBERS` or `MANAGE_SERVER`. Source and destination must be different voice channels in the same server, the target must be able to join the destination, and role hierarchy applies. A successful request is audited and delivered only to the target user.
 
 ### `Signal`
 
@@ -167,6 +198,9 @@ Legacy custom signaling event.
     - `screen_sharing`
     - `camera_on`
     - `server_id`
+- `VoiceMemberMoveRequested`
+  - Targeted event sent only to the moved member after the server validates and audits a `MoveVoiceMember` request.
+  - Includes `source_channel_id`, `channel_id`, `server_id`, and `actor_id`; only a client whose active voice session matches the source switches its LiveKit room.
 - `ScreenShareViewerUpdate`
   - Reports an opt-in viewer's current watch state for one active screen-share publisher.
   - Includes `viewer_id`, `publisher_id`, `channel_id`, `server_id`, and `watching`.


### PR DESCRIPTION
## Summary

- persist structured audit entries for voice mute, unmute, deafen, undeafen,
  disconnect, and member move actions
- add the `MOVE_MEMBERS` permission and permission-aware voice channel move flow
- include actor, target, channel, timestamp, and optional reason context
- add server-side audit log filtering and cursor pagination
- improve the Audit Log UI with readable voice moderation descriptions,
  action filters, reasons, and channel context
- add migration 048, regression coverage, and API/database/security/WebSocket docs

## Testing

- `cargo check --manifest-path apps/server/Cargo.toml --locked`
- `cargo test --manifest-path apps/server/Cargo.toml --lib --locked`
- `cargo test --manifest-path apps/server/Cargo.toml --test integration --no-run --locked`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run test:e2e:ui-smoke`
- `graphify update .`

## Migration

Adds migration `048_voice_moderation_audit.sql` for structured channel and
reason fields plus audit query indexes.