### PR TITLE
chore: harden v0.2.14 release checks

### DIFF
--- a/apps/web/src/pages/AboutPage.test.tsx
+++ b/apps/web/src/pages/AboutPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { releaseApi } from '../api'
@@ -16,12 +16,13 @@ vi.mock('../api', async (importOriginal) => {
 })
 
 afterEach(() => {
+  cleanup()
   useAuthStore.setState({ token: null, user: null, loggingOut: false })
   vi.mocked(releaseApi.getLatest).mockReset()
 })
 
 describe('AboutPage', () => {
-  it('presents the hosted and self-hosted paths to new visitors', () => {
+  it('presents the hosted and self-hosted paths to new visitors', async () => {
     vi.mocked(releaseApi.getLatest).mockResolvedValue({
       tag: 'v0.2.3',
       html_url: 'https://github.com/emircanagac/voxpery/releases/tag/v0.2.3',
@@ -65,9 +66,10 @@ describe('AboutPage', () => {
     expect(screen.getByRole('link', { name: 'Privacy Notice' })).toHaveAttribute('href', '/privacy')
     expect(screen.getByRole('link', { name: 'KVKK Notice' })).toHaveAttribute('href', '/kvkk')
     expect(screen.getByRole('link', { name: 'Terms of Service' })).toHaveAttribute('href', '/terms')
+    expect(await screen.findByText(/Latest release: v0\.2\.3/)).toBeInTheDocument()
   })
 
-  it('routes authenticated visitors back into the app', () => {
+  it('routes authenticated visitors back into the app', async () => {
     vi.mocked(releaseApi.getLatest).mockRejectedValue(new Error('release unavailable'))
     useAuthStore.setState({
       token: 'test-token',
@@ -90,5 +92,6 @@ describe('AboutPage', () => {
     expect(screen.getByRole('link', { name: 'Go to app' })).toHaveAttribute('href', '/social')
     expect(screen.getByRole('link', { name: /open voxpery/i })).toHaveAttribute('href', '/social')
     expect(screen.queryByRole('link', { name: 'Login' })).not.toBeInTheDocument()
+    await waitFor(() => expect(releaseApi.getLatest).toHaveBeenCalledTimes(1))
   })
 })

--- a/apps/web/src/pages/AuthNotificationPermission.test.tsx
+++ b/apps/web/src/pages/AuthNotificationPermission.test.tsx
@@ -1,7 +1,9 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { User } from '../api'
+import { useAuthStore } from '../stores/auth'
 import { useFeatureStore } from '../stores/features'
 import LoginPage from './LoginPage'
 import RegisterPage from './RegisterPage'
@@ -48,6 +50,7 @@ describe('auth notification permission behavior', () => {
     vi.clearAllMocks()
     localStorage.clear()
     sessionStorage.clear()
+    useAuthStore.setState({ token: null, user: null, loggingOut: false })
     useFeatureStore.setState({
       features: {
         google_oauth_enabled: false,
@@ -73,6 +76,8 @@ describe('auth notification permission behavior', () => {
   })
 
   afterEach(() => {
+    cleanup()
+    useAuthStore.setState({ token: null, user: null, loggingOut: false })
     useFeatureStore.setState({ features: null, loading: false, error: null })
     if (originalNotificationDescriptor) {
       Object.defineProperty(window, 'Notification', originalNotificationDescriptor)
@@ -82,38 +87,34 @@ describe('auth notification permission behavior', () => {
   })
 
   it('does not request notification permission during login', async () => {
+    const user = userEvent.setup()
     renderAuthPage('login')
 
-    fireEvent.change(screen.getByPlaceholderText('you@example.com or your_username'), {
-      target: { value: 'auth@example.test' },
-    })
-    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
-      target: { value: 'password-123' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
+    await user.type(screen.getByPlaceholderText('you@example.com or your_username'), 'auth@example.test')
+    await user.type(screen.getByPlaceholderText('••••••••'), 'password-123')
+    await user.click(screen.getByRole('button', { name: 'Sign In' }))
 
     await waitFor(() => expect(authApiMocks.login).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Sign In' })).toBeEnabled())
     expect(requestPermission).not.toHaveBeenCalled()
   })
 
   it('does not request notification permission during registration', async () => {
+    const user = userEvent.setup()
     renderAuthPage('register')
 
-    fireEvent.change(screen.getByPlaceholderText('your_username'), {
-      target: { value: 'auth_user' },
-    })
-    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'auth@example.test' },
-    })
+    await user.type(screen.getByPlaceholderText('your_username'), 'auth_user')
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'auth@example.test')
     const passwordInputs = screen.getAllByPlaceholderText('••••••••')
-    fireEvent.change(passwordInputs[0], { target: { value: 'password-123' } })
-    fireEvent.change(passwordInputs[1], { target: { value: 'password-123' } })
+    await user.type(passwordInputs[0], 'password-123')
+    await user.type(passwordInputs[1], 'password-123')
     const legalCheckboxes = screen.getAllByRole('checkbox')
-    fireEvent.click(legalCheckboxes[0])
-    fireEvent.click(legalCheckboxes[1])
-    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+    await user.click(legalCheckboxes[0])
+    await user.click(legalCheckboxes[1])
+    await user.click(screen.getByRole('button', { name: 'Sign Up' }))
 
     await waitFor(() => expect(authApiMocks.register).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Sign Up' })).toBeEnabled())
     expect(requestPermission).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import path from 'node:path'
 
 export default defineConfig({
   plugins: [react()],
@@ -23,7 +23,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
 })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved the desktop watched screen-share mini player to the upper-right content area while keeping its mobile placement above the bottom dock.
 - Replaced inline Friends message and removal controls with one compact more-actions menu, matching the right-click actions and supporting touch devices.
 - Refocused release web E2E coverage on isolated core UI regressions, removed legacy stateful browser suites that duplicated backend integration coverage, and enabled Redis-backed rate-limit tests in CI.
+- Removed the Vite native-config warning and made asynchronous auth and landing-page tests settle before cleanup, keeping release CI output deterministic.
 
 ### Fixed
 - Kept remote microphone tracks locally suppressed when a sender unmutes, republishes, or reconnects after the listener has deafened, without muting independently watched screen-share audio.

--- a/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_SMOKE_TEST_CHECKLIST.md
@@ -44,7 +44,14 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Release deploy guardrails verified registry presence for both images, three consecutive origin stack health checks, public web `/healthz`, immutable image tag format, stable entry-point cache policy, and the exact `/version.json` image tag.
 - [ ] Production top bar shows the expected `Beta` version badge tag (`vX.Y.Z` or `sha-<commit>`).
 
-## 3) Web Smoke Tests (mandatory)
+## 3) Focused Interaction Regression Pass (when affected)
+
+- [ ] While watching a remote screen share, open channel chat and Social/DM: the mini player remains in the upper-right without covering navigation, returns to the correct voice channel when opened, stops only the viewer subscription when closed, and disappears when the publisher stops or the viewer leaves voice. Repeat once at a narrow mobile viewport.
+- [ ] With at least 12 voice participants plus an active camera and screen share, desktop and mobile grids remain inside the viewport, preserve the shared-screen priority, and do not overlap the call bar or each other.
+- [ ] In Friends and Direct Messages, open actions through both right click and the three-dot button near every viewport edge: menus stay inside their owning panel, keyboard focus starts on the first action, and only context-appropriate profile/message/friend/DM actions appear.
+- [ ] In the desktop app, verify global push-to-talk while Voxpery is focused, unfocused, minimized, and hidden in the tray: hold transmits, release stops, and focus loss, channel leave, shortcut changes, or switching to Voice Activity never leaves the microphone open.
+
+## 4) Web Smoke Tests (mandatory)
 
 - [ ] Register works.
 - [ ] Login works.
@@ -88,7 +95,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] Automated core UI smoke includes invite/join, server settings, social/friend, auth/account, release/settings, permission, and desktop-runtime regressions.
 - [ ] Automated mobile web smoke completed for the release candidate or CI run, covering Social, DM, server chat, mobile composer actions, and the mobile member sheet.
 
-## 4) Desktop Smoke Tests (mandatory)
+## 5) Desktop Smoke Tests (mandatory)
 
 - [ ] Installer opens with Voxpery app name and icon (not default NSIS icon).
 - [ ] App opens maximized by default and reaches login screen.
@@ -121,7 +128,6 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] First voice join shows OS/browser microphone permission prompt when needed.
 - [ ] Voice join succeeds after permission grant.
 - [ ] An account with missing or stale Terms, Privacy Notice, or KVKK versions sees the blocking legal review before app/voice data loads; all three links open, unchecked submission is disabled, acceptance unlocks the same session, refresh stays unlocked, and logout remains available.
-- [ ] While the desktop app is unfocused, minimized, and hidden in the tray, holding the configured push-to-talk key transmits and releasing it stops transmission; focus loss, channel leave, and switching to Voice Activity do not leave the microphone stuck open.
 - [ ] Active call bar quality indicator shows a colored Wi-Fi icon and current ping while connected, and the visible color matches the visible ping value.
 - [ ] Voice join and leave cues are distinct enough to tell whether a member entered or left the channel.
 - [ ] While already in a voice channel, remote camera and screen-share starts play distinct media cues; stopping camera or screen share stays silent, and joining a channel with existing remote media does not replay old media-start cues.
@@ -140,7 +146,7 @@ For releases that touch voice, WebRTC, LiveKit, service workers, build output, o
 - [ ] `docs/VOICE_SUPPRESSION_SMOKE_TEST.md` completed and recorded as `GO` when suppression, CSP, service workers, build output, or production deployment config changed.
 - [ ] Voice join deny/error UX is understandable (no broken or stuck state).
 
-## 5) Final Sign-off
+## 6) Final Sign-off
 
 - [ ] Changelog updated (`docs/CHANGELOG.md`).
 - [ ] Deployment notes updated if needed (`docs/DEPLOYMENT.md`).


### PR DESCRIPTION
## Summary

- update the Vitest alias configuration to use the native ESM directory API
- make auth and landing-page tests await asynchronous UI settlement and clean up mounted store subscriptions
- add a focused release regression pass for the screen-share mini player, crowded voice grids, Social menus, and desktop global push-to-talk
- document the release test maintenance in the v0.2.14 changelog

## Validation

- `npm run lint`
- `npm run test:run` — 349 passed
- `npm run build`
- `npm run test:e2e:ui-smoke` — 52 passed
- `npm run test:e2e:mobile-smoke` — 4 passed