### PR TITLE
fix: harden attachment filesystem sinks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,41 +25,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  changes:
-    name: Detect changed areas
-    runs-on: ubuntu-latest
-    outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      js: ${{ steps.filter.outputs.js }}
-      actions: ${{ steps.filter.outputs.actions }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Filter changed files
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            rust:
-              - 'apps/server/**/*.rs'
-              - 'apps/server/Cargo.toml'
-              - 'apps/server/Cargo.lock'
-              - 'apps/desktop/src-tauri/**/*.rs'
-              - 'apps/desktop/src-tauri/Cargo.toml'
-              - 'apps/desktop/src-tauri/Cargo.lock'
-            js:
-              - 'apps/web/**/*.{js,jsx,ts,tsx,mjs,cjs}'
-              - 'apps/web/package.json'
-              - 'apps/web/package-lock.json'
-            actions:
-              - '.github/workflows/**'
-              - '.github/actions/**'
-
   analyze-rust:
     name: Analyze (rust)
-    needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -81,8 +48,6 @@ jobs:
 
   analyze-js:
     name: Analyze (javascript-typescript)
-    needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -101,8 +66,6 @@ jobs:
 
   analyze-actions:
     name: Analyze (actions)
-    needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.actions == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/apps/server/src/services/attachments.rs
+++ b/apps/server/src/services/attachments.rs
@@ -428,6 +428,13 @@ impl AttachmentService {
         &self,
         storage_key: &str,
     ) -> Result<Vec<u8>, AppError> {
+        // Keep a direct traversal guard at each filesystem sink in addition to
+        // segment validation and the canonical storage-root boundary below.
+        if storage_key.contains("..") {
+            return Err(AppError::Validation(
+                "Invalid attachment storage key".into(),
+            ));
+        }
         let path = self.resolve_existing_local_path(storage_key).await?;
         fs::read(path)
             .await
@@ -438,6 +445,13 @@ impl AttachmentService {
         &self,
         storage_key: &str,
     ) -> Result<fs::File, AppError> {
+        // Keep this check local to the sink so static analysis and reviewers can
+        // see that untrusted traversal input cannot reach File::open.
+        if storage_key.contains("..") {
+            return Err(AppError::Validation(
+                "Invalid attachment storage key".into(),
+            ));
+        }
         let path = self.resolve_existing_local_path(storage_key).await?;
         fs::File::open(path)
             .await
@@ -1434,6 +1448,63 @@ mod tests {
         }
 
         assert!(parse_storage_key_segments("attachments/2026/05/file-01_abc.png").is_ok());
+    }
+
+    #[tokio::test]
+    async fn local_read_and_open_reject_traversal_keys() {
+        let test_root = std::env::temp_dir().join(format!("voxpery-att-test-{}", Uuid::new_v4()));
+        let service = AttachmentService::new_local_for_tests(test_root.clone())
+            .await
+            .expect("service");
+
+        for key in ["../secret", "attachments/2026/05/../../secret"] {
+            assert!(matches!(
+                service.read_local_attachment_bytes(key).await,
+                Err(AppError::Validation(_))
+            ));
+            assert!(matches!(
+                service.open_local_attachment_file(key).await,
+                Err(AppError::Validation(_))
+            ));
+        }
+
+        fs::remove_dir_all(test_root).await.expect("cleanup");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_read_and_open_reject_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let test_base = std::env::temp_dir().join(format!("voxpery-att-test-{}", Uuid::new_v4()));
+        let test_root = test_base.join("storage");
+        let outside_file = test_base.join("outside.txt");
+        let service = AttachmentService::new_local_for_tests(test_root)
+            .await
+            .expect("service");
+        fs::write(&outside_file, b"outside")
+            .await
+            .expect("outside file");
+
+        let storage_key = format!("attachments/2026/08/{}", Uuid::new_v4());
+        let linked_path = service
+            .resolve_local_path(&storage_key)
+            .expect("validated path");
+        fs::create_dir_all(linked_path.parent().expect("storage parent"))
+            .await
+            .expect("storage parent");
+        symlink(&outside_file, &linked_path).expect("outside symlink");
+
+        assert!(matches!(
+            service.read_local_attachment_bytes(&storage_key).await,
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            service.open_local_attachment_file(&storage_key).await,
+            Err(AppError::Validation(_))
+        ));
+
+        fs::remove_dir_all(test_base).await.expect("cleanup");
     }
 
     #[tokio::test]

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -2254,13 +2254,7 @@ async fn strict_username_validation_rejects_invalid_usernames() {
             .body(Body::from(serde_json::to_vec(&register_body).unwrap()))
             .unwrap();
         let (status, body) = oneshot(&mut app, req).await;
-        assert_eq!(
-            status,
-            StatusCode::BAD_REQUEST,
-            "username '{}' should be rejected but got status {}",
-            username,
-            status
-        );
+        assert_eq!(status, StatusCode::BAD_REQUEST);
         let resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let err_msg = resp["error"].as_str().unwrap_or("");
         assert!(err_msg.contains("Username cannot") || err_msg.contains("Username may only"));

--- a/apps/server/tests/integration.rs
+++ b/apps/server/tests/integration.rs
@@ -2257,10 +2257,9 @@ async fn strict_username_validation_rejects_invalid_usernames() {
         assert_eq!(
             status,
             StatusCode::BAD_REQUEST,
-            "username '{}' should be rejected but got status {}. body: {}",
+            "username '{}' should be rejected but got status {}",
             username,
-            status,
-            String::from_utf8_lossy(&body)
+            status
         );
         let resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let err_msg = resp["error"].as_str().unwrap_or("");

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Kept remote microphone tracks locally suppressed when a sender unmutes, republishes, or reconnects after the listener has deafened, without muting independently watched screen-share audio.
+- Hardened attachment read/open sinks with explicit traversal guards and canonical symlink-boundary checks, and stopped integration assertions from printing response bodies into CI logs.
 - Kept Friends and direct-message context menus inside the Social sidebar and removed the redundant direct-message open action from existing conversations.
 - Kept Friends context menus in the main Social panel, aligned their profile labels with server member menus, and removed friend removal from direct-message menus.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Kept remote microphone tracks locally suppressed when a sender unmutes, republishes, or reconnects after the listener has deafened, without muting independently watched screen-share audio.
-- Hardened attachment read/open sinks with explicit traversal guards and canonical symlink-boundary checks, and stopped integration assertions from printing response bodies into CI logs.
+- Hardened attachment read/open sinks with explicit traversal guards and canonical symlink-boundary checks, removed user-controlled values from integration assertion logs, and kept all configured CodeQL languages present in pull-request scans.
 - Kept Friends and direct-message context menus inside the Social sidebar and removed the redundant direct-message open action from existing conversations.
 - Kept Friends context menus in the main Social panel, aligned their profile labels with server member menus, and removed friend removal from direct-message menus.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -263,6 +263,7 @@ let query = format!("SELECT * FROM users WHERE username = '{}'", username); // S
 - **Storage backends**:
   - Local filesystem (`ATTACHMENTS_LOCAL_DIR` + `ATTACHMENTS_KEY_PREFIX`)
   - Local files are written to a same-directory temporary path, flushed, and atomically renamed so partially written files are never exposed under final storage keys
+  - Attachment read/open sinks reject traversal input directly, allow only validated relative storage-key segments, and require the canonical target to remain under the canonical storage root so symlink escapes cannot be served
   - Upload metadata persisted in `uploaded_attachments`
   - Multi-file requests reserve quota and insert metadata in one database transaction; any request or commit failure rolls back the transaction and removes every file already finalized by that request
   - Retry-equivalent uploads are serialized by content identity and reuse the existing clean attachment record, preventing duplicate files and quota accounting


### PR DESCRIPTION
## Summary

- add explicit traversal guards at attachment read and open filesystem sinks
- retain storage-key segment validation and canonical storage-root containment checks
- add regression coverage for traversal input and Unix symlink escapes
- prevent integration assertions from printing HTTP response bodies into CI logs
- document the attachment path protections and release security fix

## Validation

- `cargo test --locked --lib -- --test-threads=1` — 101 passed
- `cargo test --locked --no-run`

## Security

Addresses CodeQL alerts #46, #47, and #48.